### PR TITLE
fix: added voyage ai batch limit mitigation

### DIFF
--- a/crates/vera-core/src/embedding/provider.rs
+++ b/crates/vera-core/src/embedding/provider.rs
@@ -545,10 +545,17 @@ fn provider_batch_limit(config: &EmbeddingProviderConfig) -> Option<usize> {
         || (base_url.contains("googleapis.com") && model_id.contains("gemini"))
         || model_id.contains("gemini")
     {
-        Some(100)
-    } else {
-        None
+        return Some(100);
     }
+
+    // Voyage AI enforces both a per-batch input count cap (128) and a
+    // per-batch token cap (120k for voyage-code-3). The token cap is handled
+    // adaptively via context_size_info; this caps input count as a safety net.
+    if base_url.contains("api.voyageai.com") || model_id.starts_with("voyage-") {
+        return Some(128);
+    }
+
+    None
 }
 
 fn effective_batch_size<P: EmbeddingProvider>(provider: &P, configured_batch_size: usize) -> usize {
@@ -596,6 +603,7 @@ fn context_size_info(error: &EmbeddingError) -> Option<ContextSizeInfo> {
         && !lower.contains("exceed_context_size_error")
         && !lower.contains("\"n_ctx\"")
         && !lower.contains("too large to process")
+        && !lower.contains("max allowed tokens per submitted batch")
     {
         return None;
     }
@@ -605,6 +613,8 @@ fn context_size_info(error: &EmbeddingError) -> Option<ContextSizeInfo> {
     static BATCH_SIZE_RE: OnceLock<Regex> = OnceLock::new();
     static INPUT_TOKENS_RE: OnceLock<Regex> = OnceLock::new();
     static N_PROMPT_RE: OnceLock<Regex> = OnceLock::new();
+    static MAX_BATCH_TOKENS_RE: OnceLock<Regex> = OnceLock::new();
+    static BATCH_TOKENS_RE: OnceLock<Regex> = OnceLock::new();
     let n_ctx_re = N_CTX_RE.get_or_init(|| Regex::new(r#""n_ctx"\s*:\s*(\d+)"#).unwrap());
     let max_context_re =
         MAX_CONTEXT_RE.get_or_init(|| Regex::new(r"max context size \((\d+)").unwrap());
@@ -613,12 +623,21 @@ fn context_size_info(error: &EmbeddingError) -> Option<ContextSizeInfo> {
         INPUT_TOKENS_RE.get_or_init(|| Regex::new(r"input \((\d+) tokens?\)").unwrap());
     let n_prompt_re =
         N_PROMPT_RE.get_or_init(|| Regex::new(r#""n_prompt_tokens"\s*:\s*(\d+)"#).unwrap());
+    let max_batch_tokens_re = MAX_BATCH_TOKENS_RE
+        .get_or_init(|| Regex::new(r"max allowed tokens per submitted batch is (\d+)").unwrap());
+    let batch_tokens_re =
+        BATCH_TOKENS_RE.get_or_init(|| Regex::new(r"your batch has (\d+) tokens?").unwrap());
 
     let max_tokens = n_ctx_re
         .captures(&lower)
         .and_then(|caps| caps.get(1))
         .or_else(|| max_context_re.captures(&lower).and_then(|caps| caps.get(1)))
         .or_else(|| batch_size_re.captures(&lower).and_then(|caps| caps.get(1)))
+        .or_else(|| {
+            max_batch_tokens_re
+                .captures(&lower)
+                .and_then(|caps| caps.get(1))
+        })
         .and_then(|capture| capture.as_str().parse::<usize>().ok())
         .or(Some(8192))?;
 
@@ -627,6 +646,11 @@ fn context_size_info(error: &EmbeddingError) -> Option<ContextSizeInfo> {
         .and_then(|caps| caps.get(1))
         .or_else(|| {
             input_tokens_re
+                .captures(&lower)
+                .and_then(|caps| caps.get(1))
+        })
+        .or_else(|| {
+            batch_tokens_re
                 .captures(&lower)
                 .and_then(|caps| caps.get(1))
         })
@@ -1205,5 +1229,39 @@ mod tests {
         );
         let provider = OpenAiProvider::new(config).unwrap();
         assert_eq!(provider.max_batch_size(), None);
+    }
+
+    #[test]
+    fn detect_voyage_batch_limit_from_base_url() {
+        let config = EmbeddingProviderConfig::new(
+            "https://api.voyageai.com/v1".into(),
+            "voyage-code-3".into(),
+            "k".into(),
+        );
+        let provider = OpenAiProvider::new(config).unwrap();
+        assert_eq!(provider.max_batch_size(), Some(128));
+    }
+
+    #[test]
+    fn detect_voyage_batch_limit_from_model_id() {
+        let config = EmbeddingProviderConfig::new(
+            "http://localhost:4000/v1".into(),
+            "voyage-code-3".into(),
+            "k".into(),
+        );
+        let provider = OpenAiProvider::new(config).unwrap();
+        assert_eq!(provider.max_batch_size(), Some(128));
+    }
+
+    #[test]
+    fn context_size_info_parses_voyage_batch_token_error() {
+        let err = EmbeddingError::ApiError {
+            status: 400,
+            message: "{\"detail\":\"Request to model 'voyage-code-3' failed. The max allowed tokens per submitted batch is 120000. Your batch has 124417 tokens after truncation. Please lower the number of tokens in the batch.\"}".to_string(),
+        };
+        let info = context_size_info(&err).expect("should recognize voyage batch token error");
+        assert_eq!(info.max_tokens, 120000);
+        assert_eq!(info.input_tokens, Some(124417));
+        assert!(is_context_size_error(&err));
     }
 }


### PR DESCRIPTION
When indexing my codebase with Voyage AI voyage-code-3 model ive got the following error:

```
2026-04-27T11:32:56.754720Z  WARN vera_core::embedding::provider: embedding API call failed attempt=8 max=8 error=embedding API error (status 400): {"detail":"Request to model 'voyage-code-3' failed. The 
Error: indexing failed: embedding generation failed: embedding API error (status 400): {"detail":"Request to model 'voyage-code-3' failed. The max allowed tokens per submitted batch is 120000. Your batch has 124417 tokens after truncation. Please lower the number of tokens in the batch."} 
```

This PR adds the batch limit similarly how gemini models restricted.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a batch-size cap for Voyage models and parse token-over-batch errors to avoid 400s when embedding with voyage-code-3.

- **Bug Fixes**
  - Cap batch size to 128 when base URL is api.voyageai.com or model ID starts with voyage-.
  - Parse "max allowed tokens per submitted batch" errors to extract max and current tokens for adaptive retries.
  - Added tests for Voyage batch limit detection and error parsing.

<sup>Written for commit 76c2f6412668600ccdcd32fa56718df25d1370e6. Summary will update on new commits. <a href="https://cubic.dev/pr/lemon07r/Vera/pull/18?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

