### PR TITLE
fix(search): preserve regex filtering and CLI output flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ pub fn authenticate(credentials: &Credentials) -> Result<Token> { ... }
 ```
 ````
 
-Use `--json` for compact JSON, `vera search --raw` or `vera grep --raw` for verbose human-readable output, `vera search --timing` for per-stage timings, or `vera grep --timing` for total regex-search time.
+Use `--json` for compact JSON. `--raw` and `--timing` work with `vera search` and `vera grep`, and you can place them before or after the subcommand (for example, `vera --timing search "auth"` or `vera grep "TODO" --raw`).
 
 ### Excluding Files
 

--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ For step-by-step instructions, API provider options, Docker, building from sourc
 vera mcp   # or: bunx @vera-ai/cli mcp / uvx vera-ai mcp
 ```
 Exposes `search_code`, `get_stats`, `get_overview`, and `regex_search` tools. `search_code` auto-indexes and starts a file watcher on first use if no index exists.
+The MCP surface stays intentionally small; use the CLI skill path when you need the full command set.
 
 </details>
 

--- a/crates/vera-cli/src/main.rs
+++ b/crates/vera-cli/src/main.rs
@@ -35,6 +35,10 @@ use clap::{Parser, Subcommand};
                   vera doctor                         # Check local setup and index health\n  \
                   vera repair                         # Re-fetch missing backend assets\n  \
                   vera upgrade                        # Show the binary update plan",
+    after_long_help = "Output flags:\n  \
+                  --json                             Structured JSON when supported\n  \
+                  --raw                              Verbose search/grep output (before or after the subcommand)\n  \
+                  --timing                           Search/grep timings to stderr (before or after the subcommand)",
     version
 )]
 struct Cli {
@@ -865,6 +869,7 @@ fn main() {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use clap::CommandFactory;
 
     #[test]
     fn cli_parses_index_command() {
@@ -1289,6 +1294,14 @@ mod tests {
     fn cli_parses_json_flag() {
         let cli = Cli::parse_from(["vera", "--json", "stats"]);
         assert!(cli.json);
+    }
+
+    #[test]
+    fn cli_help_mentions_global_output_flags() {
+        let help = Cli::command().render_long_help().to_string();
+        assert!(help.contains("--raw"));
+        assert!(help.contains("--timing"));
+        assert!(help.contains("before or after the subcommand"));
     }
 
     #[test]

--- a/crates/vera-cli/src/main.rs
+++ b/crates/vera-cli/src/main.rs
@@ -47,6 +47,19 @@ struct Cli {
     /// diagnostic commands emit structured JSON summaries.
     #[arg(long, global = true)]
     json: bool,
+
+    /// Output all fields with pretty-printed verbose formatting.
+    ///
+    /// Search-style commands honor this flag whether it appears before or
+    /// after the subcommand.
+    #[arg(long, global = true)]
+    raw: bool,
+
+    /// Print timing information to stderr when supported.
+    ///
+    /// Search prints per-stage timings; grep prints total elapsed time.
+    #[arg(long, global = true)]
+    timing: bool,
 }
 
 #[derive(Subcommand)]
@@ -386,14 +399,6 @@ enum Commands {
         #[arg(long)]
         compact: bool,
 
-        /// Output all fields with pretty-printed verbose formatting.
-        #[arg(long)]
-        raw: bool,
-
-        /// Print per-stage search timings to stderr.
-        #[arg(long)]
-        timing: bool,
-
         #[command(flatten)]
         backend: helpers::LocalBackendFlags,
     },
@@ -529,14 +534,6 @@ enum Commands {
         /// Show only function/class signatures (omit bodies).
         #[arg(long)]
         compact: bool,
-
-        /// Output all fields with pretty-printed verbose formatting.
-        #[arg(long)]
-        raw: bool,
-
-        /// Print total regex-search time to stderr.
-        #[arg(long)]
-        timing: bool,
     },
 
     /// Find symbols with no callers (potential dead code).
@@ -756,8 +753,6 @@ fn main() {
             include_generated,
             deep,
             compact,
-            raw,
-            timing,
             backend,
         } => {
             tracing::info!(queries = ?queries, deep, "searching");
@@ -774,8 +769,8 @@ fn main() {
                 limit,
                 &filters,
                 cli.json,
-                raw,
-                timing,
+                cli.raw,
+                cli.timing,
                 deep,
                 compact,
                 backend.resolve(),
@@ -817,8 +812,6 @@ fn main() {
             scope,
             include_generated,
             compact,
-            raw,
-            timing,
         } => {
             tracing::info!(pattern = %pattern, "grep");
             let filters = vera_core::types::SearchFilters {
@@ -835,8 +828,8 @@ fn main() {
                 context,
                 &filters,
                 cli.json,
-                raw,
-                timing,
+                cli.raw,
+                cli.timing,
                 compact,
             )
         }
@@ -1123,19 +1116,29 @@ mod tests {
     #[test]
     fn cli_parses_search_timing_flag() {
         let cli = Cli::parse_from(["vera", "search", "find auth", "--timing"]);
-        match cli.command {
-            Commands::Search { timing, .. } => assert!(timing),
-            _ => panic!("expected Search command"),
-        }
+        assert!(matches!(cli.command, Commands::Search { .. }));
+        assert!(cli.timing);
     }
 
     #[test]
     fn cli_parses_search_raw_flag() {
         let cli = Cli::parse_from(["vera", "search", "find auth", "--raw"]);
-        match cli.command {
-            Commands::Search { raw, .. } => assert!(raw),
-            _ => panic!("expected Search command"),
-        }
+        assert!(matches!(cli.command, Commands::Search { .. }));
+        assert!(cli.raw);
+    }
+
+    #[test]
+    fn cli_parses_global_search_timing_flag_before_subcommand() {
+        let cli = Cli::parse_from(["vera", "--timing", "search", "find auth"]);
+        assert!(matches!(cli.command, Commands::Search { .. }));
+        assert!(cli.timing);
+    }
+
+    #[test]
+    fn cli_parses_global_search_raw_flag_before_subcommand() {
+        let cli = Cli::parse_from(["vera", "--raw", "search", "find auth"]);
+        assert!(matches!(cli.command, Commands::Search { .. }));
+        assert!(cli.raw);
     }
 
     #[test]
@@ -1245,19 +1248,29 @@ mod tests {
     #[test]
     fn cli_parses_grep_timing_flag() {
         let cli = Cli::parse_from(["vera", "grep", "TODO", "--timing"]);
-        match cli.command {
-            Commands::Grep { timing, .. } => assert!(timing),
-            _ => panic!("expected Grep command"),
-        }
+        assert!(matches!(cli.command, Commands::Grep { .. }));
+        assert!(cli.timing);
     }
 
     #[test]
     fn cli_parses_grep_raw_flag() {
         let cli = Cli::parse_from(["vera", "grep", "TODO", "--raw"]);
-        match cli.command {
-            Commands::Grep { raw, .. } => assert!(raw),
-            _ => panic!("expected Grep command"),
-        }
+        assert!(matches!(cli.command, Commands::Grep { .. }));
+        assert!(cli.raw);
+    }
+
+    #[test]
+    fn cli_parses_global_grep_timing_flag_before_subcommand() {
+        let cli = Cli::parse_from(["vera", "--timing", "grep", "TODO"]);
+        assert!(matches!(cli.command, Commands::Grep { .. }));
+        assert!(cli.timing);
+    }
+
+    #[test]
+    fn cli_parses_global_grep_raw_flag_before_subcommand() {
+        let cli = Cli::parse_from(["vera", "--raw", "grep", "TODO"]);
+        assert!(matches!(cli.command, Commands::Grep { .. }));
+        assert!(cli.raw);
     }
 
     #[test]

--- a/crates/vera-core/src/retrieval/regex_search.rs
+++ b/crates/vera-core/src/retrieval/regex_search.rs
@@ -14,7 +14,7 @@ use crate::corpus::{ContentClass, classify_content, classify_path};
 use crate::retrieval::query_utils::path_depth;
 use crate::retrieval::ranking::{RankingStage, apply_query_ranking_with_filters};
 use crate::storage::metadata::MetadataStore;
-use crate::types::{Chunk, Language, SearchFilters, SearchResult};
+use crate::types::{Chunk, Language, SearchFilters, SearchResult, SymbolType};
 
 /// Search indexed files for a regex pattern.
 ///
@@ -138,7 +138,7 @@ pub fn search_regex(
                 language,
             };
 
-            if !filters.matches(&result) {
+            if !regex_result_matches(filters, symbol_type) {
                 continue;
             }
 
@@ -146,9 +146,10 @@ pub fn search_regex(
         }
     }
 
-    let results =
+    let mut results =
         apply_query_ranking_with_filters(pattern, results, RankingStage::Initial, filters);
-    Ok(crate::retrieval::apply_filters(results, filters, limit))
+    results.truncate(limit);
+    Ok(results)
 }
 
 fn collect_minified_matches(
@@ -179,12 +180,16 @@ fn collect_minified_matches(
             language,
         };
 
-        if !filters.matches(&result) {
+        if !regex_result_matches(filters, symbol_type) {
             continue;
         }
 
         results.push(result);
     }
+}
+
+fn regex_result_matches(filters: &SearchFilters, symbol_type: Option<SymbolType>) -> bool {
+    filters.matches_symbol_type(symbol_type)
 }
 
 fn symbol_for_line(
@@ -416,6 +421,49 @@ mod tests {
 
         assert_eq!(results.len(), 1);
         assert!(results[0].content.len() < content.len());
+        assert!(results[0].content.contains("targetSymbol"));
+    }
+
+    #[test]
+    fn content_class_generated_files_survive_runtime_scope_filtering() {
+        let tmp = tempfile::tempdir().unwrap();
+        let repo_root = tmp.path();
+        let index_dir = repo_root.join(".vera");
+        std::fs::create_dir_all(&index_dir).unwrap();
+
+        let content = format!("const targetSymbol=1;{}", "a=1;".repeat(400));
+        std::fs::write(repo_root.join("app.min.js"), &content).unwrap();
+
+        let store = MetadataStore::open(&index_dir.join("metadata.db")).unwrap();
+        store
+            .insert_chunks(&[Chunk {
+                id: "app:0".to_string(),
+                file_path: "app.min.js".to_string(),
+                line_start: 1,
+                line_end: 1,
+                content: content.clone(),
+                language: Language::JavaScript,
+                symbol_type: None,
+                symbol_name: None,
+            }])
+            .unwrap();
+
+        let results = search_regex(
+            &index_dir,
+            "targetSymbol",
+            5,
+            false,
+            0,
+            &SearchFilters {
+                scope: Some(crate::types::SearchScope::Runtime),
+                include_generated: Some(true),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].file_path, "app.min.js");
         assert!(results[0].content.contains("targetSymbol"));
     }
 

--- a/crates/vera-mcp/src/tools.rs
+++ b/crates/vera-mcp/src/tools.rs
@@ -290,6 +290,24 @@ fn search_code_filters(
     }
 }
 
+fn regex_search_filters(
+    args: &Value,
+    scope: Option<vera_core::types::SearchScope>,
+) -> vera_core::types::SearchFilters {
+    // Keep regex_search intentionally small over MCP. search_code already
+    // exposes richer corpus filters, so regex_search sticks to the
+    // highest-value regex controls.
+    vera_core::types::SearchFilters {
+        scope,
+        include_generated: Some(
+            args.get("include_generated")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false),
+        ),
+        ..Default::default()
+    }
+}
+
 /// Handle the `search_code` tool.
 fn handle_search_code(args: &Value) -> ToolCallResult {
     // Collect queries: support both single `query` and multi `queries`.
@@ -528,15 +546,7 @@ fn handle_regex_search(args: &Value) -> ToolCallResult {
         );
     }
 
-    let filters = vera_core::types::SearchFilters {
-        scope,
-        include_generated: Some(
-            args.get("include_generated")
-                .and_then(|v| v.as_bool())
-                .unwrap_or(false),
-        ),
-        ..Default::default()
-    };
+    let filters = regex_search_filters(args, scope);
 
     match vera_core::retrieval::search_regex(
         &index_dir,
@@ -631,6 +641,23 @@ mod tests {
         assert_eq!(filters.symbol_type.as_deref(), Some("function"));
         assert_eq!(filters.scope, Some(vera_core::types::SearchScope::Source));
         assert_eq!(filters.include_generated, Some(true));
+    }
+
+    #[test]
+    fn regex_search_schema_stays_minimal() {
+        let tools = tool_definitions();
+        let regex_search = tools
+            .iter()
+            .find(|tool| tool.name == "regex_search")
+            .unwrap();
+        let properties = regex_search.input_schema["properties"].as_object().unwrap();
+
+        assert!(properties.contains_key("pattern"));
+        assert!(properties.contains_key("scope"));
+        assert!(properties.contains_key("include_generated"));
+        assert!(!properties.contains_key("lang"));
+        assert!(!properties.contains_key("path"));
+        assert!(!properties.contains_key("symbol_type"));
     }
 
     #[test]

--- a/docs/features.md
+++ b/docs/features.md
@@ -173,14 +173,14 @@ Large chunks are automatically truncated at 8K characters with a `[...truncated]
 
 ## MCP Server
 
-`vera mcp` exposes all capabilities over JSON-RPC (stdio), compatible with any MCP client:
+`vera mcp` exposes a small set of high-value tools over JSON-RPC (stdio), compatible with any MCP client:
 
 | Tool | What it does |
 |------|-------------|
 | `search_code` | Hybrid search with multi-query, intent, and all filters. Auto-indexes and starts watcher on first use. |
 | `get_stats` | File count, chunk count, index size, language breakdown |
 | `get_overview` | Architecture overview with conventions detection |
-| `regex_search` | Regex search with context lines |
+| `regex_search` | Regex search with context lines and scope controls |
 
 Tool descriptions include explicit WHEN TO USE / WHEN NOT TO USE guidance so AI agents route queries to the right tool automatically.
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -168,8 +168,8 @@ Large chunks are automatically truncated at 8K characters with a `[...truncated]
 |------|--------|
 | *(default)* | Markdown codeblocks with file path, line range, and symbol metadata |
 | `--json` | Compact single-line JSON |
-| `--raw` | Verbose human-readable search/grep output |
-| `--timing` | Timing info to stderr (`search`: per-stage, `grep`: total) |
+| `--raw` | Verbose human-readable search/grep output. Works before or after the subcommand. |
+| `--timing` | Timing info to stderr (`search`: per-stage, `grep`: total). Works before or after the subcommand. |
 
 ## MCP Server
 

--- a/docs/query-guide.md
+++ b/docs/query-guide.md
@@ -98,7 +98,7 @@ Use `rg` when you need:
 
 ## Output Format
 
-See [features: output formats](features.md#multiple-output-formats) for all options (`--json`, `--raw`, `--timing`). `vera search --raw` and `vera grep --raw` print verbose result views. `vera search --timing` prints per-stage timings; `vera grep --timing` prints total regex-search time.
+See [features: output formats](features.md#multiple-output-formats) for all options (`--json`, `--raw`, `--timing`). `--raw` and `--timing` work with `vera search` and `vera grep`, and can appear before or after the subcommand. `vera search --timing` prints per-stage timings; `vera grep --timing` prints total regex-search time.
 
 ## Keeping Results Fresh
 

--- a/packages/npm-cli/README.md
+++ b/packages/npm-cli/README.md
@@ -45,6 +45,6 @@ For the full backend matrix, model options, Docker setup, and troubleshooting, s
 - **61+ languages** via tree-sitter AST parsing
 - **Hybrid search**: BM25 keyword + vector similarity, fused with Reciprocal Rank Fusion
 - **Cross-encoder reranking** for precision
-- **Markdown codeblock output** by default with file paths, line ranges, and optional symbol info (use `--json` for compact JSON, `--raw` for verbose output, `--timing` for step durations)
+- **Markdown codeblock output** by default with file paths, line ranges, and optional symbol info (use `--json` for compact JSON; `--raw` and `--timing` work with `vera search` and `vera grep`, before or after the subcommand)
 
 For full documentation, including custom local ONNX embedding models and manual install steps, see the [GitHub repo](https://github.com/lemon07r/Vera).

--- a/packages/python-cli/README.md
+++ b/packages/python-cli/README.md
@@ -45,6 +45,6 @@ For the full backend matrix, model options, Docker setup, and troubleshooting, s
 - **61+ languages** via tree-sitter AST parsing
 - **Hybrid search**: BM25 keyword + vector similarity, fused with Reciprocal Rank Fusion
 - **Cross-encoder reranking** for precision
-- **Markdown codeblock output** by default with file paths, line ranges, and optional symbol info (use `--json` for compact JSON, `--raw` for verbose output, `--timing` for step durations)
+- **Markdown codeblock output** by default with file paths, line ranges, and optional symbol info (use `--json` for compact JSON; `--raw` and `--timing` work with `vera search` and `vera grep`, before or after the subcommand)
 
 For full documentation, including custom local ONNX embedding models and manual install steps, see the [GitHub repo](https://github.com/lemon07r/Vera).

--- a/skills/vera/SKILL.md
+++ b/skills/vera/SKILL.md
@@ -51,7 +51,7 @@ pub async fn search_hybrid(...) -> Result<Vec<SearchResult>> { ... }
 ```
 ````
 
-The info string contains `file_path:line_start-line_end` and optional `symbol_type:symbol_name`. Use `--json` for compact single-line JSON (programmatic consumption), `--raw` for verbose `vera search` or `vera grep` output, `--timing` on `vera search` for per-stage timings, or `--timing` on `vera grep` for total regex-search time.
+The info string contains `file_path:line_start-line_end` and optional `symbol_type:symbol_name`. Use `--json` for compact single-line JSON (programmatic consumption). `--raw` and `--timing` work with `vera search` and `vera grep`, and can appear before or after the subcommand.
 
 ## Choosing the Right Tool
 

--- a/skills/vera/references/mcp.md
+++ b/skills/vera/references/mcp.md
@@ -33,10 +33,11 @@ The server exposes:
 - `search_code` (supports `queries` array for multi-query search, `intent` for reranking; auto-indexes and starts watcher on first use)
 - `get_stats`
 - `get_overview` (includes detected project conventions)
-- `regex_search`
+- `regex_search` (kept intentionally minimal: regex, context, scope, generated-file toggle, compact output)
 
 ## Guidance
 
 - Keep the Vera skill CLI-centered.
+- Keep the MCP surface small. Reach for the CLI skill when you need the full set of filters and commands.
 - Only mention MCP when the task or client explicitly depends on it.
 - Do not assume MCP is installed if the user only asked for Vera search capability.


### PR DESCRIPTION
## Summary
- preserve regex grep hits from generated files by keeping regex filtering at the file level instead of reclassifying short returned snippets
- restore `--raw` and `--timing` as true global CLI flags, add coverage for before/after-subcommand placement, and surface that behavior in top-level help
- keep MCP `regex_search` intentionally minimal and align the README, package READMEs, query guide, and Vera skill docs with the current CLI and MCP behavior

## Verification
- cargo test --workspace
- cargo clippy --workspace -- -D warnings
- cargo test -p vera-cli
- cargo clippy -p vera-cli -- -D warnings
- cargo build -p vera-cli
- target/debug/vera --help
- target/debug/vera --timing search foo
- target/debug/vera search foo --timing

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix regex search to preserve matches from generated/runtime files and restore `--raw`/`--timing` as true global flags (usable before or after subcommands). Also makes these flags discoverable in `vera` help and keeps MCP `regex_search` intentionally minimal, with docs aligned.

- **Bug Fixes**
  - Preserve generated/runtime regex hits by keeping filtering at the file level and truncating after ranking (`vera-core`); adds a test to cover generated files.
  - Restore global `--raw` and `--timing` in `vera-cli`; flags work before or after `search`/`grep`; long help now documents this and tests cover both positions.

- **Refactors**
  - Keep MCP `regex_search` small in `vera-mcp` (pattern, context, scope, include_generated) with a dedicated filter builder and schema test; update READMEs, docs, and skill guides to reflect the minimal MCP surface and global flag behavior.

<sup>Written for commit bd7f8f3b5f1735b0850ade9bf7ebaadd8a3f70a2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

