### PR TITLE
fix(embedding): auto-truncate on OpenAI token-limit errors

### DIFF
--- a/crates/vera-core/src/embedding/provider.rs
+++ b/crates/vera-core/src/embedding/provider.rs
@@ -604,6 +604,7 @@ fn context_size_info(error: &EmbeddingError) -> Option<ContextSizeInfo> {
         && !lower.contains("\"n_ctx\"")
         && !lower.contains("too large to process")
         && !lower.contains("max allowed tokens per submitted batch")
+        && !lower.contains("maximum input length")
     {
         return None;
     }
@@ -615,6 +616,7 @@ fn context_size_info(error: &EmbeddingError) -> Option<ContextSizeInfo> {
     static N_PROMPT_RE: OnceLock<Regex> = OnceLock::new();
     static MAX_BATCH_TOKENS_RE: OnceLock<Regex> = OnceLock::new();
     static BATCH_TOKENS_RE: OnceLock<Regex> = OnceLock::new();
+    static MAX_INPUT_LENGTH_RE: OnceLock<Regex> = OnceLock::new();
     let n_ctx_re = N_CTX_RE.get_or_init(|| Regex::new(r#""n_ctx"\s*:\s*(\d+)"#).unwrap());
     let max_context_re =
         MAX_CONTEXT_RE.get_or_init(|| Regex::new(r"max context size \((\d+)").unwrap());
@@ -627,6 +629,9 @@ fn context_size_info(error: &EmbeddingError) -> Option<ContextSizeInfo> {
         .get_or_init(|| Regex::new(r"max allowed tokens per submitted batch is (\d+)").unwrap());
     let batch_tokens_re =
         BATCH_TOKENS_RE.get_or_init(|| Regex::new(r"your batch has (\d+) tokens?").unwrap());
+    // OpenAI: `Invalid 'input[3]': maximum input length is 8192 tokens.`
+    let max_input_length_re = MAX_INPUT_LENGTH_RE
+        .get_or_init(|| Regex::new(r"maximum input length is (\d+)").unwrap());
 
     let max_tokens = n_ctx_re
         .captures(&lower)
@@ -635,6 +640,11 @@ fn context_size_info(error: &EmbeddingError) -> Option<ContextSizeInfo> {
         .or_else(|| batch_size_re.captures(&lower).and_then(|caps| caps.get(1)))
         .or_else(|| {
             max_batch_tokens_re
+                .captures(&lower)
+                .and_then(|caps| caps.get(1))
+        })
+        .or_else(|| {
+            max_input_length_re
                 .captures(&lower)
                 .and_then(|caps| caps.get(1))
         })
@@ -1262,6 +1272,19 @@ mod tests {
         let info = context_size_info(&err).expect("should recognize voyage batch token error");
         assert_eq!(info.max_tokens, 120000);
         assert_eq!(info.input_tokens, Some(124417));
+        assert!(is_context_size_error(&err));
+    }
+
+    #[test]
+    fn context_size_info_parses_openai_max_input_length_error() {
+        // OpenAI reports only the limit, not the input token count. See issue #21.
+        let err = EmbeddingError::ApiError {
+            status: 400,
+            message: "{\"error\":{\"message\":\"Invalid 'input[3]': maximum input length is 8192 tokens.\",\"type\":\"invalid_request_error\",\"param\":null,\"code\":null}}".to_string(),
+        };
+        let info = context_size_info(&err).expect("should recognize openai max input length error");
+        assert_eq!(info.max_tokens, 8192);
+        assert_eq!(info.input_tokens, None);
         assert!(is_context_size_error(&err));
     }
 }

--- a/crates/vera-core/src/embedding/tests.rs
+++ b/crates/vera-core/src/embedding/tests.rs
@@ -36,6 +36,11 @@ struct TokensInParensProvider {
     max_chars: usize,
 }
 
+struct OpenAiInputLengthProvider {
+    dim: usize,
+    max_chars: usize,
+}
+
 struct BatchLimitedProvider {
     dim: usize,
     max_batch_size: usize,
@@ -105,6 +110,30 @@ impl EmbeddingProvider for TokensInParensProvider {
             return Err(EmbeddingError::ApiError {
                 status: 400,
                 message: "input (9448 tokens) is larger than the max context size (8192 tokens). skipping".to_string(),
+            });
+        }
+
+        Ok(texts
+            .iter()
+            .map(|text| vec![text.len() as f32, 1.0, 2.0, 3.0][..self.dim].to_vec())
+            .collect())
+    }
+
+    fn expected_dim(&self) -> Option<usize> {
+        Some(self.dim)
+    }
+}
+
+impl EmbeddingProvider for OpenAiInputLengthProvider {
+    async fn embed_batch(&self, texts: &[String]) -> Result<Vec<Vec<f32>>, EmbeddingError> {
+        if texts
+            .iter()
+            .any(|text| text.chars().count() > self.max_chars)
+        {
+            // OpenAI's format carries the limit but no input token count.
+            return Err(EmbeddingError::ApiError {
+                status: 400,
+                message: r#"{"error":{"message":"Invalid 'input[3]': maximum input length is 8192 tokens.","type":"invalid_request_error","param":null,"code":null}}"#.to_string(),
             });
         }
 
@@ -550,6 +579,28 @@ async fn concurrent_embed_recovers_from_token_limit_batch_errors() {
 #[tokio::test]
 async fn concurrent_embed_recovers_from_tokens_in_parens_error() {
     let provider = TokensInParensProvider {
+        dim: 4,
+        max_chars: 80,
+    };
+    let mut chunks = sample_chunks(3);
+    chunks[1].content = format!("fn huge() {{\n    {}\n}}", "x".repeat(600));
+
+    let result = embed_chunks_concurrent(&provider, &chunks, 2, 2, 0)
+        .await
+        .unwrap();
+
+    assert_eq!(result.len(), 3);
+    assert_eq!(result[0].0, "chunk-0");
+    assert_eq!(result[1].0, "chunk-1");
+    assert_eq!(result[2].0, "chunk-2");
+}
+
+#[tokio::test]
+async fn concurrent_embed_recovers_from_openai_max_input_length_error() {
+    // Regression for issue #21: OpenAI's "maximum input length is N tokens"
+    // error must trigger truncation-retry instead of being fatal, even though
+    // it carries no input-token count.
+    let provider = OpenAiInputLengthProvider {
         dim: 4,
         max_chars: 80,
     };


### PR DESCRIPTION
## Summary

Fixes #21. Indexing with OpenAI embeddings (`text-embedding-3-small`, 8192-token limit) aborts with a fatal `embedding API error (status 400)` when a chunk exceeds the limit, instead of auto-truncating.

`embed_batch_resilient` already splits oversized batches and truncates oversized single chunks — but its trigger, `context_size_info()`, only recognized llama.cpp and Voyage error phrasings. OpenAI returns:

> `Invalid 'input[3]': maximum input length is 8192 tokens.`

…which matched none of the guard substrings, so `context_size_info` returned `None`, the error was treated as non-recoverable, and indexing failed.

## Fix

`crates/vera-core/src/embedding/provider.rs`, `context_size_info()`:
- Add `"maximum input length"` to the substring guard chain.
- Add a `maximum input length is (\d+)` regex and wire it into the existing `max_tokens` extraction chain (captures the real `8192`).

OpenAI's error carries the limit but **no input-token count**, so `input_tokens` stays `None` — `shrink_text_for_context_limit` already handles that via its 75%-of-length fallback, which always makes progress until the chunk fits. No other changes needed; recovery works end-to-end (batch-split → single item → truncate → retry).

## Test plan

- [x] `context_size_info_parses_openai_max_input_length_error` — unit: OpenAI JSON → `max_tokens == 8192`, `input_tokens == None`, recognized as context-size error
- [x] `concurrent_embed_recovers_from_openai_max_input_length_error` — resilience: a provider returning the OpenAI 400 for oversized input recovers via truncate-retry (mirrors existing llama.cpp/Voyage recovery tests)
- [x] `cargo test -p vera-core embedding::` — 62 passed, 0 failed

## Not included

The issue's "adjacent issue" (repeated `◐ Parsed into…` / `◐ Generating embeddings` progress lines around the error) is a separate indexing-progress display concern, unrelated to token-limit detection. Happy to look at it separately if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automatically truncates oversized chunks on OpenAI token-limit errors to prevent fatal 400s during indexing with `text-embedding-3-small` (8192 tokens). Fixes #21 by detecting OpenAI’s “maximum input length” error and triggering the existing retry + truncation flow.

- **Bug Fixes**
  - Detect OpenAI error text in `context_size_info()` and parse `maximum input length is (\d+)`, enabling split/truncate/retry.
  - When OpenAI omits input token count, use the 75% fallback truncation to ensure progress.
  - Added unit and resilience tests to cover parsing and recovery behavior.

<sup>Written for commit 7cf01e4ce106be71b4897d754f2d7abffa3d45ff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/lemon07r/Vera/pull/27?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

