### PR TITLE
fix(search): match bare directory path globs as directory prefixes (supersedes #24)

### DIFF
--- a/crates/vera-core/src/types.rs
+++ b/crates/vera-core/src/types.rs
@@ -166,7 +166,8 @@ fn glob_matches(pattern: &str, path: &str) -> bool {
     // characters (e.g. Next.js dynamic-route dirs like `app/[slug]`), so they
     // must stay eligible for the fallback.
     if !pattern.is_empty() && !pattern.contains('*') {
-        return path.starts_with(&format!("{pattern}/"));
+        return path.starts_with(pattern)
+            && path.as_bytes().get(pattern.len()) == Some(&b'/');
     }
 
     false

--- a/crates/vera-core/src/types.rs
+++ b/crates/vera-core/src/types.rs
@@ -145,7 +145,31 @@ fn glob_matches(pattern: &str, path: &str) -> bool {
     let pattern = pattern.replace('\\', "/");
     let path = path.replace('\\', "/");
 
-    glob_match_recursive(&pattern, &path)
+    // Normalize a leading `./` on both sides and a trailing `/` on the
+    // pattern, so `./app/src` and `app/src/` behave like `app/src`.
+    let pattern = pattern
+        .strip_prefix("./")
+        .unwrap_or(&pattern)
+        .trim_end_matches('/');
+    let path = path.strip_prefix("./").unwrap_or(&path);
+
+    if glob_match_recursive(pattern, path) {
+        return true;
+    }
+
+    // Directory-prefix fallback: a bare pattern with no wildcards (e.g.
+    // `app/src`) should match any file beneath that directory
+    // (`app/src/foo.ts`), i.e. behave like `app/src/**`. Kept out of the
+    // recursive matcher so wildcards like `*` retain single-segment semantics.
+    //
+    // Only `*`/`**` are wildcards in this matcher; `?` and `[` are literal
+    // characters (e.g. Next.js dynamic-route dirs like `app/[slug]`), so they
+    // must stay eligible for the fallback.
+    if !pattern.is_empty() && !pattern.contains('*') {
+        return path.starts_with(&format!("{pattern}/"));
+    }
+
+    false
 }
 
 /// Recursive glob matching helper.
@@ -1374,5 +1398,77 @@ mod tests {
         assert!(glob_matches("src/**", "src/main.rs"));
         assert!(glob_matches("src/**", "src/a/b/c.rs"));
         assert!(!glob_matches("src/**", "tests/main.rs"));
+    }
+
+    #[test]
+    fn glob_bare_directory_matches_files_beneath() {
+        // Bare directory pattern (no wildcards) behaves like `app/src/**`.
+        assert!(glob_matches("app/src", "app/src/foo.ts"));
+        assert!(glob_matches("app/src", "app/src/bar/baz.rs"));
+        // But not siblings or unrelated directories.
+        assert!(!glob_matches("app/src", "app/srcs/foo.ts"));
+        assert!(!glob_matches("app/src", "other/src/foo.ts"));
+        // Single-segment bare directory.
+        assert!(glob_matches("src", "src/foo.rs"));
+        assert!(!glob_matches("src", "srcs/foo.rs"));
+        // The directory path itself (exact, no trailing file) still matches.
+        assert!(glob_matches("app/src", "app/src"));
+        // `?` and `[` are literals in this matcher, not wildcards, so bare
+        // directories containing them (e.g. Next.js `app/[slug]`) still get
+        // the directory-prefix fallback.
+        assert!(glob_matches("app/[slug]", "app/[slug]/page.tsx"));
+        assert!(!glob_matches("app/[slug]", "app/other/page.tsx"));
+    }
+
+    #[test]
+    fn glob_trailing_slash_pattern_matches_directory() {
+        // A trailing slash on the pattern is normalized away.
+        assert!(glob_matches("app/src/", "app/src/foo.ts"));
+        assert!(!glob_matches("app/src/", "app/srcs/foo.ts"));
+    }
+
+    #[test]
+    fn glob_leading_dot_slash_is_normalized() {
+        // `./app/src` behaves like `app/src` against unprefixed paths.
+        assert!(glob_matches("./app/src", "app/src/foo.ts"));
+        // And a `./`-prefixed path is normalized too.
+        assert!(glob_matches("app/src", "./app/src/foo.ts"));
+    }
+
+    #[test]
+    fn filter_by_path_plain_directory_prefix() {
+        let filters = SearchFilters {
+            path_glob: Some("app/src".to_string()),
+            ..Default::default()
+        };
+        let inside = make_test_result("app/src/foo.ts", Language::TypeScript, None, None);
+        let deep = make_test_result("app/src/bar/baz.rs", Language::Rust, None, None);
+        let sibling = make_test_result("app/srcs/foo.ts", Language::TypeScript, None, None);
+        let other = make_test_result("other/src/foo.ts", Language::TypeScript, None, None);
+        assert!(filters.matches(&inside));
+        assert!(filters.matches(&deep));
+        assert!(!filters.matches(&sibling));
+        assert!(!filters.matches(&other));
+
+        // A wildcard pattern must NOT get directory-prefix treatment: `app/*`
+        // stays single-segment and does not match nested files.
+        let wildcard = SearchFilters {
+            path_glob: Some("app/*".to_string()),
+            ..Default::default()
+        };
+        assert!(!wildcard.matches(&deep));
+    }
+
+    #[test]
+    fn single_star_does_not_cross_directory_boundary() {
+        // `src/*` must not match `src/bar/baz` — `*` is single-segment only.
+        let filters = SearchFilters {
+            path_glob: Some("src/*".to_string()),
+            ..Default::default()
+        };
+        let shallow = make_test_result("src/foo.rs", Language::Rust, None, None);
+        let deep = make_test_result("src/bar/baz.rs", Language::Rust, None, None);
+        assert!(filters.matches(&shallow));
+        assert!(!filters.matches(&deep));
     }
 }


### PR DESCRIPTION
## Summary

Closes #23. `vera search … --path app/src` returned nothing for files under that directory. In `glob_match_recursive` (`crates/vera-core/src/types.rs`) a wildcard-free pattern matches only by exact char-for-char equality, so once `app/src` is consumed but the path still has `/foo.ts`, the empty-pattern base case returns false. `*`/`**` worked; a bare directory did not.

## Fix

Extend only the `glob_matches` wrapper — `glob_match_recursive` is left untouched, so `*` stays single-segment and `**` stays any-depth:

- Normalize a leading `./` on both sides and a trailing `/` on the pattern, so `./app/src` and `app/src/` behave like `app/src`.
- After a failed recursive match, when the pattern contains no `*`, treat it as a directory prefix (`path.starts_with("<pattern>/")`) — `app/src` behaves like `app/src/**`.

The guard checks for `*` **only**. This matcher supports `*`/`**` but not `?` or `[...]`, so those are literal characters (e.g. Next.js dynamic-route dirs like `app/[slug]`) and must stay eligible for the prefix fallback.

All search modes (hybrid/BM25, vector, regex/grep, MCP, CLI) filter through this single `SearchFilters::matches_file` → `glob_matches` chokepoint, so the fix applies uniformly.

## Relationship to #24

This supersedes #24 (also "Closes #23"). Beyond #24 it:
- keeps `glob_match_recursive` strict — avoids the wildcard-boundary bug flagged on #24's first revision (`src/*` crossing `/`); guarded by a dedicated test;
- handles **trailing slash** (`app/src/`), **leading `./`** (`./app/src`), and **literal `[`/`?`** directories (`app/[slug]`) — none covered by #24 (#24's guard wrongly treats `[`/`?` as wildcards, so `app/[slug]` matches nothing there);
- adds broader test coverage.

## Test plan

- [x] `glob_bare_directory_matches_files_beneath` — bare/single-segment dirs, siblings excluded, literal `app/[slug]`
- [x] `glob_trailing_slash_pattern_matches_directory`, `glob_leading_dot_slash_is_normalized`
- [x] `filter_by_path_plain_directory_prefix` (issue #23's exact test) + wildcard `app/*` must-not-prefix assertion
- [x] `single_star_does_not_cross_directory_boundary` — `*` stays single-segment
- [x] `cargo test -p vera-core types::tests` — 82 passed, 0 failed; existing wildcard tests unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes search path filtering so a bare directory glob matches files beneath it. `--path app/src` now includes files under `app/src` without needing `**`, and still matches the directory itself.

- **Bug Fixes**
  - Update `glob_matches` to treat wildcard-free patterns as directory prefixes after a failed recursive match; leave `glob_match_recursive` unchanged.
  - Normalize leading `./` and trailing `/` in patterns, and leading `./` in paths (e.g., `./app/src`, `app/src/` behave like `app/src`).
  - Keep wildcard semantics: `*` is single-segment and `**` is any-depth; `?` and `[` are literals (e.g., `app/[slug]`). Explicitly ensure `app/*` does not match nested files.
  - Applies across all search modes via `SearchFilters::matches_file`, with new tests covering these cases.

<sup>Written for commit 582574e056ca468f83175c3d5f7e0006d947d1ad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/lemon07r/Vera/pull/28?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

