### PR TITLE
perf(parsing): eliminate double parsing and optimize tree-sitter trav…

### DIFF
--- a/crates/vera-core/src/indexing/pipeline.rs
+++ b/crates/vera-core/src/indexing/pipeline.rs
@@ -317,10 +317,11 @@ fn parse_discovered_files_parallel(
                         Language::from_extension(ext)
                     });
 
-                let refs = parsing::parse_and_extract_references(&source, language);
-
-                let normalized_source = if language == Language::Rst {
-                    match parsing::sphinx::preprocess_rst(
+                // RST files need preprocessing before chunking, but refs
+                // come from the raw source, so they can't share a single parse.
+                let parse_result = if language == Language::Rst {
+                    let refs = parsing::parse_and_extract_references(&source, language);
+                    let normalized_source = match parsing::sphinx::preprocess_rst(
                         &source,
                         &file.absolute_path,
                         repo_root.as_path(),
@@ -334,39 +335,38 @@ fn parse_discovered_files_parallel(
                             );
                             None
                         }
-                    }
+                    };
+                    let src = normalized_source.as_deref().unwrap_or(&source);
+                    let hash = content_hash(src);
+                    parsing::parse_and_chunk(src, &file.relative_path, language, &config.indexing)
+                        .map(|chunks| (chunks, refs, hash))
                 } else {
-                    None
+                    let hash = content_hash(&source);
+                    parsing::parse_file(&source, &file.relative_path, language, &config.indexing)
+                        .map(|(chunks, refs)| (chunks, refs, hash))
                 };
-                let source_for_chunking = normalized_source.as_deref().unwrap_or(&source);
-                let hash = content_hash(source_for_chunking);
 
-                parsing::parse_and_chunk(
-                    source_for_chunking,
-                    &file.relative_path,
-                    language,
-                    &config.indexing,
-                )
-                .inspect(|chunks| {
-                    debug!(
-                        file = %file.relative_path,
-                        chunks = chunks.len(),
-                        refs = refs.len(),
-                        "parsed file"
-                    );
-                })
-                .map(|chunks| (chunks, file.relative_path.clone(), hash, refs))
-                .map_err(|err| {
-                    warn!(
-                        file = %file.relative_path,
-                        error = %err,
-                        "parse error"
-                    );
-                    FileError {
-                        file_path: file.relative_path.clone(),
-                        error: err.to_string(),
-                    }
-                })
+                parse_result
+                    .inspect(|(chunks, refs, _)| {
+                        debug!(
+                            file = %file.relative_path,
+                            chunks = chunks.len(),
+                            refs = refs.len(),
+                            "parsed file"
+                        );
+                    })
+                    .map(|(chunks, refs, hash)| (chunks, file.relative_path.clone(), hash, refs))
+                    .map_err(|err| {
+                        warn!(
+                            file = %file.relative_path,
+                            error = %err,
+                            "parse error"
+                        );
+                        FileError {
+                            file_path: file.relative_path.clone(),
+                            error: err.to_string(),
+                        }
+                    })
             })
             .collect();
 

--- a/crates/vera-core/src/indexing/update.rs
+++ b/crates/vera-core/src/indexing/update.rs
@@ -284,46 +284,49 @@ pub async fn update_repository<P: EmbeddingProvider>(
         for (rel_path, content, _hash) in &files_to_index {
             let language = detect_language_for_path(rel_path);
 
-            // Extract call-site references.
-            let refs = parsing::parse_and_extract_references(content, language);
+            // For RST, refs come from raw source; chunks from preprocessed.
+            // For all other languages, parse once for both.
+            let (chunks, refs) = if language == Language::Rst {
+                let refs = parsing::parse_and_extract_references(content, language);
+                let absolute_path = repo_root.join(rel_path);
+                let normalized_source =
+                    match parsing::sphinx::preprocess_rst(content, &absolute_path, &repo_root) {
+                        Ok(preprocessed) => Some(preprocessed),
+                        Err(err) => {
+                            warn!(
+                                file = %rel_path,
+                                error = %err,
+                                "failed to preprocess rst during update; falling back to raw source"
+                            );
+                            None
+                        }
+                    };
+                let src = normalized_source.as_deref().unwrap_or(content);
+                match parsing::parse_and_chunk(src, rel_path, language, &config.indexing) {
+                    Ok(chunks) => (chunks, refs),
+                    Err(err) => {
+                        warn!(file = %rel_path, error = %err, "parse error during update");
+                        continue;
+                    }
+                }
+            } else {
+                match parsing::parse_file(content, rel_path, language, &config.indexing) {
+                    Ok(result) => result,
+                    Err(err) => {
+                        warn!(file = %rel_path, error = %err, "parse error during update");
+                        continue;
+                    }
+                }
+            };
+
             if !refs.is_empty() {
                 metadata_store
                     .insert_references(rel_path, &refs)
                     .context("failed to store references")?;
             }
 
-            let normalized_source = if language == Language::Rst {
-                let absolute_path = repo_root.join(rel_path);
-                match parsing::sphinx::preprocess_rst(content, &absolute_path, &repo_root) {
-                    Ok(preprocessed) => Some(preprocessed),
-                    Err(err) => {
-                        warn!(
-                            file = %rel_path,
-                            error = %err,
-                            "failed to preprocess rst during update; falling back to raw source"
-                        );
-                        None
-                    }
-                }
-            } else {
-                None
-            };
-            let source_for_chunking = normalized_source.as_deref().unwrap_or(content);
-
-            match parsing::parse_and_chunk(
-                source_for_chunking,
-                rel_path,
-                language,
-                &config.indexing,
-            ) {
-                Ok(chunks) => {
-                    debug!(file = %rel_path, chunks = chunks.len(), "parsed file");
-                    all_chunks.extend(chunks);
-                }
-                Err(err) => {
-                    warn!(file = %rel_path, error = %err, "parse error during update");
-                }
-            }
+            debug!(file = %rel_path, chunks = chunks.len(), refs = refs.len(), "parsed file");
+            all_chunks.extend(chunks);
         }
 
         if !all_chunks.is_empty() {

--- a/crates/vera-core/src/indexing/update.rs
+++ b/crates/vera-core/src/indexing/update.rs
@@ -305,8 +305,13 @@ pub async fn update_repository<P: EmbeddingProvider>(
                 match parsing::parse_and_chunk(src, rel_path, language, &config.indexing) {
                     Ok(chunks) => (chunks, refs),
                     Err(err) => {
-                        warn!(file = %rel_path, error = %err, "parse error during update");
-                        continue;
+                        warn!(
+                            file = %rel_path,
+                            error = %err,
+                            refs = refs.len(),
+                            "failed to chunk rst during update; keeping extracted references"
+                        );
+                        (Vec::new(), refs)
                     }
                 }
             } else {

--- a/crates/vera-core/src/parsing/extractor.rs
+++ b/crates/vera-core/src/parsing/extractor.rs
@@ -813,7 +813,7 @@ fn name_from_node(node: &tree_sitter::Node<'_>, source: &[u8]) -> Option<String>
 pub fn extract_symbols(tree: &tree_sitter::Tree, source: &[u8], lang: Language) -> Vec<RawSymbol> {
     let mut symbols = Vec::new();
     let mut cursor = tree.root_node().walk();
-    collect_symbols_cursor(&mut cursor, source, lang, &mut symbols, 0);
+    collect_symbols_cursor(&mut cursor, source, lang, &mut symbols, 1);
     symbols.sort_by_key(|s| s.start_byte);
     symbols
 }

--- a/crates/vera-core/src/parsing/extractor.rs
+++ b/crates/vera-core/src/parsing/extractor.rs
@@ -812,7 +812,8 @@ fn name_from_node(node: &tree_sitter::Node<'_>, source: &[u8]) -> Option<String>
 /// Returns symbols sorted by their position in the source.
 pub fn extract_symbols(tree: &tree_sitter::Tree, source: &[u8], lang: Language) -> Vec<RawSymbol> {
     let mut symbols = Vec::new();
-    collect_symbols(tree.root_node(), source, lang, &mut symbols, 0);
+    let mut cursor = tree.root_node().walk();
+    collect_symbols_cursor(&mut cursor, source, lang, &mut symbols, 0);
     symbols.sort_by_key(|s| s.start_byte);
     symbols
 }
@@ -842,6 +843,30 @@ pub fn extract_rst_section_titles(tree: &tree_sitter::Tree, source: &[u8]) -> Ve
     titles.sort_by_key(|(row, _)| *row);
     titles.dedup_by(|a, b| a.0 == b.0);
     titles
+}
+
+/// Iterates siblings using a single `TreeCursor`, avoiding per-level cursor
+/// allocation. Delegates to [`collect_symbols`] for per-node logic.
+fn collect_symbols_cursor(
+    cursor: &mut tree_sitter::TreeCursor,
+    source: &[u8],
+    lang: Language,
+    symbols: &mut Vec<RawSymbol>,
+    depth: usize,
+) {
+    if depth > 6 {
+        return;
+    }
+    if !cursor.goto_first_child() {
+        return;
+    }
+    loop {
+        collect_symbols(cursor.node(), source, lang, symbols, depth);
+        if !cursor.goto_next_sibling() {
+            break;
+        }
+    }
+    cursor.goto_parent();
 }
 
 /// Recursively collect symbols from AST nodes.
@@ -888,9 +913,8 @@ fn collect_symbols(
 
     // Handle R binary_operator (x <- function() { ... }) as named function
     if lang == Language::R && kind == "binary_operator" {
-        let mut cursor = node.walk();
-        for child in node.children(&mut cursor) {
-            if child.kind() == "function_definition" {
+        if let Some(rhs) = node.child_by_field_name("rhs") {
+            if rhs.kind() == "function_definition" {
                 let name = extract_name(&node, source);
                 symbols.push(RawSymbol {
                     name,
@@ -983,7 +1007,8 @@ fn collect_symbols(
                     });
                     if text == "defmodule" {
                         if let Some(do_block) = get_elixir_do_block(&node) {
-                            collect_symbols(do_block, source, lang, symbols, depth + 1);
+                            let mut cursor = do_block.walk();
+                            collect_symbols_cursor(&mut cursor, source, lang, symbols, depth + 1);
                         }
                     }
                     return;
@@ -1103,9 +1128,7 @@ fn collect_symbols(
                 end_row: node.end_position().row,
             });
             let mut cursor = node.walk();
-            for child in node.children(&mut cursor) {
-                collect_symbols(child, source, lang, symbols, depth + 1);
-            }
+            collect_symbols_cursor(&mut cursor, source, lang, symbols, depth + 1);
             return;
         }
 
@@ -1204,9 +1227,7 @@ fn collect_symbols(
 
     // Recurse into children for wrapper nodes
     let mut cursor = node.walk();
-    for child in node.children(&mut cursor) {
-        collect_symbols(child, source, lang, symbols, depth + 1);
-    }
+    collect_symbols_cursor(&mut cursor, source, lang, symbols, depth + 1);
 }
 
 /// Extract a symbol from a Scheme `list` node if it starts with `define` or `define-syntax`.

--- a/crates/vera-core/src/parsing/mod.rs
+++ b/crates/vera-core/src/parsing/mod.rs
@@ -25,43 +25,94 @@ use tree_sitter::Parser;
 use crate::config::IndexingConfig;
 use crate::types::{Chunk, Language};
 
-/// Parse a source file and produce chunks.
+/// Parse a source file and produce both chunks and call-site references in a
+/// single pass, avoiding redundant tree-sitter parsing and symbol extraction.
 ///
-/// For Tier 1A languages (with tree-sitter support), uses AST-based
-/// symbol-aware chunking. For other languages, falls back to Tier 0
-/// line-based sliding-window chunking.
-///
-/// # Arguments
-/// - `source` — Full text content of the file
-/// - `file_path` — Repository-relative path (used in chunk IDs and metadata)
-/// - `language` — Detected programming language
-/// - `config` — Indexing configuration (max chunk lines, etc.)
+/// For languages with tree-sitter support, the file is parsed once and the
+/// resulting AST is reused for symbol extraction, chunking, and reference
+/// collection. For other languages, falls back to line-based chunking with
+/// no references.
 ///
 /// # Errors
 /// Returns an error if tree-sitter parsing fails for a supported language.
+pub fn parse_file(
+    source: &str,
+    file_path: &str,
+    language: Language,
+    config: &IndexingConfig,
+) -> Result<(Vec<Chunk>, Vec<references::RawReference>)> {
+    // Special-case formats that don't use standard symbol extraction.
+    if language == Language::Markdown {
+        let chunks = chunker::markdown_section_chunks(source, file_path);
+        return Ok((
+            chunker::split_oversized_chunks(chunks, config.max_chunk_bytes),
+            Vec::new(),
+        ));
+    }
+    if language == Language::Rst {
+        let chunks = parse_rst_section_chunks(source, file_path)?;
+        return Ok((
+            chunker::split_oversized_chunks(chunks, config.max_chunk_bytes),
+            Vec::new(),
+        ));
+    }
+    if language.prefers_file_chunking() {
+        let chunks = chunker::whole_file_chunk(source, file_path, language);
+        return Ok((
+            chunker::split_oversized_chunks(chunks, config.max_chunk_bytes),
+            Vec::new(),
+        ));
+    }
+
+    let grammar = match languages::tree_sitter_grammar(language) {
+        Some(g) => g,
+        None => {
+            let chunks = chunker::tier0_line_chunks(source, file_path, language);
+            return Ok((
+                chunker::split_oversized_chunks(chunks, config.max_chunk_bytes),
+                Vec::new(),
+            ));
+        }
+    };
+
+    let mut parser = Parser::new();
+    parser
+        .set_language(&grammar)
+        .context("failed to load tree-sitter grammar")?;
+
+    let tree = parser
+        .parse(source, None)
+        .context("tree-sitter parsing returned None")?;
+
+    // Single symbol extraction pass reused for both chunking and references.
+    let symbols = extractor::extract_symbols(&tree, source.as_bytes(), language);
+    let refs =
+        references::extract_references_with_symbols(&tree, source.as_bytes(), language, &symbols);
+    let chunks = chunker::chunks_from_symbols(&symbols, source, file_path, language, config);
+
+    let chunks = if chunks.is_empty() && !source.trim().is_empty() {
+        chunker::tier0_line_chunks(source, file_path, language)
+    } else {
+        chunks
+    };
+
+    Ok((
+        chunker::split_oversized_chunks(chunks, config.max_chunk_bytes),
+        refs,
+    ))
+}
+
+/// Parse a source file and produce chunks (without references).
+///
+/// Convenience wrapper around [`parse_file`] for callers that only need chunks.
 pub fn parse_and_chunk(
     source: &str,
     file_path: &str,
     language: Language,
     config: &IndexingConfig,
 ) -> Result<Vec<Chunk>> {
-    let chunks = if language == Language::Markdown {
-        chunker::markdown_section_chunks(source, file_path)
-    } else if language == Language::Rst {
-        parse_rst_section_chunks(source, file_path)?
-    } else if language.prefers_file_chunking() {
-        chunker::whole_file_chunk(source, file_path, language)
-    } else {
-        match languages::tree_sitter_grammar(language) {
-            Some(grammar) => parse_with_treesitter(source, file_path, language, grammar, config)?,
-            None => chunker::tier0_line_chunks(source, file_path, language),
-        }
-    };
-
-    Ok(chunker::split_oversized_chunks(
-        chunks,
-        config.max_chunk_bytes,
-    ))
+    let (chunks, _refs) = parse_file(source, file_path, language, config)?;
+    Ok(chunks)
 }
 
 fn parse_rst_section_chunks(source: &str, file_path: &str) -> Result<Vec<Chunk>> {
@@ -85,36 +136,7 @@ fn parse_rst_section_chunks(source: &str, file_path: &str) -> Result<Vec<Chunk>>
     Ok(chunker::rst_section_chunks(source, file_path, &headings))
 }
 
-/// Parse source using tree-sitter and produce symbol-aware chunks.
-fn parse_with_treesitter(
-    source: &str,
-    file_path: &str,
-    language: Language,
-    grammar: tree_sitter::Language,
-    config: &IndexingConfig,
-) -> Result<Vec<Chunk>> {
-    let mut parser = Parser::new();
-    parser
-        .set_language(&grammar)
-        .context("failed to load tree-sitter grammar")?;
-
-    let tree = parser
-        .parse(source, None)
-        .context("tree-sitter parsing returned None")?;
-
-    let symbols = extractor::extract_symbols(&tree, source.as_bytes(), language);
-    let chunks = chunker::chunks_from_symbols(&symbols, source, file_path, language, config);
-
-    // If no symbols were extracted (e.g., empty file or unparseable),
-    // fall back to Tier 0 to ensure content is still indexed.
-    if chunks.is_empty() && !source.trim().is_empty() {
-        Ok(chunker::tier0_line_chunks(source, file_path, language))
-    } else {
-        Ok(chunks)
-    }
-}
-
-/// Parse a source file and extract call-site references.
+/// Parse a source file and extract call-site references only.
 ///
 /// Only works for languages with tree-sitter grammars. Returns an empty
 /// vec for unsupported languages or parse failures.

--- a/crates/vera-core/src/parsing/references.rs
+++ b/crates/vera-core/src/parsing/references.rs
@@ -27,9 +27,22 @@ pub fn extract_references(
     source: &[u8],
     lang: Language,
 ) -> Vec<RawReference> {
-    let mut refs = Vec::new();
     let symbols = super::extractor::extract_symbols(tree, source, lang);
-    collect_calls(tree.root_node(), source, lang, &symbols, &mut refs);
+    extract_references_with_symbols(tree, source, lang, &symbols)
+}
+
+/// Extract call-site references using pre-computed symbols.
+///
+/// Use this when symbols have already been extracted (e.g., during unified
+/// parsing) to avoid redundant AST walks.
+pub fn extract_references_with_symbols(
+    tree: &tree_sitter::Tree,
+    source: &[u8],
+    lang: Language,
+    symbols: &[super::extractor::RawSymbol],
+) -> Vec<RawReference> {
+    let mut refs = Vec::new();
+    collect_calls(tree.root_node(), source, lang, symbols, &mut refs);
     refs
 }
 
@@ -165,27 +178,42 @@ fn find_enclosing_symbol(
         .and_then(|s| s.name.clone())
 }
 
-/// Recursively collect call references from AST nodes.
+/// Collect call references using a single TreeCursor for the entire traversal.
 fn collect_calls(
-    node: tree_sitter::Node<'_>,
+    root: tree_sitter::Node<'_>,
     source: &[u8],
     lang: Language,
     symbols: &[super::extractor::RawSymbol],
     refs: &mut Vec<RawReference>,
 ) {
-    if is_call_node(lang, node.kind()) {
-        if let Some(callee) = extract_callee(&node, source) {
-            let caller = find_enclosing_symbol(symbols, node.start_byte());
-            refs.push(RawReference {
-                callee,
-                caller,
-                line: node.start_position().row as u32 + 1,
-            });
+    let mut cursor = root.walk();
+    loop {
+        let node = cursor.node();
+        if is_call_node(lang, node.kind()) {
+            if let Some(callee) = extract_callee(&node, source) {
+                let caller = find_enclosing_symbol(symbols, node.start_byte());
+                refs.push(RawReference {
+                    callee,
+                    caller,
+                    line: node.start_position().row as u32 + 1,
+                });
+            }
         }
-    }
-    let mut cursor = node.walk();
-    for child in node.children(&mut cursor) {
-        collect_calls(child, source, lang, symbols, refs);
+        // Depth-first: try child, then sibling, then backtrack.
+        if cursor.goto_first_child() {
+            continue;
+        }
+        if cursor.goto_next_sibling() {
+            continue;
+        }
+        loop {
+            if !cursor.goto_parent() {
+                return;
+            }
+            if cursor.goto_next_sibling() {
+                break;
+            }
+        }
     }
 }
 


### PR DESCRIPTION
…ersal

- Add unified parse_file() that parses once and reuses the AST for symbol extraction, chunking, and reference collection
- Replace per-level cursor allocation with single TreeCursor traversal in collect_symbols and collect_calls
- Use child_by_field_name() for R binary_operator (rhs field) instead of iterating all children
- Add extract_references_with_symbols() to accept pre-computed symbols, avoiding redundant extract_symbols() calls
- Update pipeline.rs and update.rs to use parse_file() for non-RST languages (RST still needs separate parsing due to preprocessing)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Parse each file once with tree-sitter and reuse the AST for chunking and call-site references, removing duplicate parsing and extra AST walks. RST stays a special case due to preprocessing; the update flow now preserves refs even if chunking fails.

- **Performance**
  - Added parse_file() to build chunks and references in one pass; returns (chunks, refs).
  - Updated pipeline and update paths to use parse_file(); RST still preprocesses (refs from raw, chunks from preprocessed).
  - Switched symbol and call traversal to a single TreeCursor to reduce allocations and walks.
  - Tweaks: use child_by_field_name("rhs") for R binary_operator; added extract_references_with_symbols() to reuse precomputed symbols.

- **Bug Fixes**
  - Preserved symbol depth with single-cursor traversal to keep correct nesting.
  - In updates, always store RST references from raw source even if preprocessing/chunking fails.

<sup>Written for commit 0fee201538b170ed1400c6ce371edf9bc446d113. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

