### PR TITLE
fix(search): treat bare directory pattern as prefix match in path glob (Closes #23)

### DIFF
--- a/crates/vera-core/src/types.rs
+++ b/crates/vera-core/src/types.rs
@@ -145,7 +145,19 @@ fn glob_matches(pattern: &str, path: &str) -> bool {
     let pattern = pattern.replace('\\', "/");
     let path = path.replace('\\', "/");
 
-    glob_match_recursive(&pattern, &path)
+    if glob_match_recursive(&pattern, &path) {
+        return true;
+    }
+
+    // Directory-prefix fallback: a bare pattern with no wildcards (e.g. "app/src")
+    // should match any file beneath that directory ("app/src/foo.ts").
+    // This is intentionally kept out of the recursive matcher so that wildcard
+    // handlers like `*` retain strict single-segment semantics.
+    if !pattern.contains(['*', '?', '[']) {
+        return path.starts_with(&format!("{pattern}/"));
+    }
+
+    false
 }
 
 /// Recursive glob matching helper.
@@ -170,10 +182,11 @@ fn glob_match_recursive(pattern: &str, text: &str) -> bool {
         return false;
     }
 
+    if pattern.is_empty() && text.is_empty() {
+        return true;
+    }
     if pattern.is_empty() {
-        // An exhausted pattern matches the empty text, or any remaining path
-        // beneath it (directory-prefix semantics: "app/src" matches "app/src/foo.ts").
-        return text.is_empty() || text.starts_with('/');
+        return false;
     }
 
     // Handle `*` within a segment (matches anything except `/`).
@@ -1259,6 +1272,19 @@ mod tests {
         assert!(filters.matches(&deep));
         assert!(!filters.matches(&sibling));
         assert!(!filters.matches(&other));
+    }
+
+    #[test]
+    fn single_star_does_not_cross_directory_boundary() {
+        // `src/*` must not match `src/bar/baz` — `*` is single-segment only.
+        let filters = SearchFilters {
+            path_glob: Some("src/*".to_string()),
+            ..Default::default()
+        };
+        let shallow = make_test_result("src/foo.rs", Language::Rust, None, None);
+        let deep = make_test_result("src/bar/baz.rs", Language::Rust, None, None);
+        assert!(filters.matches(&shallow));
+        assert!(!filters.matches(&deep));
     }
 
     #[test]

--- a/crates/vera-core/src/types.rs
+++ b/crates/vera-core/src/types.rs
@@ -170,11 +170,10 @@ fn glob_match_recursive(pattern: &str, text: &str) -> bool {
         return false;
     }
 
-    if pattern.is_empty() && text.is_empty() {
-        return true;
-    }
     if pattern.is_empty() {
-        return false;
+        // An exhausted pattern matches the empty text, or any remaining path
+        // beneath it (directory-prefix semantics: "app/src" matches "app/src/foo.ts").
+        return text.is_empty() || text.starts_with('/');
     }
 
     // Handle `*` within a segment (matches anything except `/`).
@@ -1244,6 +1243,22 @@ mod tests {
         assert!(filters.matches(&deep));
         assert!(filters.matches(&top));
         assert!(!filters.matches(&no_match));
+    }
+
+    #[test]
+    fn filter_by_path_plain_directory_prefix() {
+        let filters = SearchFilters {
+            path_glob: Some("app/src".to_string()),
+            ..Default::default()
+        };
+        let inside = make_test_result("app/src/foo.ts", Language::TypeScript, None, None);
+        let deep = make_test_result("app/src/bar/baz.rs", Language::Rust, None, None);
+        let sibling = make_test_result("app/srcs/foo.ts", Language::TypeScript, None, None);
+        let other = make_test_result("other/src/foo.ts", Language::TypeScript, None, None);
+        assert!(filters.matches(&inside));
+        assert!(filters.matches(&deep));
+        assert!(!filters.matches(&sibling));
+        assert!(!filters.matches(&other));
     }
 
     #[test]


### PR DESCRIPTION
  --path app/src did not match files under that directory because
  glob_match_recursive returned false when the pattern was exhausted
  but the path still had a trailing segment (e.g. "/foo.ts").

  Change the empty-pattern base case to also accept text that starts
  with '/', giving "app/src" the same effect as "app/src/**".
 (Closes #23)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix path-glob matching so bare directory paths are treated as a prefix without loosening wildcard rules. `--path app/src` now matches files under that directory (same as `app/src/**`), and `src/*` remains single-segment.

- **Bug Fixes**
  - Added a directory-prefix fallback in `glob_matches` only for patterns with no wildcards.
  - Added tests for plain directory prefix behavior and for ensuring `src/*` does not cross directory boundaries.

<sup>Written for commit 682ce28d901e69c8fc1a56270bb8c48c097af582. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/lemon07r/Vera/pull/24?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

