### PR TITLE
fix(search): keep --intent prefix out of BM25 queries

### DIFF
--- a/crates/vera-cli/src/commands/search.rs
+++ b/crates/vera-cli/src/commands/search.rs
@@ -48,10 +48,10 @@ pub fn run(
     }
 
     let (results, timings) = if queries.len() == 1 {
-        let effective_query = apply_intent(&queries[0], intent);
         execute_query(
             &index_dir,
-            &effective_query,
+            &queries[0],
+            intent,
             &config,
             filters,
             result_limit,
@@ -86,9 +86,11 @@ pub fn run(
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
 fn execute_query(
     index_dir: &Path,
     query: &str,
+    intent: Option<&str>,
     config: &vera_core::config::VeraConfig,
     filters: &vera_core::types::SearchFilters,
     result_limit: usize,
@@ -99,6 +101,7 @@ fn execute_query(
         vera_core::retrieval::rag_fusion::execute_deep_search(
             index_dir,
             query,
+            intent,
             config,
             filters,
             result_limit,
@@ -108,6 +111,7 @@ fn execute_query(
         vera_core::retrieval::search_service::execute_search(
             index_dir,
             query,
+            intent,
             config,
             filters,
             result_limit,
@@ -134,10 +138,10 @@ fn execute_multi_query_search(
     let mut result_sets = Vec::with_capacity(queries.len());
 
     for query in queries {
-        let effective_query = apply_intent(query, intent);
         let (results, query_timings) = execute_query(
             index_dir,
-            &effective_query,
+            query,
+            intent,
             config,
             filters,
             per_query_limit,
@@ -175,16 +179,6 @@ fn normalize_queries(queries: &[String]) -> Vec<String> {
     }
 
     normalized
-}
-
-fn apply_intent(query: &str, intent: Option<&str>) -> String {
-    let intent = intent
-        .map(|value| value.split_whitespace().collect::<Vec<_>>().join(" "))
-        .filter(|value| !value.is_empty());
-    match intent {
-        Some(intent) => format!("intent: {intent} | {query}"),
-        None => query.to_string(),
-    }
 }
 
 fn compute_per_query_limit(result_limit: usize) -> usize {

--- a/crates/vera-core/src/retrieval/hybrid.rs
+++ b/crates/vera-core/src/retrieval/hybrid.rs
@@ -79,22 +79,23 @@ pub struct HybridTimings {
 pub async fn search_hybrid(
     index_dir: &Path,
     provider: &impl EmbeddingProvider,
-    query: &str,
+    bm25_query: &str,
+    vector_query: &str,
     limit: usize,
     rrf_k: f64,
     stored_dim: usize,
     vector_candidates: usize,
 ) -> Result<(Vec<SearchResult>, HybridTimings), HybridSearchError> {
-    let bm25_candidates = compute_bm25_candidates(query, limit);
+    let bm25_candidates = compute_bm25_candidates(bm25_query, limit);
     let mut timings = HybridTimings::default();
 
     let bm25_start = Instant::now();
-    let bm25_results = search_bm25(index_dir, query, bm25_candidates);
+    let bm25_results = search_bm25(index_dir, bm25_query, bm25_candidates);
     timings.bm25 = Some(bm25_start.elapsed());
 
     let embed_start = Instant::now();
     let vector_results =
-        search_vector(index_dir, provider, query, vector_candidates, stored_dim).await;
+        search_vector(index_dir, provider, vector_query, vector_candidates, stored_dim).await;
     let vector_elapsed = embed_start.elapsed();
     timings.embedding = Some(vector_elapsed);
     timings.vector = Some(vector_elapsed);
@@ -163,7 +164,8 @@ pub async fn search_hybrid_reranked(
     index_dir: &Path,
     provider: &impl EmbeddingProvider,
     reranker: &impl Reranker,
-    query: &str,
+    bm25_query: &str,
+    vector_query: &str,
     limit: usize,
     rrf_k: f64,
     stored_dim: usize,
@@ -175,7 +177,8 @@ pub async fn search_hybrid_reranked(
     let (hybrid_results, mut timings) = search_hybrid(
         index_dir,
         provider,
-        query,
+        bm25_query,
+        vector_query,
         fetch_limit,
         rrf_k,
         stored_dim,
@@ -188,11 +191,11 @@ pub async fn search_hybrid_reranked(
     }
 
     let rerank_start = Instant::now();
-    match rerank_results(reranker, query, &hybrid_results, rerank_candidates).await {
+    match rerank_results(reranker, vector_query, &hybrid_results, rerank_candidates).await {
         Ok(mut reranked) => {
             timings.reranking = Some(rerank_start.elapsed());
             info!(
-                query = query,
+                query = vector_query,
                 candidates = hybrid_results.len(),
                 reranked = reranked.len(),
                 "reranking complete"
@@ -706,6 +709,37 @@ mod tests {
         (index_dir, dim)
     }
 
+    // Regression for issue #20: the intent-prefixed query must only reach the
+    // vector side. BM25 receives the raw query, so an `intent: ... |` prefix in
+    // `vector_query` never makes Tantivy parse `intent:` as a missing field.
+    #[tokio::test]
+    async fn search_hybrid_keeps_intent_out_of_bm25() {
+        use crate::embedding::test_helpers::MockProvider;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let (index_dir, dim) = setup_test_index(tmp.path()).await;
+        let provider = MockProvider::new(dim);
+
+        // bm25_query is the raw user query; vector_query carries the intent prefix.
+        let (results, _timings) = search_hybrid(
+            &index_dir,
+            &provider,
+            "authenticate",
+            "intent: find auth handlers | authenticate",
+            5,
+            60.0,
+            dim,
+            50,
+        )
+        .await
+        .expect("hybrid search must not error when intent prefix is present");
+
+        assert!(
+            !results.is_empty(),
+            "BM25 should contribute results for the raw query 'authenticate'"
+        );
+    }
+
     #[tokio::test]
     async fn search_hybrid_reranked_returns_reranked_results() {
         use crate::embedding::test_helpers::MockProvider;
@@ -721,6 +755,7 @@ mod tests {
             &index_dir,
             &provider,
             &reranker,
+            "authenticate",
             "authenticate",
             5,
             60.0,
@@ -767,6 +802,7 @@ mod tests {
             &provider,
             &reranker,
             "authenticate",
+            "authenticate",
             5,
             60.0,
             dim,
@@ -803,6 +839,7 @@ mod tests {
             &provider,
             &reranker,
             "authenticate",
+            "authenticate",
             5,
             60.0,
             dim,
@@ -831,7 +868,7 @@ mod tests {
         let reranker = MockReranker::new();
 
         let (results, _timings) = search_hybrid_reranked(
-            &index_dir, &provider, &reranker, "function", 2, 60.0, dim, 10, 50,
+            &index_dir, &provider, &reranker, "function", "function", 2, 60.0, dim, 10, 50,
         )
         .await
         .unwrap();
@@ -912,6 +949,7 @@ mod tests {
             &provider,
             &reranker,
             id_query,
+            id_query,
             5,
             id_params.rrf_k,
             dim,
@@ -931,6 +969,7 @@ mod tests {
             &index_dir,
             &provider,
             &reranker,
+            nl_query,
             nl_query,
             5,
             nl_params.rrf_k,

--- a/crates/vera-core/src/retrieval/iterative_search.rs
+++ b/crates/vera-core/src/retrieval/iterative_search.rs
@@ -21,6 +21,7 @@ use super::search_service::{SearchTimings, execute_search};
 pub fn execute_iterative_search(
     index_dir: &Path,
     query: &str,
+    intent: Option<&str>,
     config: &VeraConfig,
     filters: &SearchFilters,
     result_limit: usize,
@@ -30,7 +31,7 @@ pub fn execute_iterative_search(
     let fetch_per_hop = result_limit;
 
     let (initial_results, timings) =
-        execute_search(index_dir, query, config, filters, fetch_per_hop, backend)?;
+        execute_search(index_dir, query, intent, config, filters, fetch_per_hop, backend)?;
 
     if hops == 0 || initial_results.is_empty() {
         return Ok((initial_results, timings));
@@ -67,6 +68,7 @@ pub fn execute_iterative_search(
         let (hop_results, _) = execute_search(
             index_dir,
             symbol,
+            intent,
             config,
             filters,
             fetch_per_hop / 2,

--- a/crates/vera-core/src/retrieval/rag_fusion.rs
+++ b/crates/vera-core/src/retrieval/rag_fusion.rs
@@ -28,6 +28,7 @@ use super::search_service::{SearchTimings, execute_search};
 pub fn execute_deep_search(
     index_dir: &Path,
     query: &str,
+    intent: Option<&str>,
     config: &VeraConfig,
     filters: &SearchFilters,
     result_limit: usize,
@@ -39,6 +40,7 @@ pub fn execute_deep_search(
             return super::iterative_search::execute_iterative_search(
                 index_dir,
                 query,
+                intent,
                 config,
                 filters,
                 result_limit,
@@ -51,6 +53,7 @@ pub fn execute_deep_search(
             return super::iterative_search::execute_iterative_search(
                 index_dir,
                 query,
+                intent,
                 config,
                 filters,
                 result_limit,
@@ -63,6 +66,7 @@ pub fn execute_deep_search(
     execute_rag_fusion(
         index_dir,
         query,
+        intent,
         config,
         filters,
         result_limit,
@@ -74,6 +78,7 @@ pub fn execute_deep_search(
 fn execute_rag_fusion(
     index_dir: &Path,
     query: &str,
+    intent: Option<&str>,
     config: &VeraConfig,
     filters: &SearchFilters,
     result_limit: usize,
@@ -124,6 +129,7 @@ fn execute_rag_fusion(
                             execute_search(
                                 &index_dir,
                                 &q,
+                                intent,
                                 &config,
                                 &filters,
                                 per_query_limit,

--- a/crates/vera-core/src/retrieval/search_service.rs
+++ b/crates/vera-core/src/retrieval/search_service.rs
@@ -42,12 +42,18 @@ pub struct SearchTimings {
 pub fn execute_search(
     index_dir: &Path,
     query: &str,
+    intent: Option<&str>,
     config: &VeraConfig,
     filters: &SearchFilters,
     result_limit: usize,
     backend: InferenceBackend,
 ) -> Result<(Vec<SearchResult>, SearchTimings)> {
     let total_start = Instant::now();
+    // `query` (raw) drives BM25, classification, expansion and exact-match
+    // augmentation. The intent prefix only enriches the semantic side
+    // (embedding + reranker); sending it to BM25 makes Tantivy parse
+    // `intent:` as a non-existent field and fail. See issue #20.
+    let vector_query = build_query_with_intent(query, intent);
     let fetch_limit = compute_fetch_limit(query, filters, result_limit);
     let rt = tokio::runtime::Runtime::new()?;
 
@@ -157,6 +163,7 @@ pub fn execute_search(
             &provider,
             reranker,
             query,
+            &vector_query,
             fetch_limit,
             rrf_k,
             stored_dim,
@@ -168,6 +175,7 @@ pub fn execute_search(
             index_dir,
             &provider,
             query,
+            &vector_query,
             fetch_limit,
             rrf_k,
             stored_dim,
@@ -191,6 +199,23 @@ pub fn execute_search(
 
     timings.total = Some(total_start.elapsed());
     Ok((apply_filters(results, filters, result_limit), timings))
+}
+
+/// Build the semantic query text used for embedding and reranking.
+///
+/// When an `--intent` is supplied it is prefixed as `intent: <intent> | <query>`
+/// (intent whitespace collapsed) to steer the embedding model. The raw `query`
+/// is returned unchanged when no usable intent is present. This prefixed form
+/// must never reach BM25: Tantivy's `QueryParser` treats `intent:` as a field
+/// query and there is no such field. See issue #20.
+pub(crate) fn build_query_with_intent(query: &str, intent: Option<&str>) -> String {
+    let intent = intent
+        .map(|value| value.split_whitespace().collect::<Vec<_>>().join(" "))
+        .filter(|value| !value.is_empty());
+    match intent {
+        Some(intent) => format!("intent: {intent} | {query}"),
+        None => query.to_string(),
+    }
 }
 
 /// Compute how many candidates to keep through fusion before final truncation.
@@ -498,6 +523,7 @@ mod tests {
             let res = execute_search(
                 index_dir,
                 "test",
+                None,
                 &config,
                 &filters,
                 10,
@@ -538,12 +564,26 @@ mod tests {
         let res = execute_search(
             index_dir,
             "test",
+            None,
             &config,
             &filters,
             10,
             crate::config::InferenceBackend::Api,
         );
         assert!(res.is_ok(), "Expected Ok but got {:?}", res);
+    }
+
+    #[test]
+    fn build_query_with_intent_formats_and_normalizes() {
+        // No intent: raw query unchanged (this is what BM25 receives).
+        assert_eq!(build_query_with_intent("test query", None), "test query");
+        // Empty / whitespace-only intent collapses to no prefix.
+        assert_eq!(build_query_with_intent("test query", Some("   ")), "test query");
+        // Intent present: prefixed form with whitespace collapsed.
+        assert_eq!(
+            build_query_with_intent("test query", Some("find  auth\n handlers")),
+            "intent: find auth handlers | test query"
+        );
     }
 
     #[test]

--- a/crates/vera-core/src/retrieval/search_service.rs
+++ b/crates/vera-core/src/retrieval/search_service.rs
@@ -54,6 +54,8 @@ pub fn execute_search(
     // (embedding + reranker); sending it to BM25 makes Tantivy parse
     // `intent:` as a non-existent field and fail. See issue #20.
     let vector_query = build_query_with_intent(query, intent);
+    // True when an intent prefix was actually applied (non-empty intent).
+    let has_intent = matches!(vector_query, std::borrow::Cow::Owned(_));
     let fetch_limit = compute_fetch_limit(query, filters, result_limit);
     let rt = tokio::runtime::Runtime::new()?;
 
@@ -134,7 +136,7 @@ pub fn execute_search(
             warn!("Failed to create reranker ({})", e);
             None
         });
-    let reranker_enabled = reranker.is_some() && !should_skip_reranking(query, filters);
+    let reranker_enabled = reranking_enabled(reranker.is_some(), has_intent, query, filters);
 
     // Classify query to adapt fusion parameters.
     let query_type = classify_query(query);
@@ -163,7 +165,7 @@ pub fn execute_search(
             &provider,
             reranker,
             query,
-            &vector_query,
+            vector_query.as_ref(),
             fetch_limit,
             rrf_k,
             stored_dim,
@@ -175,7 +177,7 @@ pub fn execute_search(
             index_dir,
             &provider,
             query,
-            &vector_query,
+            vector_query.as_ref(),
             fetch_limit,
             rrf_k,
             stored_dim,
@@ -208,13 +210,18 @@ pub fn execute_search(
 /// is returned unchanged when no usable intent is present. This prefixed form
 /// must never reach BM25: Tantivy's `QueryParser` treats `intent:` as a field
 /// query and there is no such field. See issue #20.
-pub(crate) fn build_query_with_intent(query: &str, intent: Option<&str>) -> String {
+pub(crate) fn build_query_with_intent<'a>(
+    query: &'a str,
+    intent: Option<&str>,
+) -> std::borrow::Cow<'a, str> {
     let intent = intent
         .map(|value| value.split_whitespace().collect::<Vec<_>>().join(" "))
         .filter(|value| !value.is_empty());
     match intent {
-        Some(intent) => format!("intent: {intent} | {query}"),
-        None => query.to_string(),
+        // Only allocate when an intent prefix is actually applied; otherwise
+        // borrow the raw query.
+        Some(intent) => std::borrow::Cow::Owned(format!("intent: {intent} | {query}")),
+        None => std::borrow::Cow::Borrowed(query),
     }
 }
 
@@ -265,6 +272,22 @@ fn effective_rerank_candidates(
     }
 
     base.max(fetch_limit)
+}
+
+/// Decide whether the cross-encoder reranker should run.
+///
+/// Skip heuristics (short identifier / path-weighted / filtered lookups) are
+/// based on the raw query. But when the user supplies an `--intent`, they are
+/// asking for semantic ranking, so the reranker must run even for short raw
+/// queries — otherwise the intent-enriched query would never reach the
+/// cross-encoder. See issue #20.
+fn reranking_enabled(
+    reranker_present: bool,
+    has_intent: bool,
+    query: &str,
+    filters: &SearchFilters,
+) -> bool {
+    reranker_present && (has_intent || !should_skip_reranking(query, filters))
 }
 
 fn should_skip_reranking(query: &str, filters: &SearchFilters) -> bool {
@@ -575,15 +598,34 @@ mod tests {
 
     #[test]
     fn build_query_with_intent_formats_and_normalizes() {
-        // No intent: raw query unchanged (this is what BM25 receives).
-        assert_eq!(build_query_with_intent("test query", None), "test query");
-        // Empty / whitespace-only intent collapses to no prefix.
-        assert_eq!(build_query_with_intent("test query", Some("   ")), "test query");
-        // Intent present: prefixed form with whitespace collapsed.
-        assert_eq!(
-            build_query_with_intent("test query", Some("find  auth\n handlers")),
-            "intent: find auth handlers | test query"
-        );
+        // No intent: raw query borrowed unchanged (this is what BM25 receives).
+        let none = build_query_with_intent("test query", None);
+        assert_eq!(none.as_ref(), "test query");
+        assert!(matches!(none, std::borrow::Cow::Borrowed(_)));
+        // Empty / whitespace-only intent collapses to no prefix (still borrowed).
+        let empty = build_query_with_intent("test query", Some("   "));
+        assert_eq!(empty.as_ref(), "test query");
+        assert!(matches!(empty, std::borrow::Cow::Borrowed(_)));
+        // Intent present: owned prefixed form with whitespace collapsed.
+        let some = build_query_with_intent("test query", Some("find  auth\n handlers"));
+        assert_eq!(some.as_ref(), "intent: find auth handlers | test query");
+        assert!(matches!(some, std::borrow::Cow::Owned(_)));
+    }
+
+    #[test]
+    fn reranking_runs_for_intent_searches_with_short_queries() {
+        let filters = SearchFilters::default();
+        // A short identifier query alone is skipped by the rerank heuristic.
+        assert!(should_skip_reranking("authenticate", &filters));
+        // Without intent that means reranking is off...
+        assert!(!reranking_enabled(true, false, "authenticate", &filters));
+        // ...but an intent forces the cross-encoder to run so it sees the
+        // intent-enriched query (issue #20 regression guard).
+        assert!(reranking_enabled(true, true, "authenticate", &filters));
+        // No reranker present: always off regardless of intent.
+        assert!(!reranking_enabled(false, true, "authenticate", &filters));
+        // Natural-language query without intent still reranks normally.
+        assert!(reranking_enabled(true, false, "how does auth work", &filters));
     }
 
     #[test]

--- a/crates/vera-mcp/src/tools.rs
+++ b/crates/vera-mcp/src/tools.rs
@@ -397,14 +397,13 @@ fn handle_search_code(args: &Value) -> ToolCallResult {
     };
 
     for query in &queries {
-        // If intent is provided, prepend it to the query for better reranking.
-        let effective_query = match intent {
-            Some(i) => format!("intent: {i} | {query}"),
-            None => query.clone(),
-        };
+        // Pass the raw query plus the optional intent. Core applies the intent
+        // only to the semantic (embedding/rerank) side; BM25 gets the raw query
+        // so Tantivy does not parse `intent:` as a field. See issue #20.
         match vera_core::retrieval::search_service::execute_search(
             &index_dir,
-            &effective_query,
+            query,
+            intent,
             &config,
             &filters,
             per_query_limit,


### PR DESCRIPTION
## Summary

Fixes #20. `vera search --intent …` formatted the query as `"intent: <text> | <query>"` and passed that single string into core. Tantivy's `QueryParser` reads `intent:` as a field query; no such BM25 field exists, so BM25 errored (`Field does not exist: 'intent'`) and hybrid search silently degraded to vector-only.

The root cause is broader than the report: that one prefixed string was the *only* query value threaded through core, so in `--deep` mode (the repro) it also broke `rag_fusion::bm25_context_hints` and polluted the LLM query-expansion prompt.

## Fix

Only the **semantic** path (embedding + cross-encoder reranker) should see the intent. Stop building the prefixed string in the CLI/MCP layer; thread the **raw query** plus an optional `intent` into core, and combine them only for the vector query via `search_service::build_query_with_intent`. BM25, query classification, query expansion, and exact-match augmentation all run on the raw query.

- **hybrid.rs** — `search_hybrid` / `search_hybrid_reranked` take `bm25_query` + `vector_query`; BM25 uses the raw one, vector + reranker use the intent-enriched one.
- **search_service.rs** — `execute_search` gains `intent: Option<&str>`; builds `vector_query`.
- **rag_fusion.rs / iterative_search.rs** — thread `intent` to per-subquery / per-hop embeddings; expansion + context hints stay on the raw query.
- **search.rs (CLI) / tools.rs (MCP)** — pass raw query + intent; remove the manual `"intent: … | …"` formatting (`apply_intent` deleted).

Embedding/rerank behavior is unchanged (the prefixed form is byte-identical to before).

## Test plan

- [x] `cargo check -p vera-core -p vera-cli -p vera-mcp` — 0 errors
- [x] New unit test `build_query_with_intent_formats_and_normalizes`
- [x] New regression test `search_hybrid_keeps_intent_out_of_bm25` (intent-prefixed `vector_query` + raw `bm25_query` → BM25 still contributes)
- [x] `cargo test -p vera-core retrieval::` — 179 passed, 0 failed (incl. existing `intent_search_*` quality tests)
- [ ] Manual: `vera search --deep --compact -n 1 --intent "test" "test query"` — no "BM25 search failed … Field does not exist: 'intent'" warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops passing the `--intent` prefix to BM25 to fix the Tantivy field error and restore true hybrid search. Also keeps reranking on for intent searches so the cross-encoder sees the intent-enriched query. Fixes #20.

- **Bug Fixes**
  - BM25 now always uses the raw query; semantic path uses `build_query_with_intent`.
  - `--deep` mode keeps context hints and expansion on raw text; no prompt pollution.
  - `vera-cli` and `vera-mcp` pass raw query + optional intent instead of preformatting.
  - Reranking is forced on when intent is present, bypassing the short-query skip heuristic.

- **Refactors**
  - `search_hybrid`/`search_hybrid_reranked` accept `bm25_query` and `vector_query`; `vera-core::execute_search` takes `intent: Option<&str>` and builds the vector query.
  - `build_query_with_intent` returns `Cow<str>` (no allocation without intent); tests cover BM25 isolation and intent-driven reranking.

<sup>Written for commit 1a42f284ddc64ebfa5342b9b4a713b9f03293353. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/lemon07r/Vera/pull/26?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

