### PR TITLE
fix(inference): bound remote work and honor rerank depth

### DIFF
--- a/crates/vera-cli/src/commands/index.rs
+++ b/crates/vera-cli/src/commands/index.rs
@@ -7,25 +7,9 @@ use anyhow::{Context, bail};
 use vera_core::config::InferenceBackend;
 use vera_core::indexing::IndexProgress;
 
-use crate::helpers::{load_runtime_config, print_human_summary};
-
-async fn wait_for_interrupt() {
-    let _ = tokio::signal::ctrl_c().await;
-}
-
-async fn cancel_on_signal<T, Operation, Signal>(
-    operation: Operation,
-    signal: Signal,
-) -> anyhow::Result<T>
-where
-    Operation: std::future::Future<Output = anyhow::Result<T>>,
-    Signal: std::future::Future<Output = ()>,
-{
-    tokio::select! {
-        result = operation => result,
-        _ = signal => bail!("indexing cancelled"),
-    }
-}
+use crate::helpers::{
+    cancel_on_signal, load_runtime_config, print_human_summary, wait_for_interrupt,
+};
 
 /// Run the `vera index <path>` command.
 #[allow(clippy::too_many_arguments)]
@@ -107,6 +91,7 @@ pub fn execute(
             .block_on(cancel_on_signal(
                 vera_core::indexing::index_repository(repo_path, &provider, &config, &model_name),
                 wait_for_interrupt(),
+                "indexing",
             ))
             .context("indexing failed")?;
         return Ok(summary);
@@ -154,53 +139,9 @@ pub fn execute(
             on_progress,
         ),
         wait_for_interrupt(),
+        "indexing",
     ));
     multi.stop();
 
     result.context("indexing failed")
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use std::sync::atomic::{AtomicBool, Ordering};
-
-    struct DropMarker(Arc<AtomicBool>);
-
-    impl Drop for DropMarker {
-        fn drop(&mut self) {
-            self.0.store(true, Ordering::SeqCst);
-        }
-    }
-
-    #[tokio::test]
-    async fn operation_result_wins_before_cancellation() {
-        let result = cancel_on_signal(async { Ok::<_, anyhow::Error>(42) }, std::future::pending())
-            .await
-            .unwrap();
-
-        assert_eq!(result, 42);
-    }
-
-    #[tokio::test]
-    async fn cancellation_drops_in_flight_operation() {
-        let dropped = Arc::new(AtomicBool::new(false));
-        let dropped_for_operation = dropped.clone();
-        let (started_tx, started_rx) = tokio::sync::oneshot::channel();
-
-        let operation = async move {
-            let _marker = DropMarker(dropped_for_operation);
-            let _ = started_tx.send(());
-            std::future::pending::<()>().await;
-            Ok::<_, anyhow::Error>(())
-        };
-        let signal = async move {
-            let _ = started_rx.await;
-        };
-
-        let error = cancel_on_signal(operation, signal).await.unwrap_err();
-
-        assert!(error.to_string().contains("cancelled"));
-        assert!(dropped.load(Ordering::SeqCst));
-    }
 }

--- a/crates/vera-cli/src/commands/index.rs
+++ b/crates/vera-cli/src/commands/index.rs
@@ -87,10 +87,19 @@ pub fn execute(
 
     // Use progress bar for interactive (non-JSON) output.
     if json_output {
+        let cancellation = vera_core::CancellationToken::new();
         let summary = rt
             .block_on(cancel_on_signal(
-                vera_core::indexing::index_repository(repo_path, &provider, &config, &model_name),
+                vera_core::indexing::index_repository(
+                    repo_path,
+                    &provider,
+                    &config,
+                    &model_name,
+                    |_| {},
+                    &cancellation,
+                ),
                 wait_for_interrupt(),
+                cancellation.clone(),
                 "indexing",
             ))
             .context("indexing failed")?;
@@ -130,15 +139,18 @@ pub fn execute(
         IndexProgress::StorageDone => {}
     };
 
+    let cancellation = vera_core::CancellationToken::new();
     let result = rt.block_on(cancel_on_signal(
-        vera_core::indexing::index_repository_with_progress(
+        vera_core::indexing::index_repository(
             repo_path,
             &provider,
             &config,
             &model_name,
             on_progress,
+            &cancellation,
         ),
         wait_for_interrupt(),
+        cancellation.clone(),
         "indexing",
     ));
     multi.stop();

--- a/crates/vera-cli/src/commands/index.rs
+++ b/crates/vera-cli/src/commands/index.rs
@@ -90,12 +90,11 @@ pub fn execute(
         let cancellation = vera_core::CancellationToken::new();
         let summary = rt
             .block_on(cancel_on_signal(
-                vera_core::indexing::index_repository(
+                vera_core::indexing::index_repository_with_cancellation(
                     repo_path,
                     &provider,
                     &config,
                     &model_name,
-                    |_| {},
                     &cancellation,
                 ),
                 wait_for_interrupt(),
@@ -141,7 +140,7 @@ pub fn execute(
 
     let cancellation = vera_core::CancellationToken::new();
     let result = rt.block_on(cancel_on_signal(
-        vera_core::indexing::index_repository(
+        vera_core::indexing::index_repository_with_progress_and_cancellation(
             repo_path,
             &provider,
             &config,

--- a/crates/vera-cli/src/commands/index.rs
+++ b/crates/vera-cli/src/commands/index.rs
@@ -9,6 +9,24 @@ use vera_core::indexing::IndexProgress;
 
 use crate::helpers::{load_runtime_config, print_human_summary};
 
+async fn wait_for_interrupt() {
+    let _ = tokio::signal::ctrl_c().await;
+}
+
+async fn cancel_on_signal<T, Operation, Signal>(
+    operation: Operation,
+    signal: Signal,
+) -> anyhow::Result<T>
+where
+    Operation: std::future::Future<Output = anyhow::Result<T>>,
+    Signal: std::future::Future<Output = ()>,
+{
+    tokio::select! {
+        result = operation => result,
+        _ = signal => bail!("indexing cancelled"),
+    }
+}
+
 /// Run the `vera index <path>` command.
 #[allow(clippy::too_many_arguments)]
 pub fn run(
@@ -86,11 +104,9 @@ pub fn execute(
     // Use progress bar for interactive (non-JSON) output.
     if json_output {
         let summary = rt
-            .block_on(vera_core::indexing::index_repository(
-                repo_path,
-                &provider,
-                &config,
-                &model_name,
+            .block_on(cancel_on_signal(
+                vera_core::indexing::index_repository(repo_path, &provider, &config, &model_name),
+                wait_for_interrupt(),
             ))
             .context("indexing failed")?;
         return Ok(summary);
@@ -129,17 +145,62 @@ pub fn execute(
         IndexProgress::StorageDone => {}
     };
 
-    let summary = rt
-        .block_on(vera_core::indexing::index_repository_with_progress(
+    let result = rt.block_on(cancel_on_signal(
+        vera_core::indexing::index_repository_with_progress(
             repo_path,
             &provider,
             &config,
             &model_name,
             on_progress,
-        ))
-        .context("indexing failed")?;
-
+        ),
+        wait_for_interrupt(),
+    ));
     multi.stop();
 
-    Ok(summary)
+    result.context("indexing failed")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    struct DropMarker(Arc<AtomicBool>);
+
+    impl Drop for DropMarker {
+        fn drop(&mut self) {
+            self.0.store(true, Ordering::SeqCst);
+        }
+    }
+
+    #[tokio::test]
+    async fn operation_result_wins_before_cancellation() {
+        let result = cancel_on_signal(async { Ok::<_, anyhow::Error>(42) }, std::future::pending())
+            .await
+            .unwrap();
+
+        assert_eq!(result, 42);
+    }
+
+    #[tokio::test]
+    async fn cancellation_drops_in_flight_operation() {
+        let dropped = Arc::new(AtomicBool::new(false));
+        let dropped_for_operation = dropped.clone();
+        let (started_tx, started_rx) = tokio::sync::oneshot::channel();
+
+        let operation = async move {
+            let _marker = DropMarker(dropped_for_operation);
+            let _ = started_tx.send(());
+            std::future::pending::<()>().await;
+            Ok::<_, anyhow::Error>(())
+        };
+        let signal = async move {
+            let _ = started_rx.await;
+        };
+
+        let error = cancel_on_signal(operation, signal).await.unwrap_err();
+
+        assert!(error.to_string().contains("cancelled"));
+        assert!(dropped.load(Ordering::SeqCst));
+    }
 }

--- a/crates/vera-cli/src/commands/update.rs
+++ b/crates/vera-cli/src/commands/update.rs
@@ -5,7 +5,7 @@ use std::path::Path;
 use anyhow::{Context, bail};
 use vera_core::config::InferenceBackend;
 
-use crate::helpers::load_runtime_config;
+use crate::helpers::{cancel_on_signal, load_runtime_config, wait_for_interrupt};
 
 /// Run the `vera update <path>` command.
 pub fn run(
@@ -78,11 +78,10 @@ pub fn run(
 
     // Run the incremental update pipeline.
     let summary = rt
-        .block_on(vera_core::indexing::update_repository(
-            repo_path,
-            &provider,
-            &config,
-            &model_name,
+        .block_on(cancel_on_signal(
+            vera_core::indexing::update_repository(repo_path, &provider, &config, &model_name),
+            wait_for_interrupt(),
+            "update",
         ))
         .context("update failed")?;
 

--- a/crates/vera-cli/src/commands/update.rs
+++ b/crates/vera-cli/src/commands/update.rs
@@ -77,10 +77,18 @@ pub fn run(
     }
 
     // Run the incremental update pipeline.
+    let cancellation = vera_core::CancellationToken::new();
     let summary = rt
         .block_on(cancel_on_signal(
-            vera_core::indexing::update_repository(repo_path, &provider, &config, &model_name),
+            vera_core::indexing::update_repository(
+                repo_path,
+                &provider,
+                &config,
+                &model_name,
+                &cancellation,
+            ),
             wait_for_interrupt(),
+            cancellation.clone(),
             "update",
         ))
         .context("update failed")?;

--- a/crates/vera-cli/src/commands/update.rs
+++ b/crates/vera-cli/src/commands/update.rs
@@ -80,7 +80,7 @@ pub fn run(
     let cancellation = vera_core::CancellationToken::new();
     let summary = rt
         .block_on(cancel_on_signal(
-            vera_core::indexing::update_repository(
+            vera_core::indexing::update_repository_with_cancellation(
                 repo_path,
                 &provider,
                 &config,

--- a/crates/vera-cli/src/helpers.rs
+++ b/crates/vera-cli/src/helpers.rs
@@ -1,11 +1,12 @@
 //! Shared helper functions for CLI command implementations.
 
+use anyhow::Context;
 use clap::Args;
 use serde::Serialize;
 
 /// Wait for the process interrupt used to cancel long-running CLI operations.
-pub async fn wait_for_interrupt() {
-    let _ = tokio::signal::ctrl_c().await;
+pub async fn wait_for_interrupt() -> std::io::Result<()> {
+    tokio::signal::ctrl_c().await
 }
 
 /// Run an operation until it completes or an interrupt signal wins.
@@ -19,11 +20,14 @@ pub async fn cancel_on_signal<T, Operation, Signal>(
 ) -> anyhow::Result<T>
 where
     Operation: std::future::Future<Output = anyhow::Result<T>>,
-    Signal: std::future::Future<Output = ()>,
+    Signal: std::future::Future<Output = std::io::Result<()>>,
 {
     tokio::select! {
         result = operation => result,
-        _ = signal => anyhow::bail!("{operation_name} cancelled"),
+        signal_result = signal => {
+            signal_result.context("failed to listen for interrupt")?;
+            anyhow::bail!("{operation_name} cancelled")
+        },
     }
 }
 
@@ -411,7 +415,7 @@ mod tests {
     async fn operation_result_wins_before_cancellation() {
         let result = cancel_on_signal(
             async { Ok::<_, anyhow::Error>(42) },
-            std::future::pending(),
+            std::future::pending::<std::io::Result<()>>(),
             "test operation",
         )
         .await
@@ -434,6 +438,7 @@ mod tests {
         };
         let signal = async move {
             let _ = started_rx.await;
+            Ok(())
         };
 
         let error = cancel_on_signal(operation, signal, "test operation")
@@ -442,5 +447,24 @@ mod tests {
 
         assert!(error.to_string().contains("test operation cancelled"));
         assert!(dropped.load(Ordering::SeqCst));
+    }
+
+    #[tokio::test]
+    async fn signal_listener_errors_are_propagated() {
+        let error = cancel_on_signal(
+            std::future::pending::<anyhow::Result<()>>(),
+            async { Err(std::io::Error::other("listener setup failed")) },
+            "test operation",
+        )
+        .await
+        .unwrap_err();
+
+        assert!(error.to_string().contains("failed to listen for interrupt"));
+        assert!(
+            error
+                .source()
+                .is_some_and(|source| source.to_string().contains("listener setup failed"))
+        );
+        assert!(!error.to_string().contains("cancelled"));
     }
 }

--- a/crates/vera-cli/src/helpers.rs
+++ b/crates/vera-cli/src/helpers.rs
@@ -3,6 +3,30 @@
 use clap::Args;
 use serde::Serialize;
 
+/// Wait for the process interrupt used to cancel long-running CLI operations.
+pub async fn wait_for_interrupt() {
+    let _ = tokio::signal::ctrl_c().await;
+}
+
+/// Run an operation until it completes or an interrupt signal wins.
+///
+/// Dropping the operation future propagates cancellation through in-flight
+/// client requests instead of leaving the CLI runtime alive until they finish.
+pub async fn cancel_on_signal<T, Operation, Signal>(
+    operation: Operation,
+    signal: Signal,
+    operation_name: &str,
+) -> anyhow::Result<T>
+where
+    Operation: std::future::Future<Output = anyhow::Result<T>>,
+    Signal: std::future::Future<Output = ()>,
+{
+    tokio::select! {
+        result = operation => result,
+        _ = signal => anyhow::bail!("{operation_name} cancelled"),
+    }
+}
+
 /// Load the effective runtime configuration.
 pub fn load_runtime_config() -> anyhow::Result<vera_core::config::VeraConfig> {
     crate::state::load_runtime_config()
@@ -366,5 +390,57 @@ pub fn print_human_summary(summary: &vera_core::indexing::IndexSummary, verbose:
     if summary.files_parsed == 0 && summary.chunks_created == 0 {
         println!();
         println!("  No source files found to index.");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    struct DropMarker(Arc<AtomicBool>);
+
+    impl Drop for DropMarker {
+        fn drop(&mut self) {
+            self.0.store(true, Ordering::SeqCst);
+        }
+    }
+
+    #[tokio::test]
+    async fn operation_result_wins_before_cancellation() {
+        let result = cancel_on_signal(
+            async { Ok::<_, anyhow::Error>(42) },
+            std::future::pending(),
+            "test operation",
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(result, 42);
+    }
+
+    #[tokio::test]
+    async fn cancellation_drops_in_flight_operation() {
+        let dropped = Arc::new(AtomicBool::new(false));
+        let dropped_for_operation = dropped.clone();
+        let (started_tx, started_rx) = tokio::sync::oneshot::channel();
+
+        let operation = async move {
+            let _marker = DropMarker(dropped_for_operation);
+            let _ = started_tx.send(());
+            std::future::pending::<()>().await;
+            Ok::<_, anyhow::Error>(())
+        };
+        let signal = async move {
+            let _ = started_rx.await;
+        };
+
+        let error = cancel_on_signal(operation, signal, "test operation")
+            .await
+            .unwrap_err();
+
+        assert!(error.to_string().contains("test operation cancelled"));
+        assert!(dropped.load(Ordering::SeqCst));
     }
 }

--- a/crates/vera-cli/src/helpers.rs
+++ b/crates/vera-cli/src/helpers.rs
@@ -16,16 +16,42 @@ pub async fn wait_for_interrupt() -> std::io::Result<()> {
 pub async fn cancel_on_signal<T, Operation, Signal>(
     operation: Operation,
     signal: Signal,
+    cancellation: vera_core::CancellationToken,
     operation_name: &str,
 ) -> anyhow::Result<T>
 where
     Operation: std::future::Future<Output = anyhow::Result<T>>,
-    Signal: std::future::Future<Output = std::io::Result<()>>,
+    Signal: std::future::Future<Output = std::io::Result<()>> + Send + 'static,
 {
+    let signal_cancellation = cancellation.clone();
+    let mut signal_task = tokio::spawn(async move {
+        let result = signal.await;
+        signal_cancellation.cancel();
+        result
+    });
+    tokio::pin!(operation);
+
     tokio::select! {
-        result = operation => result,
-        signal_result = signal => {
-            signal_result.context("failed to listen for interrupt")?;
+        result = &mut operation => {
+            if cancellation.is_cancelled() {
+                signal_task
+                    .await
+                    .context("interrupt listener task failed")?
+                    .context("failed to listen for interrupt")?;
+
+                return match result {
+                    Ok(value) => Ok(value),
+                    Err(_) => anyhow::bail!("{operation_name} cancelled"),
+                };
+            }
+
+            signal_task.abort();
+            result
+        },
+        signal_result = &mut signal_task => {
+            signal_result
+                .context("interrupt listener task failed")?
+                .context("failed to listen for interrupt")?;
             anyhow::bail!("{operation_name} cancelled")
         },
     }
@@ -416,6 +442,7 @@ mod tests {
         let result = cancel_on_signal(
             async { Ok::<_, anyhow::Error>(42) },
             std::future::pending::<std::io::Result<()>>(),
+            vera_core::CancellationToken::new(),
             "test operation",
         )
         .await
@@ -440,8 +467,9 @@ mod tests {
             let _ = started_rx.await;
             Ok(())
         };
+        let cancellation = vera_core::CancellationToken::new();
 
-        let error = cancel_on_signal(operation, signal, "test operation")
+        let error = cancel_on_signal(operation, signal, cancellation, "test operation")
             .await
             .unwrap_err();
 
@@ -454,6 +482,7 @@ mod tests {
         let error = cancel_on_signal(
             std::future::pending::<anyhow::Result<()>>(),
             async { Err(std::io::Error::other("listener setup failed")) },
+            vera_core::CancellationToken::new(),
             "test operation",
         )
         .await
@@ -466,5 +495,34 @@ mod tests {
                 .is_some_and(|source| source.to_string().contains("listener setup failed"))
         );
         assert!(!error.to_string().contains("cancelled"));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn cancellation_reaches_synchronous_operation_work() {
+        let cancellation = vera_core::CancellationToken::new();
+        let operation_cancellation = cancellation.clone();
+        let (started_tx, started_rx) = tokio::sync::oneshot::channel();
+
+        let operation = async move {
+            let _ = started_tx.send(());
+            while !operation_cancellation.is_cancelled() {
+                std::hint::spin_loop();
+            }
+            Err::<(), anyhow::Error>(anyhow::anyhow!("operation cancelled"))
+        };
+        let signal = async move {
+            let _ = started_rx.await;
+            Ok(())
+        };
+
+        let error = tokio::time::timeout(
+            std::time::Duration::from_secs(1),
+            cancel_on_signal(operation, signal, cancellation, "test operation"),
+        )
+        .await
+        .expect("synchronous operation should observe cancellation")
+        .unwrap_err();
+
+        assert!(error.to_string().contains("test operation cancelled"));
     }
 }

--- a/crates/vera-cli/src/helpers.rs
+++ b/crates/vera-cli/src/helpers.rs
@@ -24,35 +24,30 @@ where
     Signal: std::future::Future<Output = std::io::Result<()>> + Send + 'static,
 {
     let signal_cancellation = cancellation.clone();
+    let (signal_task_started_tx, signal_task_started_rx) = tokio::sync::oneshot::channel();
     let mut signal_task = tokio::spawn(async move {
+        let _ = signal_task_started_tx.send(());
         let result = signal.await;
         signal_cancellation.cancel();
         result
     });
+    signal_task_started_rx
+        .await
+        .context("interrupt listener task failed to start")?;
     tokio::pin!(operation);
 
     tokio::select! {
-        result = &mut operation => {
-            if cancellation.is_cancelled() {
-                signal_task
-                    .await
-                    .context("interrupt listener task failed")?
-                    .context("failed to listen for interrupt")?;
+        biased;
 
-                return match result {
-                    Ok(value) => Ok(value),
-                    Err(_) => anyhow::bail!("{operation_name} cancelled"),
-                };
-            }
-
-            signal_task.abort();
-            result
-        },
         signal_result = &mut signal_task => {
             signal_result
                 .context("interrupt listener task failed")?
                 .context("failed to listen for interrupt")?;
             anyhow::bail!("{operation_name} cancelled")
+        },
+        result = &mut operation => {
+            signal_task.abort();
+            result
         },
     }
 }
@@ -452,6 +447,43 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn interrupt_wins_when_operation_and_signal_are_ready() {
+        let cancellation = vera_core::CancellationToken::new();
+        let error = cancel_on_signal(
+            async { Ok::<_, anyhow::Error>(42) },
+            async { Ok(()) },
+            cancellation.clone(),
+            "test operation",
+        )
+        .await
+        .unwrap_err();
+
+        assert!(error.to_string().contains("test operation cancelled"));
+        assert!(cancellation.is_cancelled());
+    }
+
+    #[tokio::test]
+    async fn external_cancellation_does_not_wait_for_pending_signal() {
+        let cancellation = vera_core::CancellationToken::new();
+        cancellation.cancel();
+
+        let error = tokio::time::timeout(
+            std::time::Duration::from_millis(100),
+            cancel_on_signal(
+                async { Err::<(), _>(anyhow::anyhow!("operation failed")) },
+                std::future::pending::<std::io::Result<()>>(),
+                cancellation,
+                "test operation",
+            ),
+        )
+        .await
+        .expect("operation result should not wait for the signal listener")
+        .unwrap_err();
+
+        assert!(error.to_string().contains("operation failed"));
+    }
+
+    #[tokio::test]
     async fn cancellation_drops_in_flight_operation() {
         let dropped = Arc::new(AtomicBool::new(false));
         let dropped_for_operation = dropped.clone();
@@ -523,6 +555,6 @@ mod tests {
         .expect("synchronous operation should observe cancellation")
         .unwrap_err();
 
-        assert!(error.to_string().contains("test operation cancelled"));
+        assert!(error.to_string().contains("operation cancelled"));
     }
 }

--- a/crates/vera-core/src/cancellation.rs
+++ b/crates/vera-core/src/cancellation.rs
@@ -1,0 +1,27 @@
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+/// Cooperative cancellation shared across indexing pipeline stages.
+#[derive(Debug, Clone, Default)]
+pub struct CancellationToken {
+    cancelled: Arc<AtomicBool>,
+}
+
+impl CancellationToken {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn cancel(&self) {
+        self.cancelled.store(true, Ordering::Release);
+    }
+
+    pub fn is_cancelled(&self) -> bool {
+        self.cancelled.load(Ordering::Acquire)
+    }
+
+    pub(crate) fn check(&self) -> anyhow::Result<()> {
+        anyhow::ensure!(!self.is_cancelled(), "operation cancelled");
+        Ok(())
+    }
+}

--- a/crates/vera-core/src/config.rs
+++ b/crates/vera-core/src/config.rs
@@ -123,6 +123,11 @@ pub struct EmbeddingConfig {
     pub batch_size: usize,
     /// Maximum number of concurrent embedding API requests.
     pub max_concurrent_requests: usize,
+    /// Hard limit on the total number of embedding inputs that may be active
+    /// across concurrent API requests. This bounds abandoned backend work when
+    /// an indexing client disconnects.
+    #[serde(default = "default_max_in_flight_inputs")]
+    pub max_in_flight_inputs: usize,
     /// Request timeout in seconds.
     pub timeout_secs: u64,
     /// Maximum retries on transient errors.
@@ -150,12 +155,34 @@ impl Default for EmbeddingConfig {
         Self {
             batch_size: if is_local { 4 } else { 128 },
             max_concurrent_requests: if is_local { 1 } else { 8 },
+            max_in_flight_inputs: default_max_in_flight_inputs(),
             timeout_secs: 60,
             max_retries: 3,
             max_stored_dim: 1024,
             gpu_mem_limit_mb: 0,
             low_vram: false,
         }
+    }
+}
+
+fn default_max_in_flight_inputs() -> usize {
+    std::env::var("VERA_MAX_IN_FLIGHT_INPUTS")
+        .ok()
+        .and_then(|value| value.parse().ok())
+        .unwrap_or(16)
+}
+
+impl EmbeddingConfig {
+    /// Clamp configured batching so the product of batch size and concurrency
+    /// never exceeds `max_in_flight_inputs`.
+    pub fn bounded_parallelism(&self) -> (usize, usize) {
+        let max_in_flight = self.max_in_flight_inputs.max(1);
+        let batch_size = self.batch_size.max(1).min(max_in_flight);
+        let max_concurrent_requests = self
+            .max_concurrent_requests
+            .max(1)
+            .min((max_in_flight / batch_size).max(1));
+        (batch_size, max_concurrent_requests)
     }
 }
 
@@ -505,6 +532,36 @@ mod tests {
         assert!(config.retrieval.default_limit > 0);
         assert!(config.retrieval.rrf_k > 0.0);
         assert!(config.embedding.batch_size > 0);
+        assert!(config.embedding.max_in_flight_inputs > 0);
+        let (batch_size, concurrency) = config.embedding.bounded_parallelism();
+        assert!(
+            batch_size * concurrency <= config.embedding.max_in_flight_inputs,
+            "default embedding parallelism must respect its in-flight bound"
+        );
+    }
+
+    #[test]
+    fn embedding_parallelism_clamps_batch_and_concurrency() {
+        let config = EmbeddingConfig {
+            batch_size: 128,
+            max_concurrent_requests: 8,
+            max_in_flight_inputs: 16,
+            ..EmbeddingConfig::default()
+        };
+
+        assert_eq!(config.bounded_parallelism(), (16, 1));
+    }
+
+    #[test]
+    fn embedding_parallelism_normalizes_zero_values_to_one() {
+        let config = EmbeddingConfig {
+            batch_size: 0,
+            max_concurrent_requests: 0,
+            max_in_flight_inputs: 0,
+            ..EmbeddingConfig::default()
+        };
+
+        assert_eq!(config.bounded_parallelism(), (1, 1));
     }
 
     #[test]

--- a/crates/vera-core/src/config.rs
+++ b/crates/vera-core/src/config.rs
@@ -168,7 +168,8 @@ impl Default for EmbeddingConfig {
 fn default_max_in_flight_inputs() -> usize {
     std::env::var("VERA_MAX_IN_FLIGHT_INPUTS")
         .ok()
-        .and_then(|value| value.parse().ok())
+        .and_then(|value| value.parse::<usize>().ok())
+        .map(|value| value.max(1))
         .unwrap_or(16)
 }
 
@@ -562,6 +563,25 @@ mod tests {
         };
 
         assert_eq!(config.bounded_parallelism(), (1, 1));
+    }
+
+    #[test]
+    fn max_in_flight_environment_value_normalizes_zero_to_one() {
+        let _guard = env_lock().lock().unwrap();
+        let previous = std::env::var_os("VERA_MAX_IN_FLIGHT_INPUTS");
+        set_env("VERA_MAX_IN_FLIGHT_INPUTS", "0");
+
+        let max_in_flight_inputs = default_max_in_flight_inputs();
+
+        if let Some(value) = previous {
+            unsafe {
+                std::env::set_var("VERA_MAX_IN_FLIGHT_INPUTS", value);
+            }
+        } else {
+            remove_env("VERA_MAX_IN_FLIGHT_INPUTS");
+        }
+
+        assert_eq!(max_in_flight_inputs, 1);
     }
 
     #[test]

--- a/crates/vera-core/src/discovery/mod.rs
+++ b/crates/vera-core/src/discovery/mod.rs
@@ -20,6 +20,7 @@ use anyhow::{Context, Result};
 use ignore::WalkBuilder;
 use tracing::{debug, warn};
 
+use crate::CancellationToken;
 use crate::config::IndexingConfig;
 
 /// A discovered source file ready for indexing.
@@ -73,7 +74,12 @@ const BINARY_EXTENSIONS: &[&str] = &[
 ///
 /// Walks the directory respecting .gitignore patterns and default exclusions.
 /// Skips binary files and files exceeding the size threshold.
-pub fn discover_files(root: &Path, config: &IndexingConfig) -> Result<DiscoveryResult> {
+pub fn discover_files(
+    root: &Path,
+    config: &IndexingConfig,
+    cancellation: &CancellationToken,
+) -> Result<DiscoveryResult> {
+    cancellation.check()?;
     let root = root
         .canonicalize()
         .with_context(|| format!("failed to resolve path: {}", root.display()))?;
@@ -133,6 +139,7 @@ pub fn discover_files(root: &Path, config: &IndexingConfig) -> Result<DiscoveryR
     let mut error_skipped = 0usize;
 
     for entry in walker.build() {
+        cancellation.check()?;
         let entry = match entry {
             Ok(e) => e,
             Err(err) => {
@@ -288,7 +295,8 @@ mod tests {
         fs::write(dir.path().join("main.rs"), "fn main() {}").unwrap();
         fs::write(dir.path().join("lib.py"), "def hello(): pass").unwrap();
 
-        let result = discover_files(dir.path(), &default_config()).unwrap();
+        let result =
+            discover_files(dir.path(), &default_config(), &CancellationToken::new()).unwrap();
         assert_eq!(result.files.len(), 2);
 
         let names: Vec<&str> = result
@@ -307,7 +315,8 @@ mod tests {
         fs::write(dir.path().join("secret.txt"), "sensitive data").unwrap();
         fs::write(dir.path().join(".gitignore"), "secret.txt\n").unwrap();
 
-        let result = discover_files(dir.path(), &default_config()).unwrap();
+        let result =
+            discover_files(dir.path(), &default_config(), &CancellationToken::new()).unwrap();
         let names: Vec<&str> = result
             .files
             .iter()
@@ -342,7 +351,8 @@ mod tests {
         fs::create_dir_all(&pycache).unwrap();
         fs::write(pycache.join("mod.pyc"), "bytecode").unwrap();
 
-        let result = discover_files(dir.path(), &default_config()).unwrap();
+        let result =
+            discover_files(dir.path(), &default_config(), &CancellationToken::new()).unwrap();
         let names: Vec<&str> = result
             .files
             .iter()
@@ -376,7 +386,8 @@ mod tests {
         fs::write(dir.path().join("program.exe"), "not really exe").unwrap();
         fs::write(dir.path().join("archive.zip"), "not really zip").unwrap();
 
-        let result = discover_files(dir.path(), &default_config()).unwrap();
+        let result =
+            discover_files(dir.path(), &default_config(), &CancellationToken::new()).unwrap();
         assert_eq!(result.files.len(), 1);
         assert_eq!(result.files[0].relative_path, "main.rs");
         assert_eq!(result.binary_skipped, 3);
@@ -390,7 +401,8 @@ mod tests {
         let binary_content = b"some text\x00more text";
         fs::write(dir.path().join("data.txt"), binary_content).unwrap();
 
-        let result = discover_files(dir.path(), &default_config()).unwrap();
+        let result =
+            discover_files(dir.path(), &default_config(), &CancellationToken::new()).unwrap();
         assert_eq!(result.files.len(), 1);
         assert_eq!(result.files[0].relative_path, "main.rs");
         assert_eq!(result.binary_skipped, 1);
@@ -405,7 +417,8 @@ mod tests {
         let large_content = "x".repeat(1_100_000);
         fs::write(dir.path().join("huge.rs"), large_content).unwrap();
 
-        let result = discover_files(dir.path(), &default_config()).unwrap();
+        let result =
+            discover_files(dir.path(), &default_config(), &CancellationToken::new()).unwrap();
         assert_eq!(result.files.len(), 1);
         assert_eq!(result.files[0].relative_path, "small.rs");
         assert_eq!(result.large_skipped, 1);
@@ -422,7 +435,7 @@ mod tests {
             ..Default::default()
         };
 
-        let result = discover_files(dir.path(), &config).unwrap();
+        let result = discover_files(dir.path(), &config, &CancellationToken::new()).unwrap();
         assert_eq!(result.files.len(), 1);
         assert_eq!(result.files[0].relative_path, "small.rs");
         assert_eq!(result.large_skipped, 1);
@@ -434,7 +447,8 @@ mod tests {
         fs::write(dir.path().join("main.rs"), "fn main() {}").unwrap();
         fs::write(dir.path().join("empty.rs"), "").unwrap();
 
-        let result = discover_files(dir.path(), &default_config()).unwrap();
+        let result =
+            discover_files(dir.path(), &default_config(), &CancellationToken::new()).unwrap();
         assert_eq!(result.files.len(), 1);
         assert_eq!(result.files[0].relative_path, "main.rs");
     }
@@ -447,7 +461,8 @@ mod tests {
         fs::write(sub.join("helper.rs"), "fn help() {}").unwrap();
         fs::write(dir.path().join("main.rs"), "fn main() {}").unwrap();
 
-        let result = discover_files(dir.path(), &default_config()).unwrap();
+        let result =
+            discover_files(dir.path(), &default_config(), &CancellationToken::new()).unwrap();
         assert_eq!(result.files.len(), 2);
 
         let paths: Vec<&str> = result
@@ -479,7 +494,8 @@ mod tests {
         fs::write(dir.path().join("a.rs"), "fn a() {}").unwrap();
         fs::write(dir.path().join("m.rs"), "fn m() {}").unwrap();
 
-        let result = discover_files(dir.path(), &default_config()).unwrap();
+        let result =
+            discover_files(dir.path(), &default_config(), &CancellationToken::new()).unwrap();
         let paths: Vec<&str> = result
             .files
             .iter()
@@ -505,7 +521,8 @@ mod tests {
         fs::create_dir_all(&build).unwrap();
         fs::write(build.join("output.js"), "compiled").unwrap();
 
-        let result = discover_files(dir.path(), &default_config()).unwrap();
+        let result =
+            discover_files(dir.path(), &default_config(), &CancellationToken::new()).unwrap();
         let paths: Vec<&str> = result
             .files
             .iter()
@@ -541,7 +558,8 @@ mod tests {
         .unwrap();
         fs::write(includes.join("common.rst.inc"), "Shared include fragment\n").unwrap();
 
-        let result = discover_files(dir.path(), &default_config()).unwrap();
+        let result =
+            discover_files(dir.path(), &default_config(), &CancellationToken::new()).unwrap();
         let names: Vec<&str> = result
             .files
             .iter()
@@ -572,7 +590,7 @@ mod tests {
         let mut config = default_config();
         config.no_default_excludes = true;
 
-        let result = discover_files(dir.path(), &config).unwrap();
+        let result = discover_files(dir.path(), &config, &CancellationToken::new()).unwrap();
         let names: Vec<&str> = result
             .files
             .iter()
@@ -594,7 +612,8 @@ mod tests {
         fs::write(dir.path().join("app.log"), "more logs").unwrap();
         fs::write(dir.path().join(".gitignore"), "*.log\n").unwrap();
 
-        let result = discover_files(dir.path(), &default_config()).unwrap();
+        let result =
+            discover_files(dir.path(), &default_config(), &CancellationToken::new()).unwrap();
         let names: Vec<&str> = result
             .files
             .iter()
@@ -607,7 +626,11 @@ mod tests {
 
     #[test]
     fn handles_invalid_path() {
-        let result = discover_files(Path::new("/nonexistent/path"), &default_config());
+        let result = discover_files(
+            Path::new("/nonexistent/path"),
+            &default_config(),
+            &CancellationToken::new(),
+        );
         assert!(result.is_err());
     }
 
@@ -622,7 +645,8 @@ mod tests {
         // .veraignore only excludes secret.txt (notes.md should now be indexed)
         fs::write(dir.path().join(".veraignore"), "secret.txt\n").unwrap();
 
-        let result = discover_files(dir.path(), &default_config()).unwrap();
+        let result =
+            discover_files(dir.path(), &default_config(), &CancellationToken::new()).unwrap();
         let names: Vec<&str> = result
             .files
             .iter()
@@ -653,7 +677,8 @@ mod tests {
         )
         .unwrap();
 
-        let result = discover_files(dir.path(), &default_config()).unwrap();
+        let result =
+            discover_files(dir.path(), &default_config(), &CancellationToken::new()).unwrap();
         let names: Vec<&str> = result
             .files
             .iter()
@@ -677,7 +702,8 @@ mod tests {
         fs::write(dir.path().join("secret.txt"), "sensitive").unwrap();
         fs::write(dir.path().join(".gitignore"), "secret.txt\n").unwrap();
 
-        let result = discover_files(dir.path(), &default_config()).unwrap();
+        let result =
+            discover_files(dir.path(), &default_config(), &CancellationToken::new()).unwrap();
         let names: Vec<&str> = result
             .files
             .iter()
@@ -701,7 +727,7 @@ mod tests {
         let mut config = default_config();
         config.extra_excludes = vec!["vendor/**".to_string()];
 
-        let result = discover_files(dir.path(), &config).unwrap();
+        let result = discover_files(dir.path(), &config, &CancellationToken::new()).unwrap();
         let names: Vec<&str> = result
             .files
             .iter()
@@ -724,7 +750,7 @@ mod tests {
         let mut config = default_config();
         config.no_ignore = true;
 
-        let result = discover_files(dir.path(), &config).unwrap();
+        let result = discover_files(dir.path(), &config, &CancellationToken::new()).unwrap();
         let names: Vec<&str> = result
             .files
             .iter()
@@ -748,7 +774,7 @@ mod tests {
         let mut config = default_config();
         config.no_default_excludes = true;
 
-        let result = discover_files(dir.path(), &config).unwrap();
+        let result = discover_files(dir.path(), &config, &CancellationToken::new()).unwrap();
         let names: Vec<&str> = result
             .files
             .iter()
@@ -767,7 +793,8 @@ mod tests {
         fs::write(dir.path().join("main.rs"), "fn main() {}").unwrap();
         fs::write(dir.path().join(".veraignore"), "*.log\n").unwrap();
 
-        let result = discover_files(dir.path(), &default_config()).unwrap();
+        let result =
+            discover_files(dir.path(), &default_config(), &CancellationToken::new()).unwrap();
         let names: Vec<&str> = result
             .files
             .iter()

--- a/crates/vera-core/src/discovery/mod.rs
+++ b/crates/vera-core/src/discovery/mod.rs
@@ -74,7 +74,12 @@ const BINARY_EXTENSIONS: &[&str] = &[
 ///
 /// Walks the directory respecting .gitignore patterns and default exclusions.
 /// Skips binary files and files exceeding the size threshold.
-pub fn discover_files(
+pub fn discover_files(root: &Path, config: &IndexingConfig) -> Result<DiscoveryResult> {
+    discover_files_with_cancellation(root, config, &CancellationToken::new())
+}
+
+/// Discover source files while cooperatively observing cancellation.
+pub fn discover_files_with_cancellation(
     root: &Path,
     config: &IndexingConfig,
     cancellation: &CancellationToken,
@@ -295,8 +300,7 @@ mod tests {
         fs::write(dir.path().join("main.rs"), "fn main() {}").unwrap();
         fs::write(dir.path().join("lib.py"), "def hello(): pass").unwrap();
 
-        let result =
-            discover_files(dir.path(), &default_config(), &CancellationToken::new()).unwrap();
+        let result = discover_files(dir.path(), &default_config()).unwrap();
         assert_eq!(result.files.len(), 2);
 
         let names: Vec<&str> = result
@@ -315,8 +319,7 @@ mod tests {
         fs::write(dir.path().join("secret.txt"), "sensitive data").unwrap();
         fs::write(dir.path().join(".gitignore"), "secret.txt\n").unwrap();
 
-        let result =
-            discover_files(dir.path(), &default_config(), &CancellationToken::new()).unwrap();
+        let result = discover_files(dir.path(), &default_config()).unwrap();
         let names: Vec<&str> = result
             .files
             .iter()
@@ -351,8 +354,7 @@ mod tests {
         fs::create_dir_all(&pycache).unwrap();
         fs::write(pycache.join("mod.pyc"), "bytecode").unwrap();
 
-        let result =
-            discover_files(dir.path(), &default_config(), &CancellationToken::new()).unwrap();
+        let result = discover_files(dir.path(), &default_config()).unwrap();
         let names: Vec<&str> = result
             .files
             .iter()
@@ -386,8 +388,7 @@ mod tests {
         fs::write(dir.path().join("program.exe"), "not really exe").unwrap();
         fs::write(dir.path().join("archive.zip"), "not really zip").unwrap();
 
-        let result =
-            discover_files(dir.path(), &default_config(), &CancellationToken::new()).unwrap();
+        let result = discover_files(dir.path(), &default_config()).unwrap();
         assert_eq!(result.files.len(), 1);
         assert_eq!(result.files[0].relative_path, "main.rs");
         assert_eq!(result.binary_skipped, 3);
@@ -401,8 +402,7 @@ mod tests {
         let binary_content = b"some text\x00more text";
         fs::write(dir.path().join("data.txt"), binary_content).unwrap();
 
-        let result =
-            discover_files(dir.path(), &default_config(), &CancellationToken::new()).unwrap();
+        let result = discover_files(dir.path(), &default_config()).unwrap();
         assert_eq!(result.files.len(), 1);
         assert_eq!(result.files[0].relative_path, "main.rs");
         assert_eq!(result.binary_skipped, 1);
@@ -417,8 +417,7 @@ mod tests {
         let large_content = "x".repeat(1_100_000);
         fs::write(dir.path().join("huge.rs"), large_content).unwrap();
 
-        let result =
-            discover_files(dir.path(), &default_config(), &CancellationToken::new()).unwrap();
+        let result = discover_files(dir.path(), &default_config()).unwrap();
         assert_eq!(result.files.len(), 1);
         assert_eq!(result.files[0].relative_path, "small.rs");
         assert_eq!(result.large_skipped, 1);
@@ -435,7 +434,7 @@ mod tests {
             ..Default::default()
         };
 
-        let result = discover_files(dir.path(), &config, &CancellationToken::new()).unwrap();
+        let result = discover_files(dir.path(), &config).unwrap();
         assert_eq!(result.files.len(), 1);
         assert_eq!(result.files[0].relative_path, "small.rs");
         assert_eq!(result.large_skipped, 1);
@@ -447,8 +446,7 @@ mod tests {
         fs::write(dir.path().join("main.rs"), "fn main() {}").unwrap();
         fs::write(dir.path().join("empty.rs"), "").unwrap();
 
-        let result =
-            discover_files(dir.path(), &default_config(), &CancellationToken::new()).unwrap();
+        let result = discover_files(dir.path(), &default_config()).unwrap();
         assert_eq!(result.files.len(), 1);
         assert_eq!(result.files[0].relative_path, "main.rs");
     }
@@ -461,8 +459,7 @@ mod tests {
         fs::write(sub.join("helper.rs"), "fn help() {}").unwrap();
         fs::write(dir.path().join("main.rs"), "fn main() {}").unwrap();
 
-        let result =
-            discover_files(dir.path(), &default_config(), &CancellationToken::new()).unwrap();
+        let result = discover_files(dir.path(), &default_config()).unwrap();
         assert_eq!(result.files.len(), 2);
 
         let paths: Vec<&str> = result
@@ -494,8 +491,7 @@ mod tests {
         fs::write(dir.path().join("a.rs"), "fn a() {}").unwrap();
         fs::write(dir.path().join("m.rs"), "fn m() {}").unwrap();
 
-        let result =
-            discover_files(dir.path(), &default_config(), &CancellationToken::new()).unwrap();
+        let result = discover_files(dir.path(), &default_config()).unwrap();
         let paths: Vec<&str> = result
             .files
             .iter()
@@ -521,8 +517,7 @@ mod tests {
         fs::create_dir_all(&build).unwrap();
         fs::write(build.join("output.js"), "compiled").unwrap();
 
-        let result =
-            discover_files(dir.path(), &default_config(), &CancellationToken::new()).unwrap();
+        let result = discover_files(dir.path(), &default_config()).unwrap();
         let paths: Vec<&str> = result
             .files
             .iter()
@@ -558,8 +553,7 @@ mod tests {
         .unwrap();
         fs::write(includes.join("common.rst.inc"), "Shared include fragment\n").unwrap();
 
-        let result =
-            discover_files(dir.path(), &default_config(), &CancellationToken::new()).unwrap();
+        let result = discover_files(dir.path(), &default_config()).unwrap();
         let names: Vec<&str> = result
             .files
             .iter()
@@ -590,7 +584,7 @@ mod tests {
         let mut config = default_config();
         config.no_default_excludes = true;
 
-        let result = discover_files(dir.path(), &config, &CancellationToken::new()).unwrap();
+        let result = discover_files(dir.path(), &config).unwrap();
         let names: Vec<&str> = result
             .files
             .iter()
@@ -612,8 +606,7 @@ mod tests {
         fs::write(dir.path().join("app.log"), "more logs").unwrap();
         fs::write(dir.path().join(".gitignore"), "*.log\n").unwrap();
 
-        let result =
-            discover_files(dir.path(), &default_config(), &CancellationToken::new()).unwrap();
+        let result = discover_files(dir.path(), &default_config()).unwrap();
         let names: Vec<&str> = result
             .files
             .iter()
@@ -626,11 +619,7 @@ mod tests {
 
     #[test]
     fn handles_invalid_path() {
-        let result = discover_files(
-            Path::new("/nonexistent/path"),
-            &default_config(),
-            &CancellationToken::new(),
-        );
+        let result = discover_files(Path::new("/nonexistent/path"), &default_config());
         assert!(result.is_err());
     }
 
@@ -645,8 +634,7 @@ mod tests {
         // .veraignore only excludes secret.txt (notes.md should now be indexed)
         fs::write(dir.path().join(".veraignore"), "secret.txt\n").unwrap();
 
-        let result =
-            discover_files(dir.path(), &default_config(), &CancellationToken::new()).unwrap();
+        let result = discover_files(dir.path(), &default_config()).unwrap();
         let names: Vec<&str> = result
             .files
             .iter()
@@ -677,8 +665,7 @@ mod tests {
         )
         .unwrap();
 
-        let result =
-            discover_files(dir.path(), &default_config(), &CancellationToken::new()).unwrap();
+        let result = discover_files(dir.path(), &default_config()).unwrap();
         let names: Vec<&str> = result
             .files
             .iter()
@@ -702,8 +689,7 @@ mod tests {
         fs::write(dir.path().join("secret.txt"), "sensitive").unwrap();
         fs::write(dir.path().join(".gitignore"), "secret.txt\n").unwrap();
 
-        let result =
-            discover_files(dir.path(), &default_config(), &CancellationToken::new()).unwrap();
+        let result = discover_files(dir.path(), &default_config()).unwrap();
         let names: Vec<&str> = result
             .files
             .iter()
@@ -727,7 +713,7 @@ mod tests {
         let mut config = default_config();
         config.extra_excludes = vec!["vendor/**".to_string()];
 
-        let result = discover_files(dir.path(), &config, &CancellationToken::new()).unwrap();
+        let result = discover_files(dir.path(), &config).unwrap();
         let names: Vec<&str> = result
             .files
             .iter()
@@ -750,7 +736,7 @@ mod tests {
         let mut config = default_config();
         config.no_ignore = true;
 
-        let result = discover_files(dir.path(), &config, &CancellationToken::new()).unwrap();
+        let result = discover_files(dir.path(), &config).unwrap();
         let names: Vec<&str> = result
             .files
             .iter()
@@ -774,7 +760,7 @@ mod tests {
         let mut config = default_config();
         config.no_default_excludes = true;
 
-        let result = discover_files(dir.path(), &config, &CancellationToken::new()).unwrap();
+        let result = discover_files(dir.path(), &config).unwrap();
         let names: Vec<&str> = result
             .files
             .iter()
@@ -793,8 +779,7 @@ mod tests {
         fs::write(dir.path().join("main.rs"), "fn main() {}").unwrap();
         fs::write(dir.path().join(".veraignore"), "*.log\n").unwrap();
 
-        let result =
-            discover_files(dir.path(), &default_config(), &CancellationToken::new()).unwrap();
+        let result = discover_files(dir.path(), &default_config()).unwrap();
         let names: Vec<&str> = result
             .files
             .iter()

--- a/crates/vera-core/src/embedding/provider.rs
+++ b/crates/vera-core/src/embedding/provider.rs
@@ -25,6 +25,11 @@ pub enum EmbeddingError {
     #[error("embedding API connection failed: {message}")]
     ConnectionError { message: String },
 
+    /// The request exceeded its client-side timeout. Retrying could duplicate
+    /// work when an upstream proxy continues processing after disconnect.
+    #[error("embedding API request timed out: {message}")]
+    TimeoutError { message: String },
+
     /// The API returned a non-auth, non-connection error.
     #[error("embedding API error (status {status}): {message}")]
     ApiError { status: u16, message: String },
@@ -251,20 +256,19 @@ impl OpenAiProvider {
             input: texts,
         };
 
-        // Rate limit errors get extra retries beyond the normal max.
-        let max_total_retries = self.config.max_retries + 4;
         let mut last_err = None;
-        for attempt in 0..=max_total_retries {
-            if attempt > 0 {
+        let mut retries = 0;
+        loop {
+            if retries > 0 {
                 let is_rate_limit = matches!(last_err, Some(EmbeddingError::RateLimitError { .. }));
                 let delay = if is_rate_limit {
                     // Rate limit: wait 2-4s with exponential backoff.
-                    Duration::from_secs(2 + u64::from(attempt.min(2)))
+                    Duration::from_secs(2 + u64::from(retries.min(2)))
                 } else {
-                    Duration::from_millis(500 * 2u64.pow(attempt.min(5) - 1))
+                    Duration::from_millis(500 * 2u64.pow(retries.min(5) - 1))
                 };
                 debug!(
-                    attempt,
+                    attempt = retries + 1,
                     delay_ms = delay.as_millis(),
                     rate_limited = is_rate_limit,
                     "retrying embedding API"
@@ -275,27 +279,28 @@ impl OpenAiProvider {
             match self.send_request(&url, &body).await {
                 Ok(vectors) => return Ok(vectors),
                 Err(e) => {
-                    // Don't retry auth or context-size errors; they won't
-                    // resolve with the same request. Context-size errors are
-                    // handled by embed_batch_resilient which truncates the text.
-                    if matches!(e, EmbeddingError::AuthError { .. }) || is_context_size_error(&e) {
+                    // A timed-out request may still be running behind a proxy,
+                    // so replaying it can create an abandoned-work queue.
+                    // Context-size errors are handled by embed_batch_resilient.
+                    if !is_retryable_error(&e) {
                         return Err(e);
                     }
+
+                    let retry_limit = retry_limit_for_error(&e, self.config.max_retries);
                     warn!(
-                        attempt = attempt + 1,
-                        max = max_total_retries + 1,
+                        attempt = retries + 1,
+                        max = retry_limit + 1,
                         error = %e,
                         "embedding API call failed"
                     );
+                    if retries >= retry_limit {
+                        return Err(e);
+                    }
                     last_err = Some(e);
+                    retries += 1;
                 }
             }
         }
-
-        Err(last_err.unwrap_or_else(|| EmbeddingError::ApiError {
-            status: 0,
-            message: "all retries exhausted".to_string(),
-        }))
     }
 
     /// Send a single HTTP request and parse the response.
@@ -313,7 +318,11 @@ impl OpenAiProvider {
             .send()
             .await
             .map_err(|e| {
-                if e.is_connect() || e.is_timeout() {
+                if e.is_timeout() {
+                    EmbeddingError::TimeoutError {
+                        message: format!("request to embedding API timed out: {e}"),
+                    }
+                } else if e.is_connect() {
                     EmbeddingError::ConnectionError {
                         message: format!("failed to connect to embedding API: {e}"),
                     }
@@ -355,13 +364,17 @@ impl OpenAiProvider {
             });
         }
 
-        let resp: EmbeddingResponse =
-            response
-                .json()
-                .await
-                .map_err(|e| EmbeddingError::ResponseError {
+        let resp: EmbeddingResponse = response.json().await.map_err(|e| {
+            if e.is_timeout() {
+                EmbeddingError::TimeoutError {
+                    message: format!("timed out reading embedding response: {e}"),
+                }
+            } else {
+                EmbeddingError::ResponseError {
                     message: format!("failed to parse embedding response: {e}"),
-                })?;
+                }
+            }
+        })?;
 
         // Sort by index to ensure correct ordering.
         let mut data = resp.data;
@@ -574,6 +587,21 @@ fn effective_batch_size<P: EmbeddingProvider>(provider: &P, configured_batch_siz
     }
 }
 
+fn retry_limit_for_error(error: &EmbeddingError, configured_retries: u32) -> u32 {
+    if matches!(error, EmbeddingError::RateLimitError { .. }) {
+        configured_retries.saturating_add(4)
+    } else {
+        configured_retries
+    }
+}
+
+fn is_retryable_error(error: &EmbeddingError) -> bool {
+    !matches!(
+        error,
+        EmbeddingError::AuthError { .. } | EmbeddingError::TimeoutError { .. }
+    ) && !is_context_size_error(error)
+}
+
 #[derive(Clone)]
 struct EmbeddingBatchItem {
     original_index: usize,
@@ -585,6 +613,7 @@ fn embedding_error_message(error: &EmbeddingError) -> &str {
     match error {
         EmbeddingError::AuthError { message }
         | EmbeddingError::ConnectionError { message }
+        | EmbeddingError::TimeoutError { message }
         | EmbeddingError::ApiError { message, .. }
         | EmbeddingError::RateLimitError { message }
         | EmbeddingError::ResponseError { message } => message,
@@ -1103,6 +1132,9 @@ pub(crate) mod test_helpers {
                             message: message.clone(),
                         }
                     }
+                    EmbeddingError::TimeoutError { message } => EmbeddingError::TimeoutError {
+                        message: message.clone(),
+                    },
                     EmbeddingError::ApiError { status, message } => EmbeddingError::ApiError {
                         status: *status,
                         message: message.clone(),
@@ -1263,5 +1295,34 @@ mod tests {
         assert_eq!(info.max_tokens, 120000);
         assert_eq!(info.input_tokens, Some(124417));
         assert!(is_context_size_error(&err));
+    }
+
+    #[test]
+    fn rate_limits_receive_only_the_documented_extra_retries() {
+        let error = EmbeddingError::RateLimitError {
+            message: "busy".into(),
+        };
+        assert_eq!(retry_limit_for_error(&error, 3), 7);
+    }
+
+    #[test]
+    fn ordinary_failures_do_not_receive_rate_limit_retries() {
+        let error = EmbeddingError::ConnectionError {
+            message: "refused".into(),
+        };
+        assert_eq!(retry_limit_for_error(&error, 3), 3);
+    }
+
+    #[test]
+    fn timeouts_are_not_retried() {
+        let timeout = EmbeddingError::TimeoutError {
+            message: "upstream may still be working".into(),
+        };
+        let connection = EmbeddingError::ConnectionError {
+            message: "connection refused".into(),
+        };
+
+        assert!(!is_retryable_error(&timeout));
+        assert!(is_retryable_error(&connection));
     }
 }

--- a/crates/vera-core/src/embedding/provider.rs
+++ b/crates/vera-core/src/embedding/provider.rs
@@ -336,21 +336,23 @@ impl OpenAiProvider {
         let status = response.status().as_u16();
 
         if status == 401 || status == 403 {
-            let text = response.text().await.unwrap_or_default();
+            let text = read_response_text(response, "failed to read authentication error response")
+                .await?;
             return Err(EmbeddingError::AuthError {
                 message: sanitize_error_message(&text),
             });
         }
 
         if status == 429 {
-            let text = response.text().await.unwrap_or_default();
+            let text = read_response_text(response, "failed to read rate limit response").await?;
             return Err(EmbeddingError::RateLimitError {
                 message: sanitize_error_message(&text),
             });
         }
 
         if !response.status().is_success() {
-            let text = response.text().await.unwrap_or_default();
+            let text =
+                read_response_text(response, "failed to read embedding error response").await?;
             // Some providers return 400 with "Unable to process" for transient
             // overload conditions. Treat these as rate limits so they get retried.
             if status == 400 && text.contains("Unable to process") {
@@ -364,17 +366,10 @@ impl OpenAiProvider {
             });
         }
 
-        let resp: EmbeddingResponse = response.json().await.map_err(|e| {
-            if e.is_timeout() {
-                EmbeddingError::TimeoutError {
-                    message: format!("timed out reading embedding response: {e}"),
-                }
-            } else {
-                EmbeddingError::ResponseError {
-                    message: format!("failed to parse embedding response: {e}"),
-                }
-            }
-        })?;
+        let resp: EmbeddingResponse = response
+            .json()
+            .await
+            .map_err(|error| response_read_error(error, "failed to parse embedding response"))?;
 
         // Sort by index to ensure correct ordering.
         let mut data = resp.data;
@@ -394,6 +389,28 @@ impl OpenAiProvider {
 
         Ok(vectors)
     }
+}
+
+fn response_read_error(error: reqwest::Error, context: &str) -> EmbeddingError {
+    if error.is_timeout() {
+        EmbeddingError::TimeoutError {
+            message: format!("{context}: {error}"),
+        }
+    } else {
+        EmbeddingError::ResponseError {
+            message: format!("{context}: {error}"),
+        }
+    }
+}
+
+async fn read_response_text(
+    response: reqwest::Response,
+    context: &str,
+) -> Result<String, EmbeddingError> {
+    response
+        .text()
+        .await
+        .map_err(|error| response_read_error(error, context))
 }
 
 impl EmbeddingProvider for OpenAiProvider {
@@ -1176,6 +1193,9 @@ pub(crate) mod test_helpers {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
     #[test]
     fn prepare_query_text_with_prefix() {
@@ -1324,5 +1344,53 @@ mod tests {
 
         assert!(!is_retryable_error(&timeout));
         assert!(is_retryable_error(&connection));
+    }
+
+    #[tokio::test]
+    async fn delayed_rate_limit_body_is_a_non_retryable_timeout() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let request_count = Arc::new(AtomicUsize::new(0));
+        let server_request_count = request_count.clone();
+
+        let server = tokio::spawn(async move {
+            loop {
+                let (mut stream, _) = listener.accept().await.unwrap();
+                server_request_count.fetch_add(1, Ordering::SeqCst);
+                tokio::spawn(async move {
+                    let mut request = [0_u8; 2048];
+                    let _ = stream.read(&mut request).await;
+                    stream
+                        .write_all(
+                            b"HTTP/1.1 429 Too Many Requests\r\nContent-Length: 4\r\nConnection: close\r\n\r\n",
+                        )
+                        .await
+                        .unwrap();
+                    tokio::time::sleep(Duration::from_millis(200)).await;
+                    let _ = stream.write_all(b"slow").await;
+                });
+            }
+        });
+
+        let config = EmbeddingProviderConfig::new(
+            format!("http://{address}"),
+            "test-model".into(),
+            "test-key".into(),
+        )
+        .with_timeout(Duration::from_millis(50))
+        .with_max_retries(3);
+        let provider = OpenAiProvider::new(config).unwrap();
+
+        let error = tokio::time::timeout(
+            Duration::from_secs(1),
+            provider.embed_batch(&["input".to_string()]),
+        )
+        .await
+        .expect("a body timeout must not enter rate-limit backoff")
+        .unwrap_err();
+
+        assert!(matches!(error, EmbeddingError::TimeoutError { .. }));
+        assert_eq!(request_count.load(Ordering::SeqCst), 1);
+        server.abort();
     }
 }

--- a/crates/vera-core/src/indexing/mod.rs
+++ b/crates/vera-core/src/indexing/mod.rs
@@ -9,10 +9,7 @@
 pub mod pipeline;
 pub mod update;
 
-pub use pipeline::{
-    FileError, IndexProgress, IndexSummary, index_dir, index_repository,
-    index_repository_with_progress,
-};
+pub use pipeline::{FileError, IndexProgress, IndexSummary, index_dir, index_repository};
 pub use update::{UpdateSummary, content_hash, update_repository};
 
 /// Truncate embedding vectors to at most `max_dim` dimensions.

--- a/crates/vera-core/src/indexing/mod.rs
+++ b/crates/vera-core/src/indexing/mod.rs
@@ -9,8 +9,14 @@
 pub mod pipeline;
 pub mod update;
 
-pub use pipeline::{FileError, IndexProgress, IndexSummary, index_dir, index_repository};
-pub use update::{UpdateSummary, content_hash, update_repository};
+pub use pipeline::{
+    FileError, IndexProgress, IndexSummary, index_dir, index_repository,
+    index_repository_with_cancellation, index_repository_with_progress,
+    index_repository_with_progress_and_cancellation,
+};
+pub use update::{
+    UpdateSummary, content_hash, update_repository, update_repository_with_cancellation,
+};
 
 /// Truncate embedding vectors to at most `max_dim` dimensions.
 ///

--- a/crates/vera-core/src/indexing/pipeline.rs
+++ b/crates/vera-core/src/indexing/pipeline.rs
@@ -108,7 +108,66 @@ pub fn index_dir(repo_root: &Path) -> std::path::PathBuf {
 ///
 /// # Errors
 /// Returns an error if the path is invalid, not a directory, or storage fails.
-pub async fn index_repository<P, F>(
+pub async fn index_repository<P: EmbeddingProvider>(
+    repo_path: &Path,
+    provider: &P,
+    config: &VeraConfig,
+    model_name: &str,
+) -> Result<IndexSummary> {
+    index_repository_with_cancellation(
+        repo_path,
+        provider,
+        config,
+        model_name,
+        &CancellationToken::new(),
+    )
+    .await
+}
+
+/// Index a repository while cooperatively observing cancellation.
+pub async fn index_repository_with_cancellation<P: EmbeddingProvider>(
+    repo_path: &Path,
+    provider: &P,
+    config: &VeraConfig,
+    model_name: &str,
+    cancellation: &CancellationToken,
+) -> Result<IndexSummary> {
+    index_repository_with_progress_and_cancellation(
+        repo_path,
+        provider,
+        config,
+        model_name,
+        |_| {},
+        cancellation,
+    )
+    .await
+}
+
+/// Index a repository and report progress to the supplied callback.
+pub async fn index_repository_with_progress<P, F>(
+    repo_path: &Path,
+    provider: &P,
+    config: &VeraConfig,
+    model_name: &str,
+    on_progress: F,
+) -> Result<IndexSummary>
+where
+    P: EmbeddingProvider,
+    F: Fn(IndexProgress) + Send + Sync,
+{
+    index_repository_with_progress_and_cancellation(
+        repo_path,
+        provider,
+        config,
+        model_name,
+        on_progress,
+        &CancellationToken::new(),
+    )
+    .await
+}
+
+/// Index a repository with progress reporting and cooperative cancellation.
+pub async fn index_repository_with_progress_and_cancellation<P, F>(
     repo_path: &Path,
     provider: &P,
     config: &VeraConfig,
@@ -138,8 +197,9 @@ where
     info!(path = %repo_root.display(), "starting indexing");
 
     // ── 2. Discover files ────────────────────────────────────────
-    let discovery = discovery::discover_files(&repo_root, &config.indexing, cancellation)
-        .context("file discovery failed")?;
+    let discovery =
+        discovery::discover_files_with_cancellation(&repo_root, &config.indexing, cancellation)
+            .context("file discovery failed")?;
 
     if discovery.files.is_empty() {
         return Ok(IndexSummary {

--- a/crates/vera-core/src/indexing/pipeline.rs
+++ b/crates/vera-core/src/indexing/pipeline.rs
@@ -204,8 +204,19 @@ where
     }
 
     // ── 4. Generate embeddings (concurrent batches) ──────────────
-    let batch_size = config.embedding.batch_size;
-    let max_concurrent_requests = config.embedding.max_concurrent_requests;
+    let (batch_size, max_concurrent_requests) = config.embedding.bounded_parallelism();
+    if batch_size != config.embedding.batch_size
+        || max_concurrent_requests != config.embedding.max_concurrent_requests
+    {
+        info!(
+            configured_batch_size = config.embedding.batch_size,
+            configured_concurrency = config.embedding.max_concurrent_requests,
+            max_in_flight_inputs = config.embedding.max_in_flight_inputs,
+            batch_size,
+            max_concurrent_requests,
+            "clamped embedding parallelism to the in-flight input bound"
+        );
+    }
 
     let progress_cb = |done: usize, total: usize| {
         on_progress(IndexProgress::EmbeddingProgress { done, total });

--- a/crates/vera-core/src/indexing/pipeline.rs
+++ b/crates/vera-core/src/indexing/pipeline.rs
@@ -12,6 +12,7 @@ use anyhow::{Context, Result, bail};
 use rayon::prelude::*;
 use tracing::{debug, info, warn};
 
+use crate::CancellationToken;
 use crate::config::VeraConfig;
 use crate::discovery::{self, DiscoveryResult};
 use crate::embedding::{EmbeddingProvider, embed_chunks_concurrent_with_progress};
@@ -72,9 +73,6 @@ pub enum IndexProgress {
     StorageDone,
 }
 
-/// No-op progress callback (used when caller doesn't need progress).
-pub(crate) fn no_progress(_: IndexProgress) {}
-
 // ── Index directory layout ───────────────────────────────────────────
 
 /// Default index directory name (placed inside the indexed repo).
@@ -110,28 +108,20 @@ pub fn index_dir(repo_root: &Path) -> std::path::PathBuf {
 ///
 /// # Errors
 /// Returns an error if the path is invalid, not a directory, or storage fails.
-pub async fn index_repository<P: EmbeddingProvider>(
-    repo_path: &Path,
-    provider: &P,
-    config: &VeraConfig,
-    model_name: &str,
-) -> Result<IndexSummary> {
-    index_repository_with_progress(repo_path, provider, config, model_name, no_progress).await
-}
-
-/// Index a repository with progress reporting via a callback.
-pub async fn index_repository_with_progress<P, F>(
+pub async fn index_repository<P, F>(
     repo_path: &Path,
     provider: &P,
     config: &VeraConfig,
     model_name: &str,
     on_progress: F,
+    cancellation: &CancellationToken,
 ) -> Result<IndexSummary>
 where
     P: EmbeddingProvider,
     F: Fn(IndexProgress) + Send + Sync,
 {
     let start = Instant::now();
+    cancellation.check()?;
 
     // ── 1. Validate path ─────────────────────────────────────────
     if !repo_path.exists() {
@@ -148,8 +138,8 @@ where
     info!(path = %repo_root.display(), "starting indexing");
 
     // ── 2. Discover files ────────────────────────────────────────
-    let discovery =
-        discovery::discover_files(&repo_root, &config.indexing).context("file discovery failed")?;
+    let discovery = discovery::discover_files(&repo_root, &config.indexing, cancellation)
+        .context("file discovery failed")?;
 
     if discovery.files.is_empty() {
         return Ok(IndexSummary {
@@ -178,7 +168,7 @@ where
 
     // ── 3. Parse and chunk each file (parallelized with rayon) ──
     let (all_chunks, parse_errors, file_hashes, all_refs) =
-        parse_discovered_files_parallel(&discovery, &repo_root, config);
+        parse_discovered_files_parallel(&discovery, &repo_root, config, cancellation)?;
 
     info!(
         chunks = all_chunks.len(),
@@ -204,6 +194,7 @@ where
     }
 
     // ── 4. Generate embeddings (concurrent batches) ──────────────
+    cancellation.check()?;
     let (batch_size, max_concurrent_requests) = config.embedding.bounded_parallelism();
     if batch_size != config.embedding.batch_size
         || max_concurrent_requests != config.embedding.max_concurrent_requests
@@ -231,6 +222,7 @@ where
     )
     .await
     .context("embedding generation failed")?;
+    cancellation.check()?;
 
     // Truncate vectors if max_stored_dim is configured.
     let stored_dim = super::truncate_embeddings(&mut embeddings, config.embedding.max_stored_dim);
@@ -286,12 +278,13 @@ fn parse_discovered_files_parallel(
     discovery: &DiscoveryResult,
     repo_root: &Path,
     config: &VeraConfig,
-) -> (
+    cancellation: &CancellationToken,
+) -> Result<(
     Vec<Chunk>,
     Vec<FileError>,
     Vec<(String, String)>,
     Vec<(String, Vec<RawReference>)>,
-) {
+)> {
     let config = Arc::new(config.clone());
     let repo_root = Arc::new(repo_root.to_path_buf());
 
@@ -301,18 +294,25 @@ fn parse_discovered_files_parallel(
         discovery
             .files
             .par_iter()
-            .map(|file| {
-                let source = std::fs::read_to_string(&file.absolute_path).map_err(|err| {
-                    warn!(
-                        file = %file.relative_path,
-                        error = %err,
-                        "failed to read file for parsing"
-                    );
-                    FileError {
-                        file_path: file.relative_path.clone(),
-                        error: err.to_string(),
+            .filter_map(|file| {
+                if cancellation.is_cancelled() {
+                    return None;
+                }
+
+                let source = match std::fs::read_to_string(&file.absolute_path) {
+                    Ok(source) => source,
+                    Err(err) => {
+                        warn!(
+                            file = %file.relative_path,
+                            error = %err,
+                            "failed to read file for parsing"
+                        );
+                        return Some(Err(FileError {
+                            file_path: file.relative_path.clone(),
+                            error: err.to_string(),
+                        }));
                     }
-                })?;
+                };
 
                 let language = file
                     .absolute_path
@@ -357,29 +357,35 @@ fn parse_discovered_files_parallel(
                         .map(|(chunks, refs)| (chunks, refs, hash))
                 };
 
-                parse_result
-                    .inspect(|(chunks, refs, _)| {
-                        debug!(
-                            file = %file.relative_path,
-                            chunks = chunks.len(),
-                            refs = refs.len(),
-                            "parsed file"
-                        );
-                    })
-                    .map(|(chunks, refs, hash)| (chunks, file.relative_path.clone(), hash, refs))
-                    .map_err(|err| {
-                        warn!(
-                            file = %file.relative_path,
-                            error = %err,
-                            "parse error"
-                        );
-                        FileError {
-                            file_path: file.relative_path.clone(),
-                            error: err.to_string(),
-                        }
-                    })
+                Some(
+                    parse_result
+                        .inspect(|(chunks, refs, _)| {
+                            debug!(
+                                file = %file.relative_path,
+                                chunks = chunks.len(),
+                                refs = refs.len(),
+                                "parsed file"
+                            );
+                        })
+                        .map(|(chunks, refs, hash)| {
+                            (chunks, file.relative_path.clone(), hash, refs)
+                        })
+                        .map_err(|err| {
+                            warn!(
+                                file = %file.relative_path,
+                                error = %err,
+                                "parse error"
+                            );
+                            FileError {
+                                file_path: file.relative_path.clone(),
+                                error: err.to_string(),
+                            }
+                        }),
+                )
             })
             .collect();
+
+    cancellation.check()?;
 
     // Flatten results into chunks, errors, file hashes, and references.
     let mut all_chunks = Vec::new();
@@ -399,7 +405,7 @@ fn parse_discovered_files_parallel(
         }
     }
 
-    (all_chunks, parse_errors, file_hashes, all_refs)
+    Ok((all_chunks, parse_errors, file_hashes, all_refs))
 }
 
 /// Write chunks, embeddings, BM25 index, file hashes, and references to disk.

--- a/crates/vera-core/src/indexing/pipeline_tests.rs
+++ b/crates/vera-core/src/indexing/pipeline_tests.rs
@@ -6,6 +6,7 @@ use std::path::Path;
 use tempfile::TempDir;
 
 use super::*;
+use crate::CancellationToken;
 use crate::config::VeraConfig;
 use crate::embedding::test_helpers::MockProvider;
 use crate::storage::bm25::Bm25Index;
@@ -28,9 +29,16 @@ async fn index_simple_repo() {
 
     let provider = MockProvider::new(8);
     let config = default_config();
-    let summary = index_repository(dir.path(), &provider, &config, "mock-model")
-        .await
-        .unwrap();
+    let summary = index_repository(
+        dir.path(),
+        &provider,
+        &config,
+        "mock-model",
+        |_| {},
+        &CancellationToken::new(),
+    )
+    .await
+    .unwrap();
 
     assert_eq!(summary.files_parsed, 2);
     assert!(summary.chunks_created > 0);
@@ -47,6 +55,31 @@ async fn index_simple_repo() {
 }
 
 #[tokio::test]
+async fn pre_cancelled_index_stops_before_creating_artifacts() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("main.rs"), "fn main() {}\n").unwrap();
+
+    let provider = MockProvider::new(8);
+    let config = default_config();
+    let cancellation = CancellationToken::new();
+    cancellation.cancel();
+
+    let error = super::index_repository(
+        dir.path(),
+        &provider,
+        &config,
+        "mock-model",
+        |_| {},
+        &cancellation,
+    )
+    .await
+    .unwrap_err();
+
+    assert!(error.to_string().contains("operation cancelled"));
+    assert!(!index_dir(dir.path()).exists());
+}
+
+#[tokio::test]
 async fn index_invalid_path() {
     let provider = MockProvider::new(8);
     let config = default_config();
@@ -55,6 +88,8 @@ async fn index_invalid_path() {
         &provider,
         &config,
         "mock-model",
+        |_| {},
+        &CancellationToken::new(),
     )
     .await;
 
@@ -74,7 +109,15 @@ async fn index_file_not_directory() {
 
     let provider = MockProvider::new(8);
     let config = default_config();
-    let result = index_repository(&file, &provider, &config, "mock-model").await;
+    let result = index_repository(
+        &file,
+        &provider,
+        &config,
+        "mock-model",
+        |_| {},
+        &CancellationToken::new(),
+    )
+    .await;
 
     assert!(result.is_err());
     let err = result.unwrap_err().to_string();
@@ -90,9 +133,16 @@ async fn index_empty_repo() {
 
     let provider = MockProvider::new(8);
     let config = default_config();
-    let summary = index_repository(dir.path(), &provider, &config, "mock-model")
-        .await
-        .unwrap();
+    let summary = index_repository(
+        dir.path(),
+        &provider,
+        &config,
+        "mock-model",
+        |_| {},
+        &CancellationToken::new(),
+    )
+    .await
+    .unwrap();
 
     assert_eq!(summary.files_parsed, 0);
     assert_eq!(summary.chunks_created, 0);
@@ -109,9 +159,16 @@ async fn index_skips_binary_files() {
 
     let provider = MockProvider::new(8);
     let config = default_config();
-    let summary = index_repository(dir.path(), &provider, &config, "mock-model")
-        .await
-        .unwrap();
+    let summary = index_repository(
+        dir.path(),
+        &provider,
+        &config,
+        "mock-model",
+        |_| {},
+        &CancellationToken::new(),
+    )
+    .await
+    .unwrap();
 
     assert_eq!(summary.files_parsed, 1);
     assert!(summary.binary_skipped >= 1);
@@ -128,9 +185,16 @@ async fn index_stores_correct_metadata() {
 
     let provider = MockProvider::new(8);
     let config = default_config();
-    let summary = index_repository(dir.path(), &provider, &config, "mock-model")
-        .await
-        .unwrap();
+    let summary = index_repository(
+        dir.path(),
+        &provider,
+        &config,
+        "mock-model",
+        |_| {},
+        &CancellationToken::new(),
+    )
+    .await
+    .unwrap();
 
     assert!(summary.chunks_created > 0);
 
@@ -155,9 +219,16 @@ async fn index_stores_bm25_index() {
 
     let provider = MockProvider::new(8);
     let config = default_config();
-    let _summary = index_repository(dir.path(), &provider, &config, "mock-model")
-        .await
-        .unwrap();
+    let _summary = index_repository(
+        dir.path(),
+        &provider,
+        &config,
+        "mock-model",
+        |_| {},
+        &CancellationToken::new(),
+    )
+    .await
+    .unwrap();
 
     // Verify BM25 index can be searched.
     let idx = index_dir(&dir.path().canonicalize().unwrap());
@@ -176,9 +247,16 @@ async fn index_summary_reports_parse_errors() {
 
     let provider = MockProvider::new(8);
     let config = default_config();
-    let summary = index_repository(dir.path(), &provider, &config, "mock-model")
-        .await
-        .unwrap();
+    let summary = index_repository(
+        dir.path(),
+        &provider,
+        &config,
+        "mock-model",
+        |_| {},
+        &CancellationToken::new(),
+    )
+    .await
+    .unwrap();
 
     // No errors expected for a simple valid file.
     assert!(summary.parse_errors.is_empty());
@@ -199,9 +277,16 @@ async fn index_handles_mixed_languages() {
 
     let provider = MockProvider::new(8);
     let config = default_config();
-    let summary = index_repository(dir.path(), &provider, &config, "mock-model")
-        .await
-        .unwrap();
+    let summary = index_repository(
+        dir.path(),
+        &provider,
+        &config,
+        "mock-model",
+        |_| {},
+        &CancellationToken::new(),
+    )
+    .await
+    .unwrap();
 
     assert_eq!(summary.files_parsed, 4);
     assert!(summary.chunks_created >= 4);
@@ -224,9 +309,16 @@ async fn index_permission_error_continues() {
 
     let provider = MockProvider::new(8);
     let config = default_config();
-    let summary = index_repository(dir.path(), &provider, &config, "mock-model")
-        .await
-        .unwrap();
+    let summary = index_repository(
+        dir.path(),
+        &provider,
+        &config,
+        "mock-model",
+        |_| {},
+        &CancellationToken::new(),
+    )
+    .await
+    .unwrap();
 
     // Should still complete successfully (exit 0).
     assert!(summary.files_parsed >= 1);

--- a/crates/vera-core/src/indexing/pipeline_tests.rs
+++ b/crates/vera-core/src/indexing/pipeline_tests.rs
@@ -29,16 +29,10 @@ async fn index_simple_repo() {
 
     let provider = MockProvider::new(8);
     let config = default_config();
-    let summary = index_repository(
-        dir.path(),
-        &provider,
-        &config,
-        "mock-model",
-        |_| {},
-        &CancellationToken::new(),
-    )
-    .await
-    .unwrap();
+    let summary =
+        index_repository_with_progress(dir.path(), &provider, &config, "mock-model", |_| {})
+            .await
+            .unwrap();
 
     assert_eq!(summary.files_parsed, 2);
     assert!(summary.chunks_created > 0);
@@ -64,7 +58,7 @@ async fn pre_cancelled_index_stops_before_creating_artifacts() {
     let cancellation = CancellationToken::new();
     cancellation.cancel();
 
-    let error = super::index_repository(
+    let error = super::index_repository_with_progress_and_cancellation(
         dir.path(),
         &provider,
         &config,
@@ -88,8 +82,6 @@ async fn index_invalid_path() {
         &provider,
         &config,
         "mock-model",
-        |_| {},
-        &CancellationToken::new(),
     )
     .await;
 
@@ -109,15 +101,7 @@ async fn index_file_not_directory() {
 
     let provider = MockProvider::new(8);
     let config = default_config();
-    let result = index_repository(
-        &file,
-        &provider,
-        &config,
-        "mock-model",
-        |_| {},
-        &CancellationToken::new(),
-    )
-    .await;
+    let result = index_repository(&file, &provider, &config, "mock-model").await;
 
     assert!(result.is_err());
     let err = result.unwrap_err().to_string();
@@ -133,16 +117,9 @@ async fn index_empty_repo() {
 
     let provider = MockProvider::new(8);
     let config = default_config();
-    let summary = index_repository(
-        dir.path(),
-        &provider,
-        &config,
-        "mock-model",
-        |_| {},
-        &CancellationToken::new(),
-    )
-    .await
-    .unwrap();
+    let summary = index_repository(dir.path(), &provider, &config, "mock-model")
+        .await
+        .unwrap();
 
     assert_eq!(summary.files_parsed, 0);
     assert_eq!(summary.chunks_created, 0);
@@ -159,16 +136,9 @@ async fn index_skips_binary_files() {
 
     let provider = MockProvider::new(8);
     let config = default_config();
-    let summary = index_repository(
-        dir.path(),
-        &provider,
-        &config,
-        "mock-model",
-        |_| {},
-        &CancellationToken::new(),
-    )
-    .await
-    .unwrap();
+    let summary = index_repository(dir.path(), &provider, &config, "mock-model")
+        .await
+        .unwrap();
 
     assert_eq!(summary.files_parsed, 1);
     assert!(summary.binary_skipped >= 1);
@@ -185,16 +155,9 @@ async fn index_stores_correct_metadata() {
 
     let provider = MockProvider::new(8);
     let config = default_config();
-    let summary = index_repository(
-        dir.path(),
-        &provider,
-        &config,
-        "mock-model",
-        |_| {},
-        &CancellationToken::new(),
-    )
-    .await
-    .unwrap();
+    let summary = index_repository(dir.path(), &provider, &config, "mock-model")
+        .await
+        .unwrap();
 
     assert!(summary.chunks_created > 0);
 
@@ -219,16 +182,9 @@ async fn index_stores_bm25_index() {
 
     let provider = MockProvider::new(8);
     let config = default_config();
-    let _summary = index_repository(
-        dir.path(),
-        &provider,
-        &config,
-        "mock-model",
-        |_| {},
-        &CancellationToken::new(),
-    )
-    .await
-    .unwrap();
+    let _summary = index_repository(dir.path(), &provider, &config, "mock-model")
+        .await
+        .unwrap();
 
     // Verify BM25 index can be searched.
     let idx = index_dir(&dir.path().canonicalize().unwrap());
@@ -247,16 +203,9 @@ async fn index_summary_reports_parse_errors() {
 
     let provider = MockProvider::new(8);
     let config = default_config();
-    let summary = index_repository(
-        dir.path(),
-        &provider,
-        &config,
-        "mock-model",
-        |_| {},
-        &CancellationToken::new(),
-    )
-    .await
-    .unwrap();
+    let summary = index_repository(dir.path(), &provider, &config, "mock-model")
+        .await
+        .unwrap();
 
     // No errors expected for a simple valid file.
     assert!(summary.parse_errors.is_empty());
@@ -277,16 +226,9 @@ async fn index_handles_mixed_languages() {
 
     let provider = MockProvider::new(8);
     let config = default_config();
-    let summary = index_repository(
-        dir.path(),
-        &provider,
-        &config,
-        "mock-model",
-        |_| {},
-        &CancellationToken::new(),
-    )
-    .await
-    .unwrap();
+    let summary = index_repository(dir.path(), &provider, &config, "mock-model")
+        .await
+        .unwrap();
 
     assert_eq!(summary.files_parsed, 4);
     assert!(summary.chunks_created >= 4);
@@ -309,16 +251,9 @@ async fn index_permission_error_continues() {
 
     let provider = MockProvider::new(8);
     let config = default_config();
-    let summary = index_repository(
-        dir.path(),
-        &provider,
-        &config,
-        "mock-model",
-        |_| {},
-        &CancellationToken::new(),
-    )
-    .await
-    .unwrap();
+    let summary = index_repository(dir.path(), &provider, &config, "mock-model")
+        .await
+        .unwrap();
 
     // Should still complete successfully (exit 0).
     assert!(summary.files_parsed >= 1);

--- a/crates/vera-core/src/indexing/update.rs
+++ b/crates/vera-core/src/indexing/update.rs
@@ -111,6 +111,23 @@ pub async fn update_repository<P: EmbeddingProvider>(
     provider: &P,
     config: &VeraConfig,
     model_name: &str,
+) -> Result<UpdateSummary> {
+    update_repository_with_cancellation(
+        repo_path,
+        provider,
+        config,
+        model_name,
+        &CancellationToken::new(),
+    )
+    .await
+}
+
+/// Update an existing repository index while cooperatively observing cancellation.
+pub async fn update_repository_with_cancellation<P: EmbeddingProvider>(
+    repo_path: &Path,
+    provider: &P,
+    config: &VeraConfig,
+    model_name: &str,
     cancellation: &CancellationToken,
 ) -> Result<UpdateSummary> {
     let start = Instant::now();
@@ -139,8 +156,9 @@ pub async fn update_repository<P: EmbeddingProvider>(
     info!(path = %repo_root.display(), "starting incremental update");
 
     // ── 2. Discover current files on disk ────────────────────────
-    let disc = discovery::discover_files(&repo_root, &config.indexing, cancellation)
-        .context("file discovery failed")?;
+    let disc =
+        discovery::discover_files_with_cancellation(&repo_root, &config.indexing, cancellation)
+            .context("file discovery failed")?;
 
     // ── 3. Load stored hashes and classify files ─────────────────
     let metadata_path = idx_dir.join("metadata.db");

--- a/crates/vera-core/src/indexing/update.rs
+++ b/crates/vera-core/src/indexing/update.rs
@@ -336,11 +336,24 @@ pub async fn update_repository<P: EmbeddingProvider>(
 
         if !all_chunks.is_empty() {
             // Generate embeddings.
+            let (batch_size, max_concurrent_requests) = config.embedding.bounded_parallelism();
+            if batch_size != config.embedding.batch_size
+                || max_concurrent_requests != config.embedding.max_concurrent_requests
+            {
+                info!(
+                    configured_batch_size = config.embedding.batch_size,
+                    configured_concurrency = config.embedding.max_concurrent_requests,
+                    max_in_flight_inputs = config.embedding.max_in_flight_inputs,
+                    batch_size,
+                    max_concurrent_requests,
+                    "clamped update embedding parallelism to the in-flight input bound"
+                );
+            }
             let mut embeddings = embed_chunks_concurrent(
                 provider,
                 &all_chunks,
-                config.embedding.batch_size,
-                config.embedding.max_concurrent_requests,
+                batch_size,
+                max_concurrent_requests,
                 config.indexing.max_chunk_bytes,
             )
             .await

--- a/crates/vera-core/src/indexing/update.rs
+++ b/crates/vera-core/src/indexing/update.rs
@@ -19,6 +19,7 @@ use anyhow::{Context, Result, bail};
 use sha2::{Digest, Sha256};
 use tracing::{debug, info, warn};
 
+use crate::CancellationToken;
 use crate::config::VeraConfig;
 use crate::discovery;
 use crate::embedding::{EmbeddingProvider, embed_chunks_concurrent};
@@ -110,8 +111,10 @@ pub async fn update_repository<P: EmbeddingProvider>(
     provider: &P,
     config: &VeraConfig,
     model_name: &str,
+    cancellation: &CancellationToken,
 ) -> Result<UpdateSummary> {
     let start = Instant::now();
+    cancellation.check()?;
 
     // ── 1. Validate path ─────────────────────────────────────────
     if !repo_path.exists() {
@@ -136,8 +139,8 @@ pub async fn update_repository<P: EmbeddingProvider>(
     info!(path = %repo_root.display(), "starting incremental update");
 
     // ── 2. Discover current files on disk ────────────────────────
-    let disc =
-        discovery::discover_files(&repo_root, &config.indexing).context("file discovery failed")?;
+    let disc = discovery::discover_files(&repo_root, &config.indexing, cancellation)
+        .context("file discovery failed")?;
 
     // ── 3. Load stored hashes and classify files ─────────────────
     let metadata_path = idx_dir.join("metadata.db");
@@ -191,6 +194,7 @@ pub async fn update_repository<P: EmbeddingProvider>(
     // Read file contents and compute hashes for current files.
     let mut current_files: HashMap<String, String> = HashMap::new(); // rel_path → content
     for file in &disc.files {
+        cancellation.check()?;
         match std::fs::read_to_string(&file.absolute_path) {
             Ok(content) => {
                 current_files.insert(file.relative_path.clone(), content);
@@ -210,6 +214,7 @@ pub async fn update_repository<P: EmbeddingProvider>(
     let mut unchanged = 0usize;
 
     for (rel_path, content) in &current_files {
+        cancellation.check()?;
         let language = detect_language_for_path(rel_path);
         let hash = hash_for_indexing_source(content, rel_path, language, &repo_root);
         let stored_hash = metadata_store
@@ -233,6 +238,7 @@ pub async fn update_repository<P: EmbeddingProvider>(
     }
 
     for stored_path in &stored_files {
+        cancellation.check()?;
         if !current_paths.contains(stored_path.as_str()) {
             deleted.push(stored_path.clone());
         }
@@ -246,42 +252,16 @@ pub async fn update_repository<P: EmbeddingProvider>(
         "file classification complete"
     );
 
-    // ── 4. Process deletions ─────────────────────────────────────
-    if !deleted.is_empty() {
-        let vector_path = idx_dir.join("vectors.db");
-        let vector_store = VectorStore::open(&vector_path, stored_dim)
-            .context("failed to open vector store for deletion")?;
-        let bm25_dir = idx_dir.join("bm25");
-        let bm25_index =
-            Bm25Index::open(&bm25_dir).context("failed to open BM25 index for deletion")?;
-
-        for file_path in &deleted {
-            remove_file_from_index(&metadata_store, &vector_store, &bm25_index, file_path)?;
-        }
-    }
-
-    // ── 5. Process modifications and additions ───────────────────
+    // ── 4. Prepare modifications and additions ───────────────────
     let files_to_index: Vec<(String, String, String)> =
         modified.iter().chain(added.iter()).cloned().collect();
+    let mut all_chunks = Vec::new();
+    let mut references_by_file = Vec::new();
 
     if !files_to_index.is_empty() {
-        // For modified files, first remove old data.
-        if !modified.is_empty() {
-            let vector_path = idx_dir.join("vectors.db");
-            let vector_store = VectorStore::open(&vector_path, stored_dim)
-                .context("failed to open vector store for modification")?;
-            let bm25_dir = idx_dir.join("bm25");
-            let bm25_index =
-                Bm25Index::open(&bm25_dir).context("failed to open BM25 index for modification")?;
-
-            for (file_path, _, _) in &modified {
-                remove_file_from_index(&metadata_store, &vector_store, &bm25_index, file_path)?;
-            }
-        }
-
         // Parse and chunk new/modified files.
-        let mut all_chunks = Vec::new();
         for (rel_path, content, _hash) in &files_to_index {
+            cancellation.check()?;
             let language = detect_language_for_path(rel_path);
 
             // For RST, refs come from raw source; chunks from preprocessed.
@@ -323,86 +303,118 @@ pub async fn update_repository<P: EmbeddingProvider>(
                     }
                 }
             };
+            cancellation.check()?;
 
             if !refs.is_empty() {
-                metadata_store
-                    .insert_references(rel_path, &refs)
-                    .context("failed to store references")?;
+                references_by_file.push((rel_path.clone(), refs.clone()));
             }
 
             debug!(file = %rel_path, chunks = chunks.len(), refs = refs.len(), "parsed file");
             all_chunks.extend(chunks);
         }
+    }
 
-        if !all_chunks.is_empty() {
-            // Generate embeddings.
-            let (batch_size, max_concurrent_requests) = config.embedding.bounded_parallelism();
-            if batch_size != config.embedding.batch_size
-                || max_concurrent_requests != config.embedding.max_concurrent_requests
-            {
-                info!(
-                    configured_batch_size = config.embedding.batch_size,
-                    configured_concurrency = config.embedding.max_concurrent_requests,
-                    max_in_flight_inputs = config.embedding.max_in_flight_inputs,
-                    batch_size,
-                    max_concurrent_requests,
-                    "clamped update embedding parallelism to the in-flight input bound"
-                );
-            }
-            let mut embeddings = embed_chunks_concurrent(
-                provider,
-                &all_chunks,
+    let mut embeddings = Vec::new();
+    let mut final_stored_dim = stored_dim;
+    if !all_chunks.is_empty() {
+        // Generate embeddings.
+        cancellation.check()?;
+        let (batch_size, max_concurrent_requests) = config.embedding.bounded_parallelism();
+        if batch_size != config.embedding.batch_size
+            || max_concurrent_requests != config.embedding.max_concurrent_requests
+        {
+            info!(
+                configured_batch_size = config.embedding.batch_size,
+                configured_concurrency = config.embedding.max_concurrent_requests,
+                max_in_flight_inputs = config.embedding.max_in_flight_inputs,
                 batch_size,
                 max_concurrent_requests,
-                config.indexing.max_chunk_bytes,
-            )
-            .await
-            .context("embedding generation failed")?;
-
-            // Truncate if needed.
-            let final_stored_dim = super::truncate_embeddings(&mut embeddings, stored_dim);
-
-            // Store metadata.
-            metadata_store
-                .insert_chunks(&all_chunks)
-                .context("failed to insert updated chunk metadata")?;
-
-            // Store vectors.
-            let vector_path = idx_dir.join("vectors.db");
-            let vector_store = VectorStore::open(&vector_path, final_stored_dim)
-                .context("failed to open vector store for insertion")?;
-
-            let batch: Vec<(&str, &[f32])> = embeddings
-                .iter()
-                .map(|(id, vec)| (id.as_str(), vec.as_slice()))
-                .collect();
-            vector_store
-                .insert_batch(&batch)
-                .context("failed to insert updated vectors")?;
-
-            // Store BM25 documents.
-            let bm25_dir = idx_dir.join("bm25");
-            let bm25_index =
-                Bm25Index::open(&bm25_dir).context("failed to open BM25 index for insertion")?;
-
-            let lang_strings: Vec<String> =
-                all_chunks.iter().map(|c| c.language.to_string()).collect();
-            let bm25_docs: Vec<Bm25Document<'_>> = all_chunks
-                .iter()
-                .zip(lang_strings.iter())
-                .map(|(c, lang)| Bm25Document {
-                    chunk_id: &c.id,
-                    file_path: &c.file_path,
-                    content: &c.content,
-                    symbol_name: c.symbol_name.as_deref(),
-                    language: lang,
-                })
-                .collect();
-            bm25_index
-                .insert_batch(&bm25_docs)
-                .context("failed to insert updated BM25 documents")?;
+                "clamped update embedding parallelism to the in-flight input bound"
+            );
         }
+        embeddings = embed_chunks_concurrent(
+            provider,
+            &all_chunks,
+            batch_size,
+            max_concurrent_requests,
+            config.indexing.max_chunk_bytes,
+        )
+        .await
+        .context("embedding generation failed")?;
+        cancellation.check()?;
 
+        // Truncate if needed.
+        final_stored_dim = super::truncate_embeddings(&mut embeddings, stored_dim);
+    }
+
+    // ── 5. Publish the prepared update without interruption ──────
+    cancellation.check()?;
+
+    // Remove deleted files and stale data for modified files.
+    if !deleted.is_empty() || !modified.is_empty() {
+        let vector_path = idx_dir.join("vectors.db");
+        let vector_store = VectorStore::open(&vector_path, stored_dim)
+            .context("failed to open vector store for removal")?;
+        let bm25_dir = idx_dir.join("bm25");
+        let bm25_index =
+            Bm25Index::open(&bm25_dir).context("failed to open BM25 index for removal")?;
+
+        for file_path in deleted
+            .iter()
+            .chain(modified.iter().map(|(file_path, _, _)| file_path))
+        {
+            remove_file_from_index(&metadata_store, &vector_store, &bm25_index, file_path)?;
+        }
+    }
+
+    for (rel_path, refs) in &references_by_file {
+        metadata_store
+            .insert_references(rel_path, refs)
+            .context("failed to store references")?;
+    }
+
+    if !all_chunks.is_empty() {
+        // Store metadata.
+        metadata_store
+            .insert_chunks(&all_chunks)
+            .context("failed to insert updated chunk metadata")?;
+
+        // Store vectors.
+        let vector_path = idx_dir.join("vectors.db");
+        let vector_store = VectorStore::open(&vector_path, final_stored_dim)
+            .context("failed to open vector store for insertion")?;
+
+        let batch: Vec<(&str, &[f32])> = embeddings
+            .iter()
+            .map(|(id, vec)| (id.as_str(), vec.as_slice()))
+            .collect();
+        vector_store
+            .insert_batch(&batch)
+            .context("failed to insert updated vectors")?;
+
+        // Store BM25 documents.
+        let bm25_dir = idx_dir.join("bm25");
+        let bm25_index =
+            Bm25Index::open(&bm25_dir).context("failed to open BM25 index for insertion")?;
+
+        let lang_strings: Vec<String> = all_chunks.iter().map(|c| c.language.to_string()).collect();
+        let bm25_docs: Vec<Bm25Document<'_>> = all_chunks
+            .iter()
+            .zip(lang_strings.iter())
+            .map(|(c, lang)| Bm25Document {
+                chunk_id: &c.id,
+                file_path: &c.file_path,
+                content: &c.content,
+                symbol_name: c.symbol_name.as_deref(),
+                language: lang,
+            })
+            .collect();
+        bm25_index
+            .insert_batch(&bm25_docs)
+            .context("failed to insert updated BM25 documents")?;
+    }
+
+    if !files_to_index.is_empty() {
         // Update file hashes for all indexed files.
         for (rel_path, _content, hash) in &files_to_index {
             metadata_store

--- a/crates/vera-core/src/indexing/update_tests.rs
+++ b/crates/vera-core/src/indexing/update_tests.rs
@@ -5,6 +5,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 
 use tempfile::TempDir;
 
+use crate::CancellationToken;
 use crate::config::VeraConfig;
 use crate::embedding::test_helpers::MockProvider;
 use crate::embedding::{EmbeddingError, EmbeddingProvider};
@@ -94,15 +95,28 @@ async fn update_no_changes() {
     let config = default_config();
 
     // Initial index.
-    let idx_summary = index_repository(dir.path(), &provider, &config, "mock-model")
-        .await
-        .unwrap();
+    let idx_summary = index_repository(
+        dir.path(),
+        &provider,
+        &config,
+        "mock-model",
+        |_| {},
+        &CancellationToken::new(),
+    )
+    .await
+    .unwrap();
     assert!(idx_summary.chunks_created > 0);
 
     // Update with no changes.
-    let update_summary = update_repository(dir.path(), &provider, &config, "mock-model")
-        .await
-        .unwrap();
+    let update_summary = update_repository(
+        dir.path(),
+        &provider,
+        &config,
+        "mock-model",
+        &CancellationToken::new(),
+    )
+    .await
+    .unwrap();
 
     assert_eq!(update_summary.files_modified, 0);
     assert_eq!(update_summary.files_added, 0);
@@ -121,9 +135,16 @@ async fn update_respects_max_in_flight_input_bound() {
 
     let initial_provider = MockProvider::new(8);
     let initial_config = default_config();
-    index_repository(dir.path(), &initial_provider, &initial_config, "mock-model")
-        .await
-        .unwrap();
+    index_repository(
+        dir.path(),
+        &initial_provider,
+        &initial_config,
+        "mock-model",
+        |_| {},
+        &CancellationToken::new(),
+    )
+    .await
+    .unwrap();
 
     for name in ["one.rs", "two.rs", "three.rs"] {
         fs::write(dir.path().join(name), format!("fn {}() {{}}\n", &name[..3])).unwrap();
@@ -135,9 +156,15 @@ async fn update_respects_max_in_flight_input_bound() {
     config.embedding.max_concurrent_requests = 8;
     config.embedding.max_in_flight_inputs = 2;
 
-    let summary = update_repository(dir.path(), &provider, &config, "mock-model")
-        .await
-        .unwrap();
+    let summary = update_repository(
+        dir.path(),
+        &provider,
+        &config,
+        "mock-model",
+        &CancellationToken::new(),
+    )
+    .await
+    .unwrap();
 
     assert_eq!(summary.files_added, 3);
     assert_eq!(provider.largest_batch.load(Ordering::SeqCst), 2);
@@ -159,9 +186,16 @@ async fn update_modified_file() {
     let config = default_config();
 
     // Initial index.
-    let idx_summary = index_repository(dir.path(), &provider, &config, "mock-model")
-        .await
-        .unwrap();
+    let idx_summary = index_repository(
+        dir.path(),
+        &provider,
+        &config,
+        "mock-model",
+        |_| {},
+        &CancellationToken::new(),
+    )
+    .await
+    .unwrap();
     let _initial_chunks = idx_summary.chunks_created as u64;
 
     // Modify one file.
@@ -172,9 +206,15 @@ async fn update_modified_file() {
     .unwrap();
 
     // Update.
-    let update_summary = update_repository(dir.path(), &provider, &config, "mock-model")
-        .await
-        .unwrap();
+    let update_summary = update_repository(
+        dir.path(),
+        &provider,
+        &config,
+        "mock-model",
+        &CancellationToken::new(),
+    )
+    .await
+    .unwrap();
 
     assert_eq!(update_summary.files_modified, 1);
     assert_eq!(update_summary.files_added, 0);
@@ -213,9 +253,16 @@ async fn update_detects_rst_include_dependency_changes() {
     let provider = MockProvider::new(8);
     let config = default_config();
 
-    index_repository(dir.path(), &provider, &config, "mock-model")
-        .await
-        .unwrap();
+    index_repository(
+        dir.path(),
+        &provider,
+        &config,
+        "mock-model",
+        |_| {},
+        &CancellationToken::new(),
+    )
+    .await
+    .unwrap();
 
     let idx = index_dir(&dir.path().canonicalize().unwrap());
     let metadata = MetadataStore::open(&idx.join("metadata.db")).unwrap();
@@ -232,9 +279,15 @@ async fn update_detects_rst_include_dependency_changes() {
     )
     .unwrap();
 
-    let update_summary = update_repository(dir.path(), &provider, &config, "mock-model")
-        .await
-        .unwrap();
+    let update_summary = update_repository(
+        dir.path(),
+        &provider,
+        &config,
+        "mock-model",
+        &CancellationToken::new(),
+    )
+    .await
+    .unwrap();
 
     assert_eq!(update_summary.files_modified, 1);
     assert_eq!(update_summary.files_added, 0);
@@ -265,9 +318,16 @@ async fn update_added_file() {
     let config = default_config();
 
     // Initial index.
-    let idx_summary = index_repository(dir.path(), &provider, &config, "mock-model")
-        .await
-        .unwrap();
+    let idx_summary = index_repository(
+        dir.path(),
+        &provider,
+        &config,
+        "mock-model",
+        |_| {},
+        &CancellationToken::new(),
+    )
+    .await
+    .unwrap();
     let initial_chunks = idx_summary.chunks_created as u64;
 
     // Add a new file.
@@ -278,9 +338,15 @@ async fn update_added_file() {
     .unwrap();
 
     // Update.
-    let update_summary = update_repository(dir.path(), &provider, &config, "mock-model")
-        .await
-        .unwrap();
+    let update_summary = update_repository(
+        dir.path(),
+        &provider,
+        &config,
+        "mock-model",
+        &CancellationToken::new(),
+    )
+    .await
+    .unwrap();
 
     assert_eq!(update_summary.files_modified, 0);
     assert_eq!(update_summary.files_added, 1);
@@ -321,18 +387,31 @@ async fn update_deleted_file() {
     let config = default_config();
 
     // Initial index.
-    let idx_summary = index_repository(dir.path(), &provider, &config, "mock-model")
-        .await
-        .unwrap();
+    let idx_summary = index_repository(
+        dir.path(),
+        &provider,
+        &config,
+        "mock-model",
+        |_| {},
+        &CancellationToken::new(),
+    )
+    .await
+    .unwrap();
     let initial_chunks = idx_summary.chunks_created as u64;
 
     // Delete a file.
     fs::remove_file(dir.path().join("lib.py")).unwrap();
 
     // Update.
-    let update_summary = update_repository(dir.path(), &provider, &config, "mock-model")
-        .await
-        .unwrap();
+    let update_summary = update_repository(
+        dir.path(),
+        &provider,
+        &config,
+        "mock-model",
+        &CancellationToken::new(),
+    )
+    .await
+    .unwrap();
 
     assert_eq!(update_summary.files_modified, 0);
     assert_eq!(update_summary.files_added, 0);
@@ -367,13 +446,56 @@ async fn update_without_index_fails() {
     let provider = MockProvider::new(8);
     let config = default_config();
 
-    let result = update_repository(dir.path(), &provider, &config, "mock-model").await;
+    let result = update_repository(
+        dir.path(),
+        &provider,
+        &config,
+        "mock-model",
+        &CancellationToken::new(),
+    )
+    .await;
     assert!(result.is_err());
     let err = result.unwrap_err().to_string();
     assert!(
         err.contains("no index found"),
         "should report no index: {err}"
     );
+}
+
+#[tokio::test]
+async fn pre_cancelled_update_preserves_existing_index() {
+    let dir = TempDir::new().unwrap();
+    let source_path = dir.path().join("main.rs");
+    fs::write(&source_path, "fn original() {}\n").unwrap();
+
+    let provider = MockProvider::new(8);
+    let config = default_config();
+    index_repository(
+        dir.path(),
+        &provider,
+        &config,
+        "mock-model",
+        |_| {},
+        &CancellationToken::new(),
+    )
+    .await
+    .unwrap();
+
+    let idx = index_dir(&dir.path().canonicalize().unwrap());
+    let metadata = MetadataStore::open(&idx.join("metadata.db")).unwrap();
+    let original_hash = metadata.get_file_hash("main.rs").unwrap();
+    drop(metadata);
+    fs::write(&source_path, "fn changed() {}\n").unwrap();
+
+    let cancellation = CancellationToken::new();
+    cancellation.cancel();
+    let error = update_repository(dir.path(), &provider, &config, "mock-model", &cancellation)
+        .await
+        .unwrap_err();
+
+    assert!(error.to_string().contains("operation cancelled"));
+    let metadata = MetadataStore::open(&idx.join("metadata.db")).unwrap();
+    assert_eq!(metadata.get_file_hash("main.rs").unwrap(), original_hash);
 }
 
 // ── Update: consistency with fresh index ────────────────────────────
@@ -397,9 +519,16 @@ async fn update_matches_fresh_index() {
     let config = default_config();
 
     // Initial index.
-    index_repository(dir.path(), &provider, &config, "mock-model")
-        .await
-        .unwrap();
+    index_repository(
+        dir.path(),
+        &provider,
+        &config,
+        "mock-model",
+        |_| {},
+        &CancellationToken::new(),
+    )
+    .await
+    .unwrap();
 
     // Apply a sequence of changes.
     // 1. Modify main.rs
@@ -418,9 +547,15 @@ async fn update_matches_fresh_index() {
     .unwrap();
 
     // Run update.
-    let update_summary = update_repository(dir.path(), &provider, &config, "mock-model")
-        .await
-        .unwrap();
+    let update_summary = update_repository(
+        dir.path(),
+        &provider,
+        &config,
+        "mock-model",
+        &CancellationToken::new(),
+    )
+    .await
+    .unwrap();
     assert_eq!(update_summary.files_modified, 1);
     assert_eq!(update_summary.files_added, 1);
     assert_eq!(update_summary.files_deleted, 1);
@@ -433,9 +568,16 @@ async fn update_matches_fresh_index() {
     let updated_languages = updated_metadata.language_stats().unwrap();
 
     // Now do a fresh index of the same directory.
-    let _fresh_summary = index_repository(dir.path(), &provider, &config, "mock-model")
-        .await
-        .unwrap();
+    let _fresh_summary = index_repository(
+        dir.path(),
+        &provider,
+        &config,
+        "mock-model",
+        |_| {},
+        &CancellationToken::new(),
+    )
+    .await
+    .unwrap();
 
     let fresh_metadata = MetadataStore::open(&idx.join("metadata.db")).unwrap();
     let fresh_chunk_count = fresh_metadata.chunk_count().unwrap();
@@ -470,18 +612,31 @@ async fn update_mixed_add_modify_delete() {
     let config = default_config();
 
     // Initial index.
-    index_repository(dir.path(), &provider, &config, "mock-model")
-        .await
-        .unwrap();
+    index_repository(
+        dir.path(),
+        &provider,
+        &config,
+        "mock-model",
+        |_| {},
+        &CancellationToken::new(),
+    )
+    .await
+    .unwrap();
 
     // Modify a.rs, delete b.py, add d.ts.
     fs::write(dir.path().join("a.rs"), "fn a_updated() { 42 }").unwrap();
     fs::remove_file(dir.path().join("b.py")).unwrap();
     fs::write(dir.path().join("d.ts"), "function d(): void {}").unwrap();
 
-    let update_summary = update_repository(dir.path(), &provider, &config, "mock-model")
-        .await
-        .unwrap();
+    let update_summary = update_repository(
+        dir.path(),
+        &provider,
+        &config,
+        "mock-model",
+        &CancellationToken::new(),
+    )
+    .await
+    .unwrap();
 
     assert_eq!(update_summary.files_modified, 1);
     assert_eq!(update_summary.files_added, 1);
@@ -516,9 +671,16 @@ async fn update_vector_store_consistent() {
     let config = default_config();
 
     // Initial index.
-    index_repository(dir.path(), &provider, &config, "mock-model")
-        .await
-        .unwrap();
+    index_repository(
+        dir.path(),
+        &provider,
+        &config,
+        "mock-model",
+        |_| {},
+        &CancellationToken::new(),
+    )
+    .await
+    .unwrap();
 
     let idx = index_dir(&dir.path().canonicalize().unwrap());
     let initial_vec_count = VectorStore::open(&idx.join("vectors.db"), 8)
@@ -528,9 +690,15 @@ async fn update_vector_store_consistent() {
 
     // Add a file.
     fs::write(dir.path().join("lib.py"), "def lib(): return 1").unwrap();
-    update_repository(dir.path(), &provider, &config, "mock-model")
-        .await
-        .unwrap();
+    update_repository(
+        dir.path(),
+        &provider,
+        &config,
+        "mock-model",
+        &CancellationToken::new(),
+    )
+    .await
+    .unwrap();
 
     let after_add_vec_count = VectorStore::open(&idx.join("vectors.db"), 8)
         .unwrap()
@@ -543,9 +711,15 @@ async fn update_vector_store_consistent() {
 
     // Delete the added file.
     fs::remove_file(dir.path().join("lib.py")).unwrap();
-    update_repository(dir.path(), &provider, &config, "mock-model")
-        .await
-        .unwrap();
+    update_repository(
+        dir.path(),
+        &provider,
+        &config,
+        "mock-model",
+        &CancellationToken::new(),
+    )
+    .await
+    .unwrap();
 
     let after_del_vec_count = VectorStore::open(&idx.join("vectors.db"), 8)
         .unwrap()

--- a/crates/vera-core/src/indexing/update_tests.rs
+++ b/crates/vera-core/src/indexing/update_tests.rs
@@ -1,11 +1,13 @@
 //! Tests for incremental update logic.
 
 use std::fs;
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 use tempfile::TempDir;
 
 use crate::config::VeraConfig;
 use crate::embedding::test_helpers::MockProvider;
+use crate::embedding::{EmbeddingError, EmbeddingProvider};
 use crate::indexing::{index_dir, index_repository, update_repository};
 use crate::storage::bm25::Bm25Index;
 use crate::storage::metadata::MetadataStore;
@@ -15,6 +17,42 @@ use super::content_hash;
 
 fn default_config() -> VeraConfig {
     VeraConfig::default()
+}
+
+struct BatchBoundProvider {
+    max_batch_size: usize,
+    largest_batch: AtomicUsize,
+}
+
+impl BatchBoundProvider {
+    fn new(max_batch_size: usize) -> Self {
+        Self {
+            max_batch_size,
+            largest_batch: AtomicUsize::new(0),
+        }
+    }
+}
+
+impl EmbeddingProvider for BatchBoundProvider {
+    async fn embed_batch(&self, texts: &[String]) -> Result<Vec<Vec<f32>>, EmbeddingError> {
+        self.largest_batch.fetch_max(texts.len(), Ordering::SeqCst);
+        if texts.len() > self.max_batch_size {
+            return Err(EmbeddingError::ApiError {
+                status: 400,
+                message: format!(
+                    "batch contained {} inputs, limit is {}",
+                    texts.len(),
+                    self.max_batch_size
+                ),
+            });
+        }
+
+        Ok(vec![vec![0.0; 8]; texts.len()])
+    }
+
+    fn expected_dim(&self) -> Option<usize> {
+        Some(8)
+    }
 }
 
 // ── Content hash tests ──────────────────────────────────────────────
@@ -74,6 +112,35 @@ async fn update_no_changes() {
         update_summary.total_chunks,
         idx_summary.chunks_created as u64
     );
+}
+
+#[tokio::test]
+async fn update_respects_max_in_flight_input_bound() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("main.rs"), "fn main() {}\n").unwrap();
+
+    let initial_provider = MockProvider::new(8);
+    let initial_config = default_config();
+    index_repository(dir.path(), &initial_provider, &initial_config, "mock-model")
+        .await
+        .unwrap();
+
+    for name in ["one.rs", "two.rs", "three.rs"] {
+        fs::write(dir.path().join(name), format!("fn {}() {{}}\n", &name[..3])).unwrap();
+    }
+
+    let provider = BatchBoundProvider::new(2);
+    let mut config = default_config();
+    config.embedding.batch_size = 128;
+    config.embedding.max_concurrent_requests = 8;
+    config.embedding.max_in_flight_inputs = 2;
+
+    let summary = update_repository(dir.path(), &provider, &config, "mock-model")
+        .await
+        .unwrap();
+
+    assert_eq!(summary.files_added, 3);
+    assert_eq!(provider.largest_batch.load(Ordering::SeqCst), 2);
 }
 
 // ── Update: file modified ───────────────────────────────────────────

--- a/crates/vera-core/src/indexing/update_tests.rs
+++ b/crates/vera-core/src/indexing/update_tests.rs
@@ -4,6 +4,7 @@ use std::fs;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 use tempfile::TempDir;
+use tokio::sync::{Notify, watch};
 
 use crate::CancellationToken;
 use crate::config::VeraConfig;
@@ -23,14 +24,50 @@ fn default_config() -> VeraConfig {
 struct BatchBoundProvider {
     max_batch_size: usize,
     largest_batch: AtomicUsize,
+    active_inputs: AtomicUsize,
+    peak_active_inputs: AtomicUsize,
+    started_requests: AtomicUsize,
+    request_started: Notify,
+    release_requests: watch::Sender<bool>,
 }
 
 impl BatchBoundProvider {
     fn new(max_batch_size: usize) -> Self {
+        let (release_requests, _) = watch::channel(false);
         Self {
             max_batch_size,
             largest_batch: AtomicUsize::new(0),
+            active_inputs: AtomicUsize::new(0),
+            peak_active_inputs: AtomicUsize::new(0),
+            started_requests: AtomicUsize::new(0),
+            request_started: Notify::new(),
+            release_requests,
         }
+    }
+
+    async fn wait_for_started_requests(&self, minimum: usize) {
+        loop {
+            let request_started = self.request_started.notified();
+            if self.started_requests.load(Ordering::SeqCst) >= minimum {
+                return;
+            }
+            request_started.await;
+        }
+    }
+
+    fn release_requests(&self) {
+        self.release_requests.send_replace(true);
+    }
+}
+
+struct ActiveInputs<'a> {
+    count: &'a AtomicUsize,
+    inputs: usize,
+}
+
+impl Drop for ActiveInputs<'_> {
+    fn drop(&mut self) {
+        self.count.fetch_sub(self.inputs, Ordering::SeqCst);
     }
 }
 
@@ -46,6 +83,27 @@ impl EmbeddingProvider for BatchBoundProvider {
                     self.max_batch_size
                 ),
             });
+        }
+
+        let active_inputs =
+            self.active_inputs.fetch_add(texts.len(), Ordering::SeqCst) + texts.len();
+        let _active_inputs = ActiveInputs {
+            count: &self.active_inputs,
+            inputs: texts.len(),
+        };
+        self.peak_active_inputs
+            .fetch_max(active_inputs, Ordering::SeqCst);
+        self.started_requests.fetch_add(1, Ordering::SeqCst);
+        self.request_started.notify_one();
+
+        let mut release_requests = self.release_requests.subscribe();
+        if !*release_requests.borrow() {
+            release_requests
+                .changed()
+                .await
+                .map_err(|error| EmbeddingError::ResponseError {
+                    message: format!("test request release channel closed: {error}"),
+                })?;
         }
 
         Ok(vec![vec![0.0; 8]; texts.len()])
@@ -95,28 +153,15 @@ async fn update_no_changes() {
     let config = default_config();
 
     // Initial index.
-    let idx_summary = index_repository(
-        dir.path(),
-        &provider,
-        &config,
-        "mock-model",
-        |_| {},
-        &CancellationToken::new(),
-    )
-    .await
-    .unwrap();
+    let idx_summary = index_repository(dir.path(), &provider, &config, "mock-model")
+        .await
+        .unwrap();
     assert!(idx_summary.chunks_created > 0);
 
     // Update with no changes.
-    let update_summary = update_repository(
-        dir.path(),
-        &provider,
-        &config,
-        "mock-model",
-        &CancellationToken::new(),
-    )
-    .await
-    .unwrap();
+    let update_summary = update_repository(dir.path(), &provider, &config, "mock-model")
+        .await
+        .unwrap();
 
     assert_eq!(update_summary.files_modified, 0);
     assert_eq!(update_summary.files_added, 0);
@@ -135,39 +180,47 @@ async fn update_respects_max_in_flight_input_bound() {
 
     let initial_provider = MockProvider::new(8);
     let initial_config = default_config();
-    index_repository(
-        dir.path(),
-        &initial_provider,
-        &initial_config,
-        "mock-model",
-        |_| {},
-        &CancellationToken::new(),
-    )
-    .await
-    .unwrap();
+    index_repository(dir.path(), &initial_provider, &initial_config, "mock-model")
+        .await
+        .unwrap();
 
-    for name in ["one.rs", "two.rs", "three.rs"] {
+    for name in ["one.rs", "two.rs", "three.rs", "four.rs"] {
         fs::write(dir.path().join(name), format!("fn {}() {{}}\n", &name[..3])).unwrap();
     }
 
     let provider = BatchBoundProvider::new(2);
     let mut config = default_config();
-    config.embedding.batch_size = 128;
+    config.embedding.batch_size = 2;
     config.embedding.max_concurrent_requests = 8;
-    config.embedding.max_in_flight_inputs = 2;
+    config.embedding.max_in_flight_inputs = 4;
 
-    let summary = update_repository(
+    let cancellation = CancellationToken::new();
+    let update = crate::indexing::update_repository_with_cancellation(
         dir.path(),
         &provider,
         &config,
         "mock-model",
-        &CancellationToken::new(),
-    )
-    .await
-    .unwrap();
+        &cancellation,
+    );
+    let observe_concurrency = async {
+        provider.wait_for_started_requests(2).await;
+        tokio::task::yield_now().await;
+        let peak_active_inputs = provider.peak_active_inputs.load(Ordering::SeqCst);
+        provider.release_requests();
+        peak_active_inputs
+    };
+    let (summary, peak_active_inputs) =
+        tokio::time::timeout(std::time::Duration::from_secs(1), async {
+            tokio::join!(update, observe_concurrency)
+        })
+        .await
+        .expect("embedding requests should overlap without exceeding the input bound");
+    let summary = summary.unwrap();
 
-    assert_eq!(summary.files_added, 3);
+    assert_eq!(summary.files_added, 4);
     assert_eq!(provider.largest_batch.load(Ordering::SeqCst), 2);
+    assert_eq!(peak_active_inputs, 4);
+    assert!(peak_active_inputs <= config.embedding.max_in_flight_inputs);
 }
 
 // ── Update: file modified ───────────────────────────────────────────
@@ -186,16 +239,9 @@ async fn update_modified_file() {
     let config = default_config();
 
     // Initial index.
-    let idx_summary = index_repository(
-        dir.path(),
-        &provider,
-        &config,
-        "mock-model",
-        |_| {},
-        &CancellationToken::new(),
-    )
-    .await
-    .unwrap();
+    let idx_summary = index_repository(dir.path(), &provider, &config, "mock-model")
+        .await
+        .unwrap();
     let _initial_chunks = idx_summary.chunks_created as u64;
 
     // Modify one file.
@@ -206,15 +252,9 @@ async fn update_modified_file() {
     .unwrap();
 
     // Update.
-    let update_summary = update_repository(
-        dir.path(),
-        &provider,
-        &config,
-        "mock-model",
-        &CancellationToken::new(),
-    )
-    .await
-    .unwrap();
+    let update_summary = update_repository(dir.path(), &provider, &config, "mock-model")
+        .await
+        .unwrap();
 
     assert_eq!(update_summary.files_modified, 1);
     assert_eq!(update_summary.files_added, 0);
@@ -253,16 +293,9 @@ async fn update_detects_rst_include_dependency_changes() {
     let provider = MockProvider::new(8);
     let config = default_config();
 
-    index_repository(
-        dir.path(),
-        &provider,
-        &config,
-        "mock-model",
-        |_| {},
-        &CancellationToken::new(),
-    )
-    .await
-    .unwrap();
+    index_repository(dir.path(), &provider, &config, "mock-model")
+        .await
+        .unwrap();
 
     let idx = index_dir(&dir.path().canonicalize().unwrap());
     let metadata = MetadataStore::open(&idx.join("metadata.db")).unwrap();
@@ -279,15 +312,9 @@ async fn update_detects_rst_include_dependency_changes() {
     )
     .unwrap();
 
-    let update_summary = update_repository(
-        dir.path(),
-        &provider,
-        &config,
-        "mock-model",
-        &CancellationToken::new(),
-    )
-    .await
-    .unwrap();
+    let update_summary = update_repository(dir.path(), &provider, &config, "mock-model")
+        .await
+        .unwrap();
 
     assert_eq!(update_summary.files_modified, 1);
     assert_eq!(update_summary.files_added, 0);
@@ -318,16 +345,9 @@ async fn update_added_file() {
     let config = default_config();
 
     // Initial index.
-    let idx_summary = index_repository(
-        dir.path(),
-        &provider,
-        &config,
-        "mock-model",
-        |_| {},
-        &CancellationToken::new(),
-    )
-    .await
-    .unwrap();
+    let idx_summary = index_repository(dir.path(), &provider, &config, "mock-model")
+        .await
+        .unwrap();
     let initial_chunks = idx_summary.chunks_created as u64;
 
     // Add a new file.
@@ -338,15 +358,9 @@ async fn update_added_file() {
     .unwrap();
 
     // Update.
-    let update_summary = update_repository(
-        dir.path(),
-        &provider,
-        &config,
-        "mock-model",
-        &CancellationToken::new(),
-    )
-    .await
-    .unwrap();
+    let update_summary = update_repository(dir.path(), &provider, &config, "mock-model")
+        .await
+        .unwrap();
 
     assert_eq!(update_summary.files_modified, 0);
     assert_eq!(update_summary.files_added, 1);
@@ -387,31 +401,18 @@ async fn update_deleted_file() {
     let config = default_config();
 
     // Initial index.
-    let idx_summary = index_repository(
-        dir.path(),
-        &provider,
-        &config,
-        "mock-model",
-        |_| {},
-        &CancellationToken::new(),
-    )
-    .await
-    .unwrap();
+    let idx_summary = index_repository(dir.path(), &provider, &config, "mock-model")
+        .await
+        .unwrap();
     let initial_chunks = idx_summary.chunks_created as u64;
 
     // Delete a file.
     fs::remove_file(dir.path().join("lib.py")).unwrap();
 
     // Update.
-    let update_summary = update_repository(
-        dir.path(),
-        &provider,
-        &config,
-        "mock-model",
-        &CancellationToken::new(),
-    )
-    .await
-    .unwrap();
+    let update_summary = update_repository(dir.path(), &provider, &config, "mock-model")
+        .await
+        .unwrap();
 
     assert_eq!(update_summary.files_modified, 0);
     assert_eq!(update_summary.files_added, 0);
@@ -446,14 +447,7 @@ async fn update_without_index_fails() {
     let provider = MockProvider::new(8);
     let config = default_config();
 
-    let result = update_repository(
-        dir.path(),
-        &provider,
-        &config,
-        "mock-model",
-        &CancellationToken::new(),
-    )
-    .await;
+    let result = update_repository(dir.path(), &provider, &config, "mock-model").await;
     assert!(result.is_err());
     let err = result.unwrap_err().to_string();
     assert!(
@@ -470,16 +464,9 @@ async fn pre_cancelled_update_preserves_existing_index() {
 
     let provider = MockProvider::new(8);
     let config = default_config();
-    index_repository(
-        dir.path(),
-        &provider,
-        &config,
-        "mock-model",
-        |_| {},
-        &CancellationToken::new(),
-    )
-    .await
-    .unwrap();
+    index_repository(dir.path(), &provider, &config, "mock-model")
+        .await
+        .unwrap();
 
     let idx = index_dir(&dir.path().canonicalize().unwrap());
     let metadata = MetadataStore::open(&idx.join("metadata.db")).unwrap();
@@ -489,9 +476,15 @@ async fn pre_cancelled_update_preserves_existing_index() {
 
     let cancellation = CancellationToken::new();
     cancellation.cancel();
-    let error = update_repository(dir.path(), &provider, &config, "mock-model", &cancellation)
-        .await
-        .unwrap_err();
+    let error = crate::indexing::update_repository_with_cancellation(
+        dir.path(),
+        &provider,
+        &config,
+        "mock-model",
+        &cancellation,
+    )
+    .await
+    .unwrap_err();
 
     assert!(error.to_string().contains("operation cancelled"));
     let metadata = MetadataStore::open(&idx.join("metadata.db")).unwrap();
@@ -519,16 +512,9 @@ async fn update_matches_fresh_index() {
     let config = default_config();
 
     // Initial index.
-    index_repository(
-        dir.path(),
-        &provider,
-        &config,
-        "mock-model",
-        |_| {},
-        &CancellationToken::new(),
-    )
-    .await
-    .unwrap();
+    index_repository(dir.path(), &provider, &config, "mock-model")
+        .await
+        .unwrap();
 
     // Apply a sequence of changes.
     // 1. Modify main.rs
@@ -547,15 +533,9 @@ async fn update_matches_fresh_index() {
     .unwrap();
 
     // Run update.
-    let update_summary = update_repository(
-        dir.path(),
-        &provider,
-        &config,
-        "mock-model",
-        &CancellationToken::new(),
-    )
-    .await
-    .unwrap();
+    let update_summary = update_repository(dir.path(), &provider, &config, "mock-model")
+        .await
+        .unwrap();
     assert_eq!(update_summary.files_modified, 1);
     assert_eq!(update_summary.files_added, 1);
     assert_eq!(update_summary.files_deleted, 1);
@@ -568,16 +548,9 @@ async fn update_matches_fresh_index() {
     let updated_languages = updated_metadata.language_stats().unwrap();
 
     // Now do a fresh index of the same directory.
-    let _fresh_summary = index_repository(
-        dir.path(),
-        &provider,
-        &config,
-        "mock-model",
-        |_| {},
-        &CancellationToken::new(),
-    )
-    .await
-    .unwrap();
+    let _fresh_summary = index_repository(dir.path(), &provider, &config, "mock-model")
+        .await
+        .unwrap();
 
     let fresh_metadata = MetadataStore::open(&idx.join("metadata.db")).unwrap();
     let fresh_chunk_count = fresh_metadata.chunk_count().unwrap();
@@ -612,31 +585,18 @@ async fn update_mixed_add_modify_delete() {
     let config = default_config();
 
     // Initial index.
-    index_repository(
-        dir.path(),
-        &provider,
-        &config,
-        "mock-model",
-        |_| {},
-        &CancellationToken::new(),
-    )
-    .await
-    .unwrap();
+    index_repository(dir.path(), &provider, &config, "mock-model")
+        .await
+        .unwrap();
 
     // Modify a.rs, delete b.py, add d.ts.
     fs::write(dir.path().join("a.rs"), "fn a_updated() { 42 }").unwrap();
     fs::remove_file(dir.path().join("b.py")).unwrap();
     fs::write(dir.path().join("d.ts"), "function d(): void {}").unwrap();
 
-    let update_summary = update_repository(
-        dir.path(),
-        &provider,
-        &config,
-        "mock-model",
-        &CancellationToken::new(),
-    )
-    .await
-    .unwrap();
+    let update_summary = update_repository(dir.path(), &provider, &config, "mock-model")
+        .await
+        .unwrap();
 
     assert_eq!(update_summary.files_modified, 1);
     assert_eq!(update_summary.files_added, 1);
@@ -671,16 +631,9 @@ async fn update_vector_store_consistent() {
     let config = default_config();
 
     // Initial index.
-    index_repository(
-        dir.path(),
-        &provider,
-        &config,
-        "mock-model",
-        |_| {},
-        &CancellationToken::new(),
-    )
-    .await
-    .unwrap();
+    index_repository(dir.path(), &provider, &config, "mock-model")
+        .await
+        .unwrap();
 
     let idx = index_dir(&dir.path().canonicalize().unwrap());
     let initial_vec_count = VectorStore::open(&idx.join("vectors.db"), 8)
@@ -690,15 +643,9 @@ async fn update_vector_store_consistent() {
 
     // Add a file.
     fs::write(dir.path().join("lib.py"), "def lib(): return 1").unwrap();
-    update_repository(
-        dir.path(),
-        &provider,
-        &config,
-        "mock-model",
-        &CancellationToken::new(),
-    )
-    .await
-    .unwrap();
+    update_repository(dir.path(), &provider, &config, "mock-model")
+        .await
+        .unwrap();
 
     let after_add_vec_count = VectorStore::open(&idx.join("vectors.db"), 8)
         .unwrap()
@@ -711,15 +658,9 @@ async fn update_vector_store_consistent() {
 
     // Delete the added file.
     fs::remove_file(dir.path().join("lib.py")).unwrap();
-    update_repository(
-        dir.path(),
-        &provider,
-        &config,
-        "mock-model",
-        &CancellationToken::new(),
-    )
-    .await
-    .unwrap();
+    update_repository(dir.path(), &provider, &config, "mock-model")
+        .await
+        .unwrap();
 
     let after_del_vec_count = VectorStore::open(&idx.join("vectors.db"), 8)
         .unwrap()

--- a/crates/vera-core/src/lib.rs
+++ b/crates/vera-core/src/lib.rs
@@ -12,10 +12,13 @@
 //! - [`storage`] — Persistent storage backends (SQLite + sqlite-vec, Tantivy).
 //! - [`embedding`] — Embedding generation via external API providers.
 
+mod cancellation;
 pub mod chunk_text;
 pub mod corpus;
 pub mod discovery;
 pub mod embedding;
+
+pub use cancellation::CancellationToken;
 
 /// Install the rustls crypto provider (ring). Safe to call multiple times.
 pub fn init_tls() {

--- a/crates/vera-core/src/retrieval/hybrid.rs
+++ b/crates/vera-core/src/retrieval/hybrid.rs
@@ -197,6 +197,7 @@ pub async fn search_hybrid_reranked(
                 reranked = reranked.len(),
                 "reranking complete"
             );
+            reranked.extend(hybrid_results.into_iter().skip(rerank_candidates));
             reranked.truncate(limit);
             Ok((reranked, timings))
         }
@@ -837,6 +838,53 @@ mod tests {
         .unwrap();
 
         assert!(results.len() <= 2, "should respect the limit of 2");
+    }
+
+    #[tokio::test]
+    async fn reranking_preserves_unreranked_tail_for_later_filtering() {
+        use crate::embedding::test_helpers::MockProvider;
+        use crate::retrieval::apply_filters;
+        use crate::retrieval::reranker::test_helpers::MockReranker;
+        use crate::types::SearchFilters;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let (index_dir, dim) = setup_test_index(tmp.path()).await;
+        let provider = MockProvider::new(dim);
+        let reranker = MockReranker::new();
+
+        let (hybrid_results, _) =
+            search_hybrid(&index_dir, &provider, "function", 10, 60.0, dim, 50)
+                .await
+                .unwrap();
+        let first = hybrid_results
+            .first()
+            .expect("test index should have results");
+        let tail_candidate = hybrid_results
+            .iter()
+            .skip(1)
+            .find(|candidate| candidate.file_path != first.file_path)
+            .expect("test index should have a tail candidate from another file")
+            .clone();
+
+        let (reranked_results, _) = search_hybrid_reranked(
+            &index_dir, &provider, &reranker, "function", 10, 60.0, dim, 1, 50,
+        )
+        .await
+        .unwrap();
+        let filtered = apply_filters(
+            reranked_results,
+            &SearchFilters {
+                path_glob: Some(tail_candidate.file_path.clone()),
+                ..Default::default()
+            },
+            10,
+        );
+
+        assert!(filtered.iter().any(|result| {
+            result.file_path == tail_candidate.file_path
+                && result.line_start == tail_candidate.line_start
+                && result.line_end == tail_candidate.line_end
+        }));
     }
 
     // ── compute_vector_candidates tests ─────────────────────────────

--- a/crates/vera-core/src/retrieval/search_service.rs
+++ b/crates/vera-core/src/retrieval/search_service.rs
@@ -135,12 +135,8 @@ pub fn execute_search(
     let query_params = params_for_query_type(query_type);
     let rrf_k = query_params.rrf_k;
     let vector_candidates = effective_vector_candidates(fetch_limit, query_params);
-    let rerank_candidates = effective_rerank_candidates(
-        config.retrieval.rerank_candidates,
-        fetch_limit,
-        query,
-        filters,
-    );
+    let rerank_candidates =
+        effective_rerank_candidates(config.retrieval.rerank_candidates, result_limit);
 
     let ranking_stage = if reranker_enabled {
         RankingStage::PostRerank
@@ -160,7 +156,7 @@ pub fn execute_search(
             fetch_limit,
             rrf_k,
             stored_dim,
-            rerank_candidates.max(fetch_limit),
+            rerank_candidates,
             vector_candidates,
         ))?
     } else {
@@ -229,17 +225,8 @@ fn effective_vector_candidates(
     compute_vector_candidates(fetch_limit, query_params.vector_candidate_multiplier)
 }
 
-fn effective_rerank_candidates(
-    base: usize,
-    fetch_limit: usize,
-    query: &str,
-    filters: &SearchFilters,
-) -> usize {
-    if needs_structural_overfetch(query, filters) {
-        return base;
-    }
-
-    base.max(fetch_limit)
+fn effective_rerank_candidates(configured: usize, result_limit: usize) -> usize {
+    configured.max(result_limit)
 }
 
 fn should_skip_reranking(query: &str, filters: &SearchFilters) -> bool {
@@ -547,17 +534,12 @@ mod tests {
     }
 
     #[test]
-    fn effective_candidates_use_base_multipliers() {
-        // Rerank candidates just return base.max(fetch_limit)
-        let filters = SearchFilters::default();
+    fn rerank_candidate_depth_is_independent_of_fetch_depth() {
+        assert_eq!(effective_rerank_candidates(20, 5), 20);
         assert_eq!(
-            effective_rerank_candidates(50, 10, "anything", &filters),
-            50
-        );
-        assert_eq!(effective_rerank_candidates(5, 10, "anything", &filters), 10);
-        assert_eq!(
-            effective_rerank_candidates(50, 160, "file type detection and filtering", &filters),
-            50
+            effective_rerank_candidates(4, 5),
+            5,
+            "reranking must cover enough candidates to return the requested result count"
         );
 
         // Vector candidates use query_params multiplier without inflation

--- a/crates/vera-mcp/src/tools.rs
+++ b/crates/vera-mcp/src/tools.rs
@@ -364,11 +364,14 @@ fn handle_search_code(args: &Value) -> ToolCallResult {
             Ok(t) => t,
             Err(e) => return e,
         };
+        let cancellation = vera_core::CancellationToken::new();
         match rt.block_on(vera_core::indexing::index_repository(
             &cwd,
             &provider,
             &idx_config,
             &model_name,
+            |_| {},
+            &cancellation,
         )) {
             Ok(_) => {}
             Err(e) => return ToolCallResult::error(format!("Auto-indexing failed: {e}")),

--- a/crates/vera-mcp/src/tools.rs
+++ b/crates/vera-mcp/src/tools.rs
@@ -365,12 +365,11 @@ fn handle_search_code(args: &Value) -> ToolCallResult {
             Err(e) => return e,
         };
         let cancellation = vera_core::CancellationToken::new();
-        match rt.block_on(vera_core::indexing::index_repository(
+        match rt.block_on(vera_core::indexing::index_repository_with_cancellation(
             &cwd,
             &provider,
             &idx_config,
             &model_name,
-            |_| {},
             &cancellation,
         )) {
             Ok(_) => {}

--- a/crates/vera-mcp/src/watcher.rs
+++ b/crates/vera-mcp/src/watcher.rs
@@ -198,12 +198,14 @@ fn run_update_blocking(
     let (provider, model_name) = rt.block_on(vera_core::embedding::create_dynamic_provider(
         &config, backend,
     ))?;
+    let cancellation = vera_core::CancellationToken::new();
 
     rt.block_on(vera_core::indexing::update_repository(
         repo_path,
         &provider,
         &config,
         &model_name,
+        &cancellation,
     ))
 }
 

--- a/crates/vera-mcp/src/watcher.rs
+++ b/crates/vera-mcp/src/watcher.rs
@@ -200,7 +200,7 @@ fn run_update_blocking(
     ))?;
     let cancellation = vera_core::CancellationToken::new();
 
-    rt.block_on(vera_core::indexing::update_repository(
+    rt.block_on(vera_core::indexing::update_repository_with_cancellation(
         repo_path,
         &provider,
         &config,


### PR DESCRIPTION

---

**TL;DR:** Bounds remote embedding work, prevents unsafe timeout retries, keeps reranking within its configured budget, preserves the existing `vera-core` indexing APIs, and makes full indexing and incremental updates respond to Ctrl-C during synchronous discovery and parsing.

## Problem

API-backed indexing and updates permitted `batch_size * max_concurrent_requests` inputs to be active without a separate hard ceiling. With the remote-provider defaults, that could expose 1,024 inputs at once. If a proxy or inference server continues processing after its client disconnects, interrupting a run or retrying a timed-out request can leave a large amount of abandoned work behind.

The retry loop also applied four extra rate-limit retries to every retryable error. Request and response-body timeouts could therefore replay work that might still be executing upstream.

Retrieval overfetch could expand the number of results sent to the reranker beyond `retrieval.rerank_candidates`. Limiting the reranking window also discarded the remaining fetched candidates before post-filtering, so restrictive filters could miss valid results.

The original Ctrl-C handling only raced the indexing future against the signal future. Discovery and parsing are synchronous, so they could block polling long enough to prevent the signal branch from running.

The cancellation changes initially altered existing public `vera-core` function signatures, which would break downstream callers.

## Changes

- Add `embedding.max_in_flight_inputs`, defaulting to 16 and configurable with `VERA_MAX_IN_FLIGHT_INPUTS`.
- Normalize a configured or environment-provided in-flight limit of zero to one.
- Clamp embedding batch size and request concurrency in full indexing and incremental updates so their product cannot exceed the bound.
- Measure total overlapping inputs in the concurrency regression, not only the size of one request.
- Run the interrupt listener independently and share a cooperative cancellation token across CLI and core indexing stages.
- Give completed interrupt signals deterministic priority while preserving ordinary operation errors and avoiding waits on unrelated pending signals.
- Check cancellation between discovery entries, Rayon parsing work items, incremental-update reads, classification, and parsing.
- Prepare incremental updates before publication, then finish cross-store publication without interruption to avoid cancellation-induced partial updates.
- Propagate signal-listener setup errors instead of reporting them as cancellation.
- Classify request and response-body timeouts separately and do not retry them.
- Reserve four additional retries for rate-limit responses; ordinary transient failures retain the configured retry count.
- Set reranking depth to the larger of the configured candidate count and requested result limit, independent of retrieval overfetch.
- Preserve the unreranked fetch tail so post-filtering can still inspect every fetched candidate.
- Preserve the existing `discover_files`, `index_repository`, `index_repository_with_progress`, and `update_repository` signatures.
- Add explicit cancellation-aware variants and use them from the CLI and MCP paths that own cancellation tokens.

## Design notes

The compatibility entry points create an uncancelled token and delegate to the cancellation-aware variants, preserving their historical behavior. CLI and MCP operations use the explicit cancellation variants so Ctrl-C and lifecycle cancellation remain cooperative.

The default in-flight ceiling favors bounded backend liability over maximum throughput for arbitrary API providers. Deployments whose inference server can safely sustain more work can raise the limit explicitly.

Timeouts fail instead of being replayed because the client cannot know whether a proxy cancelled the upstream request. Connection failures and rate limits remain retryable, where replaying is less likely to duplicate active inference.

Cancellation is cooperative at file boundaries. A dedicated signal task can set the token while the main operation is inside synchronous work. Once final index publication begins, the operation completes that publication so metadata, vector, and BM25 stores are not interrupted by Ctrl-C.

Reranking remains bounded by its configured candidate budget. Candidates outside that window retain their original ordering and stay available to post-filters.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p vera-core -p vera-cli -p vera-mcp`: 756 tests passed
- `cargo clippy -p vera-core -p vera-cli -p vera-mcp --all-targets -- -D warnings -A clippy::useless_conversion -A clippy::len_zero -A clippy::cmp_owned`
- `git diff --check`
- Added regressions for zero-valued environment configuration, signal-listener errors, simultaneous interrupt readiness, external cancellation, response-body timeouts, total in-flight inputs, synchronous cancellation, cancellation before publication, and filtered retrieval from the unreranked tail.
- Indexed a 41-file Mesa sample through an OpenAI-compatible Lemonade endpoint: 35 parsed files, 355 chunks and embeddings, 42.5 seconds wall time, and 56 MiB peak RSS.
- During a larger cancellation test, Lemonade peaked at four processing plus four deferred items. Ctrl-C returned in about 80 ms, and 30 post-cancellation samples observed no processing or deferred backlog.

## Review focus

- Public compatibility entry points and their cancellation-aware variants
- `EmbeddingConfig::bounded_parallelism` and the overlapping-input regression
- `CancellationToken`, `cancel_on_signal`, and cancellation checks in discovery and parsing
- Incremental update preparation versus non-interruptible publication
- `OpenAiProvider` response-body timeout classification and retry accounting
- Reranking the configured window while retaining the fetched tail for filters


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added graceful cancellation for indexing, updating, discovery, and embedding operations when interrupted.
  - Added configurable limits for concurrent embedding inputs to improve resource management.
  - Added clearer timeout handling and refined retry behavior for embedding requests.

- **Bug Fixes**
  - Prevented cancelled updates from modifying existing indexes.
  - Improved search reranking consistency regardless of fetch depth.
  - Preserved relevant search results when applying path filters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->