### PR TITLE
feat(update): limit files per run

### DIFF
--- a/crates/vera-cli/src/commands/index.rs
+++ b/crates/vera-cli/src/commands/index.rs
@@ -7,25 +7,9 @@ use anyhow::{Context, bail};
 use vera_core::config::InferenceBackend;
 use vera_core::indexing::IndexProgress;
 
-use crate::helpers::{load_runtime_config, print_human_summary};
-
-async fn wait_for_interrupt() {
-    let _ = tokio::signal::ctrl_c().await;
-}
-
-async fn cancel_on_signal<T, Operation, Signal>(
-    operation: Operation,
-    signal: Signal,
-) -> anyhow::Result<T>
-where
-    Operation: std::future::Future<Output = anyhow::Result<T>>,
-    Signal: std::future::Future<Output = ()>,
-{
-    tokio::select! {
-        result = operation => result,
-        _ = signal => bail!("indexing cancelled"),
-    }
-}
+use crate::helpers::{
+    cancel_on_signal, load_runtime_config, print_human_summary, wait_for_interrupt,
+};
 
 /// Run the `vera index <path>` command.
 #[allow(clippy::too_many_arguments)]
@@ -107,6 +91,7 @@ pub fn execute(
             .block_on(cancel_on_signal(
                 vera_core::indexing::index_repository(repo_path, &provider, &config, &model_name),
                 wait_for_interrupt(),
+                "indexing",
             ))
             .context("indexing failed")?;
         return Ok(summary);
@@ -154,53 +139,9 @@ pub fn execute(
             on_progress,
         ),
         wait_for_interrupt(),
+        "indexing",
     ));
     multi.stop();
 
     result.context("indexing failed")
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use std::sync::atomic::{AtomicBool, Ordering};
-
-    struct DropMarker(Arc<AtomicBool>);
-
-    impl Drop for DropMarker {
-        fn drop(&mut self) {
-            self.0.store(true, Ordering::SeqCst);
-        }
-    }
-
-    #[tokio::test]
-    async fn operation_result_wins_before_cancellation() {
-        let result = cancel_on_signal(async { Ok::<_, anyhow::Error>(42) }, std::future::pending())
-            .await
-            .unwrap();
-
-        assert_eq!(result, 42);
-    }
-
-    #[tokio::test]
-    async fn cancellation_drops_in_flight_operation() {
-        let dropped = Arc::new(AtomicBool::new(false));
-        let dropped_for_operation = dropped.clone();
-        let (started_tx, started_rx) = tokio::sync::oneshot::channel();
-
-        let operation = async move {
-            let _marker = DropMarker(dropped_for_operation);
-            let _ = started_tx.send(());
-            std::future::pending::<()>().await;
-            Ok::<_, anyhow::Error>(())
-        };
-        let signal = async move {
-            let _ = started_rx.await;
-        };
-
-        let error = cancel_on_signal(operation, signal).await.unwrap_err();
-
-        assert!(error.to_string().contains("cancelled"));
-        assert!(dropped.load(Ordering::SeqCst));
-    }
 }

--- a/crates/vera-cli/src/commands/index.rs
+++ b/crates/vera-cli/src/commands/index.rs
@@ -9,6 +9,24 @@ use vera_core::indexing::IndexProgress;
 
 use crate::helpers::{load_runtime_config, print_human_summary};
 
+async fn wait_for_interrupt() {
+    let _ = tokio::signal::ctrl_c().await;
+}
+
+async fn cancel_on_signal<T, Operation, Signal>(
+    operation: Operation,
+    signal: Signal,
+) -> anyhow::Result<T>
+where
+    Operation: std::future::Future<Output = anyhow::Result<T>>,
+    Signal: std::future::Future<Output = ()>,
+{
+    tokio::select! {
+        result = operation => result,
+        _ = signal => bail!("indexing cancelled"),
+    }
+}
+
 /// Run the `vera index <path>` command.
 #[allow(clippy::too_many_arguments)]
 pub fn run(
@@ -86,11 +104,9 @@ pub fn execute(
     // Use progress bar for interactive (non-JSON) output.
     if json_output {
         let summary = rt
-            .block_on(vera_core::indexing::index_repository(
-                repo_path,
-                &provider,
-                &config,
-                &model_name,
+            .block_on(cancel_on_signal(
+                vera_core::indexing::index_repository(repo_path, &provider, &config, &model_name),
+                wait_for_interrupt(),
             ))
             .context("indexing failed")?;
         return Ok(summary);
@@ -129,17 +145,62 @@ pub fn execute(
         IndexProgress::StorageDone => {}
     };
 
-    let summary = rt
-        .block_on(vera_core::indexing::index_repository_with_progress(
+    let result = rt.block_on(cancel_on_signal(
+        vera_core::indexing::index_repository_with_progress(
             repo_path,
             &provider,
             &config,
             &model_name,
             on_progress,
-        ))
-        .context("indexing failed")?;
-
+        ),
+        wait_for_interrupt(),
+    ));
     multi.stop();
 
-    Ok(summary)
+    result.context("indexing failed")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    struct DropMarker(Arc<AtomicBool>);
+
+    impl Drop for DropMarker {
+        fn drop(&mut self) {
+            self.0.store(true, Ordering::SeqCst);
+        }
+    }
+
+    #[tokio::test]
+    async fn operation_result_wins_before_cancellation() {
+        let result = cancel_on_signal(async { Ok::<_, anyhow::Error>(42) }, std::future::pending())
+            .await
+            .unwrap();
+
+        assert_eq!(result, 42);
+    }
+
+    #[tokio::test]
+    async fn cancellation_drops_in_flight_operation() {
+        let dropped = Arc::new(AtomicBool::new(false));
+        let dropped_for_operation = dropped.clone();
+        let (started_tx, started_rx) = tokio::sync::oneshot::channel();
+
+        let operation = async move {
+            let _marker = DropMarker(dropped_for_operation);
+            let _ = started_tx.send(());
+            std::future::pending::<()>().await;
+            Ok::<_, anyhow::Error>(())
+        };
+        let signal = async move {
+            let _ = started_rx.await;
+        };
+
+        let error = cancel_on_signal(operation, signal).await.unwrap_err();
+
+        assert!(error.to_string().contains("cancelled"));
+        assert!(dropped.load(Ordering::SeqCst));
+    }
 }

--- a/crates/vera-cli/src/commands/update.rs
+++ b/crates/vera-cli/src/commands/update.rs
@@ -5,7 +5,7 @@ use std::path::Path;
 use anyhow::{Context, bail};
 use vera_core::config::InferenceBackend;
 
-use crate::helpers::load_runtime_config;
+use crate::helpers::{cancel_on_signal, load_runtime_config, wait_for_interrupt};
 
 /// Run the `vera update <path>` command.
 pub fn run(
@@ -78,11 +78,10 @@ pub fn run(
 
     // Run the incremental update pipeline.
     let summary = rt
-        .block_on(vera_core::indexing::update_repository(
-            repo_path,
-            &provider,
-            &config,
-            &model_name,
+        .block_on(cancel_on_signal(
+            vera_core::indexing::update_repository(repo_path, &provider, &config, &model_name),
+            wait_for_interrupt(),
+            "update",
         ))
         .context("update failed")?;
 

--- a/crates/vera-cli/src/commands/update.rs
+++ b/crates/vera-cli/src/commands/update.rs
@@ -1,9 +1,12 @@
 //! `vera update <path>` — Incrementally update the index.
 
+use std::io::IsTerminal;
 use std::path::Path;
+use std::sync::Arc;
 
 use anyhow::{Context, bail};
 use vera_core::config::InferenceBackend;
+use vera_core::indexing::UpdateProgress;
 
 use crate::helpers::{cancel_on_signal, load_runtime_config, wait_for_interrupt};
 
@@ -15,6 +18,7 @@ pub fn run(
     exclude: Vec<String>,
     no_ignore: bool,
     no_default_excludes: bool,
+    no_progress: bool,
 ) -> anyhow::Result<()> {
     let repo_path = Path::new(path);
 
@@ -76,14 +80,84 @@ pub fn run(
         }
     }
 
-    // Run the incremental update pipeline.
-    let summary = rt
-        .block_on(cancel_on_signal(
+    let show_progress = !json_output && !no_progress && std::io::stderr().is_terminal();
+    let summary = if show_progress {
+        let multi = cliclack::multi_progress("Updating...");
+        let spinner = multi.add(cliclack::spinner());
+        spinner.start("Discovering files...");
+        let embed_bar: Arc<cliclack::ProgressBar> = Arc::new(multi.add(cliclack::progress_bar(0)));
+        let embed_started = Arc::new(std::sync::atomic::AtomicBool::new(false));
+
+        let spinner_ref = &spinner;
+        let embed_bar_ref = embed_bar.clone();
+        let embed_started_ref = embed_started.clone();
+
+        let on_progress = move |event: UpdateProgress| match event {
+            UpdateProgress::DiscoveryDone { file_count } => {
+                spinner_ref.stop(format!("Discovered {file_count} files"));
+                spinner_ref.start("Classifying changes...");
+            }
+            UpdateProgress::ClassificationDone {
+                modified,
+                added,
+                deleted,
+                unchanged,
+            } => {
+                spinner_ref.stop(format!(
+                    "Changes: {added} added, {modified} modified, {deleted} deleted; \
+                     {unchanged} unchanged"
+                ));
+                spinner_ref.start("Parsing changed files...");
+            }
+            UpdateProgress::ParsingDone {
+                file_count,
+                chunk_count,
+            } => {
+                spinner_ref.stop(format!(
+                    "Parsed {file_count} changed files into {chunk_count} chunks"
+                ));
+            }
+            UpdateProgress::EmbeddingProgress { done, total } => {
+                if !embed_started_ref.load(std::sync::atomic::Ordering::Relaxed) {
+                    embed_started_ref.store(true, std::sync::atomic::Ordering::Relaxed);
+                    embed_bar_ref.set_length(total as u64);
+                    embed_bar_ref.start("Generating embeddings...");
+                }
+                embed_bar_ref.set_position(done as u64);
+                embed_bar_ref.set_message(format!("Generating embeddings ({done}/{total})"));
+            }
+            UpdateProgress::EmbeddingDone { count } => {
+                if embed_started_ref.load(std::sync::atomic::Ordering::Relaxed) {
+                    embed_bar_ref.stop(format!("Generated {count} embeddings"));
+                }
+                spinner_ref.start("Writing index updates...");
+            }
+            UpdateProgress::StorageDone => {
+                spinner_ref.stop("Wrote index updates");
+            }
+        };
+
+        let result = rt.block_on(cancel_on_signal(
+            vera_core::indexing::update_repository_with_progress(
+                repo_path,
+                &provider,
+                &config,
+                &model_name,
+                on_progress,
+            ),
+            wait_for_interrupt(),
+            "update",
+        ));
+        multi.stop();
+        result.context("update failed")?
+    } else {
+        rt.block_on(cancel_on_signal(
             vera_core::indexing::update_repository(repo_path, &provider, &config, &model_name),
             wait_for_interrupt(),
             "update",
         ))
-        .context("update failed")?;
+        .context("update failed")?
+    };
 
     // Output results.
     if json_output {

--- a/crates/vera-cli/src/commands/update.rs
+++ b/crates/vera-cli/src/commands/update.rs
@@ -6,20 +6,29 @@ use std::sync::Arc;
 
 use anyhow::{Context, bail};
 use vera_core::config::InferenceBackend;
-use vera_core::indexing::UpdateProgress;
+use vera_core::indexing::{UpdateOptions, UpdateProgress};
 
 use crate::helpers::{cancel_on_signal, load_runtime_config, wait_for_interrupt};
 
+pub struct CommandOptions {
+    pub backend: InferenceBackend,
+    pub exclude: Vec<String>,
+    pub no_ignore: bool,
+    pub no_default_excludes: bool,
+    pub no_progress: bool,
+    pub max_files: Option<usize>,
+}
+
 /// Run the `vera update <path>` command.
-pub fn run(
-    path: &str,
-    json_output: bool,
-    backend: InferenceBackend,
-    exclude: Vec<String>,
-    no_ignore: bool,
-    no_default_excludes: bool,
-    no_progress: bool,
-) -> anyhow::Result<()> {
+pub fn run(path: &str, json_output: bool, options: CommandOptions) -> anyhow::Result<()> {
+    let CommandOptions {
+        backend,
+        exclude,
+        no_ignore,
+        no_default_excludes,
+        no_progress,
+        max_files,
+    } = options;
     let repo_path = Path::new(path);
 
     if !repo_path.exists() {
@@ -81,6 +90,7 @@ pub fn run(
     }
 
     let show_progress = !json_output && !no_progress && std::io::stderr().is_terminal();
+    let options = UpdateOptions { max_files };
     let summary = if show_progress {
         let multi = cliclack::multi_progress("Updating...");
         let spinner = multi.add(cliclack::spinner());
@@ -102,10 +112,11 @@ pub fn run(
                 added,
                 deleted,
                 unchanged,
+                deferred,
             } => {
                 spinner_ref.stop(format!(
                     "Changes: {added} added, {modified} modified, {deleted} deleted; \
-                     {unchanged} unchanged"
+                     {unchanged} unchanged, {deferred} deferred"
                 ));
                 spinner_ref.start("Parsing changed files...");
             }
@@ -138,11 +149,12 @@ pub fn run(
         };
 
         let result = rt.block_on(cancel_on_signal(
-            vera_core::indexing::update_repository_with_progress(
+            vera_core::indexing::update_repository_with_options_and_progress(
                 repo_path,
                 &provider,
                 &config,
                 &model_name,
+                &options,
                 on_progress,
             ),
             wait_for_interrupt(),
@@ -152,7 +164,14 @@ pub fn run(
         result.context("update failed")?
     } else {
         rt.block_on(cancel_on_signal(
-            vera_core::indexing::update_repository(repo_path, &provider, &config, &model_name),
+            vera_core::indexing::update_repository_with_options_and_progress(
+                repo_path,
+                &provider,
+                &config,
+                &model_name,
+                &options,
+                |_| {},
+            ),
             wait_for_interrupt(),
             "update",
         ))
@@ -179,11 +198,15 @@ fn print_update_summary(summary: &vera_core::indexing::UpdateSummary) {
     println!("  Files added:     {}", summary.files_added);
     println!("  Files deleted:   {}", summary.files_deleted);
     println!("  Files unchanged: {}", summary.files_unchanged);
+    println!("  Files deferred:  {}", summary.files_deferred);
     println!("  Total chunks:    {}", summary.total_chunks);
     println!("  Elapsed time:    {:.2}s", summary.elapsed_secs);
 
-    let total_changed = summary.files_modified + summary.files_added + summary.files_deleted;
-    if total_changed == 0 {
+    let total_pending = summary.files_modified
+        + summary.files_added
+        + summary.files_deleted
+        + summary.files_deferred;
+    if total_pending == 0 {
         println!();
         println!("  Index is up to date — no changes detected.");
     }

--- a/crates/vera-cli/src/helpers.rs
+++ b/crates/vera-cli/src/helpers.rs
@@ -3,6 +3,30 @@
 use clap::Args;
 use serde::Serialize;
 
+/// Wait for the process interrupt used to cancel long-running CLI operations.
+pub async fn wait_for_interrupt() {
+    let _ = tokio::signal::ctrl_c().await;
+}
+
+/// Run an operation until it completes or an interrupt signal wins.
+///
+/// Dropping the operation future propagates cancellation through in-flight
+/// client requests instead of leaving the CLI runtime alive until they finish.
+pub async fn cancel_on_signal<T, Operation, Signal>(
+    operation: Operation,
+    signal: Signal,
+    operation_name: &str,
+) -> anyhow::Result<T>
+where
+    Operation: std::future::Future<Output = anyhow::Result<T>>,
+    Signal: std::future::Future<Output = ()>,
+{
+    tokio::select! {
+        result = operation => result,
+        _ = signal => anyhow::bail!("{operation_name} cancelled"),
+    }
+}
+
 /// Load the effective runtime configuration.
 pub fn load_runtime_config() -> anyhow::Result<vera_core::config::VeraConfig> {
     crate::state::load_runtime_config()
@@ -366,5 +390,57 @@ pub fn print_human_summary(summary: &vera_core::indexing::IndexSummary, verbose:
     if summary.files_parsed == 0 && summary.chunks_created == 0 {
         println!();
         println!("  No source files found to index.");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    struct DropMarker(Arc<AtomicBool>);
+
+    impl Drop for DropMarker {
+        fn drop(&mut self) {
+            self.0.store(true, Ordering::SeqCst);
+        }
+    }
+
+    #[tokio::test]
+    async fn operation_result_wins_before_cancellation() {
+        let result = cancel_on_signal(
+            async { Ok::<_, anyhow::Error>(42) },
+            std::future::pending(),
+            "test operation",
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(result, 42);
+    }
+
+    #[tokio::test]
+    async fn cancellation_drops_in_flight_operation() {
+        let dropped = Arc::new(AtomicBool::new(false));
+        let dropped_for_operation = dropped.clone();
+        let (started_tx, started_rx) = tokio::sync::oneshot::channel();
+
+        let operation = async move {
+            let _marker = DropMarker(dropped_for_operation);
+            let _ = started_tx.send(());
+            std::future::pending::<()>().await;
+            Ok::<_, anyhow::Error>(())
+        };
+        let signal = async move {
+            let _ = started_rx.await;
+        };
+
+        let error = cancel_on_signal(operation, signal, "test operation")
+            .await
+            .unwrap_err();
+
+        assert!(error.to_string().contains("test operation cancelled"));
+        assert!(dropped.load(Ordering::SeqCst));
     }
 }

--- a/crates/vera-cli/src/main.rs
+++ b/crates/vera-cli/src/main.rs
@@ -425,6 +425,7 @@ enum Commands {
                       Examples:\n  \
                       vera update .                  # Update current directory\n  \
                       vera update /path/to/repo      # Update a specific repo\n  \
+                      vera update . --max-files 250  # Bound work for this run\n  \
                       vera update . --json           # Output summary as JSON")]
     Update {
         /// Path to the directory to update.
@@ -443,6 +444,9 @@ enum Commands {
         /// Disable the interactive update progress display.
         #[arg(long)]
         no_progress: bool,
+        /// Maximum added or modified files to process in this run.
+        #[arg(long, value_name = "N")]
+        max_files: Option<std::num::NonZeroUsize>,
     },
 
     /// Show architecture overview of the indexed project.
@@ -790,16 +794,20 @@ fn main() {
             no_ignore,
             no_default_excludes,
             no_progress,
+            max_files,
         } => {
             tracing::info!(path = %path, "updating");
             commands::update::run(
                 &path,
                 cli.json,
-                backend.resolve(),
-                exclude,
-                no_ignore,
-                no_default_excludes,
-                no_progress,
+                commands::update::CommandOptions {
+                    backend: backend.resolve(),
+                    exclude,
+                    no_ignore,
+                    no_default_excludes,
+                    no_progress,
+                    max_files: max_files.map(std::num::NonZeroUsize::get),
+                },
             )
         }
         Commands::Overview => {
@@ -1190,6 +1198,23 @@ mod tests {
                 ..
             }
         ));
+    }
+
+    #[test]
+    fn cli_parses_update_max_files_flag() {
+        let cli = Cli::parse_from(["vera", "update", "/tmp/repo", "--max-files", "250"]);
+        assert!(matches!(
+            cli.command,
+            Commands::Update {
+                max_files: Some(max_files),
+                ..
+            } if max_files.get() == 250
+        ));
+    }
+
+    #[test]
+    fn cli_rejects_zero_update_max_files() {
+        assert!(Cli::try_parse_from(["vera", "update", "/tmp/repo", "--max-files", "0"]).is_err());
     }
 
     #[test]

--- a/crates/vera-cli/src/main.rs
+++ b/crates/vera-cli/src/main.rs
@@ -440,6 +440,9 @@ enum Commands {
         /// Disable smart default exclusions.
         #[arg(long)]
         no_default_excludes: bool,
+        /// Disable the interactive update progress display.
+        #[arg(long)]
+        no_progress: bool,
     },
 
     /// Show architecture overview of the indexed project.
@@ -786,6 +789,7 @@ fn main() {
             exclude,
             no_ignore,
             no_default_excludes,
+            no_progress,
         } => {
             tracing::info!(path = %path, "updating");
             commands::update::run(
@@ -795,6 +799,7 @@ fn main() {
                 exclude,
                 no_ignore,
                 no_default_excludes,
+                no_progress,
             )
         }
         Commands::Overview => {
@@ -1173,6 +1178,18 @@ mod tests {
     fn cli_parses_update_command() {
         let cli = Cli::parse_from(["vera", "update", "/tmp/repo"]);
         assert!(matches!(cli.command, Commands::Update { path, .. } if path == "/tmp/repo"));
+    }
+
+    #[test]
+    fn cli_parses_update_no_progress_flag() {
+        let cli = Cli::parse_from(["vera", "update", "/tmp/repo", "--no-progress"]);
+        assert!(matches!(
+            cli.command,
+            Commands::Update {
+                no_progress: true,
+                ..
+            }
+        ));
     }
 
     #[test]

--- a/crates/vera-core/src/config.rs
+++ b/crates/vera-core/src/config.rs
@@ -123,6 +123,11 @@ pub struct EmbeddingConfig {
     pub batch_size: usize,
     /// Maximum number of concurrent embedding API requests.
     pub max_concurrent_requests: usize,
+    /// Hard limit on the total number of embedding inputs that may be active
+    /// across concurrent API requests. This bounds abandoned backend work when
+    /// an indexing client disconnects.
+    #[serde(default = "default_max_in_flight_inputs")]
+    pub max_in_flight_inputs: usize,
     /// Request timeout in seconds.
     pub timeout_secs: u64,
     /// Maximum retries on transient errors.
@@ -150,12 +155,34 @@ impl Default for EmbeddingConfig {
         Self {
             batch_size: if is_local { 4 } else { 128 },
             max_concurrent_requests: if is_local { 1 } else { 8 },
+            max_in_flight_inputs: default_max_in_flight_inputs(),
             timeout_secs: 60,
             max_retries: 3,
             max_stored_dim: 1024,
             gpu_mem_limit_mb: 0,
             low_vram: false,
         }
+    }
+}
+
+fn default_max_in_flight_inputs() -> usize {
+    std::env::var("VERA_MAX_IN_FLIGHT_INPUTS")
+        .ok()
+        .and_then(|value| value.parse().ok())
+        .unwrap_or(16)
+}
+
+impl EmbeddingConfig {
+    /// Clamp configured batching so the product of batch size and concurrency
+    /// never exceeds `max_in_flight_inputs`.
+    pub fn bounded_parallelism(&self) -> (usize, usize) {
+        let max_in_flight = self.max_in_flight_inputs.max(1);
+        let batch_size = self.batch_size.max(1).min(max_in_flight);
+        let max_concurrent_requests = self
+            .max_concurrent_requests
+            .max(1)
+            .min((max_in_flight / batch_size).max(1));
+        (batch_size, max_concurrent_requests)
     }
 }
 
@@ -505,6 +532,36 @@ mod tests {
         assert!(config.retrieval.default_limit > 0);
         assert!(config.retrieval.rrf_k > 0.0);
         assert!(config.embedding.batch_size > 0);
+        assert!(config.embedding.max_in_flight_inputs > 0);
+        let (batch_size, concurrency) = config.embedding.bounded_parallelism();
+        assert!(
+            batch_size * concurrency <= config.embedding.max_in_flight_inputs,
+            "default embedding parallelism must respect its in-flight bound"
+        );
+    }
+
+    #[test]
+    fn embedding_parallelism_clamps_batch_and_concurrency() {
+        let config = EmbeddingConfig {
+            batch_size: 128,
+            max_concurrent_requests: 8,
+            max_in_flight_inputs: 16,
+            ..EmbeddingConfig::default()
+        };
+
+        assert_eq!(config.bounded_parallelism(), (16, 1));
+    }
+
+    #[test]
+    fn embedding_parallelism_normalizes_zero_values_to_one() {
+        let config = EmbeddingConfig {
+            batch_size: 0,
+            max_concurrent_requests: 0,
+            max_in_flight_inputs: 0,
+            ..EmbeddingConfig::default()
+        };
+
+        assert_eq!(config.bounded_parallelism(), (1, 1));
     }
 
     #[test]

--- a/crates/vera-core/src/embedding/provider.rs
+++ b/crates/vera-core/src/embedding/provider.rs
@@ -25,6 +25,11 @@ pub enum EmbeddingError {
     #[error("embedding API connection failed: {message}")]
     ConnectionError { message: String },
 
+    /// The request exceeded its client-side timeout. Retrying could duplicate
+    /// work when an upstream proxy continues processing after disconnect.
+    #[error("embedding API request timed out: {message}")]
+    TimeoutError { message: String },
+
     /// The API returned a non-auth, non-connection error.
     #[error("embedding API error (status {status}): {message}")]
     ApiError { status: u16, message: String },
@@ -251,20 +256,19 @@ impl OpenAiProvider {
             input: texts,
         };
 
-        // Rate limit errors get extra retries beyond the normal max.
-        let max_total_retries = self.config.max_retries + 4;
         let mut last_err = None;
-        for attempt in 0..=max_total_retries {
-            if attempt > 0 {
+        let mut retries = 0;
+        loop {
+            if retries > 0 {
                 let is_rate_limit = matches!(last_err, Some(EmbeddingError::RateLimitError { .. }));
                 let delay = if is_rate_limit {
                     // Rate limit: wait 2-4s with exponential backoff.
-                    Duration::from_secs(2 + u64::from(attempt.min(2)))
+                    Duration::from_secs(2 + u64::from(retries.min(2)))
                 } else {
-                    Duration::from_millis(500 * 2u64.pow(attempt.min(5) - 1))
+                    Duration::from_millis(500 * 2u64.pow(retries.min(5) - 1))
                 };
                 debug!(
-                    attempt,
+                    attempt = retries + 1,
                     delay_ms = delay.as_millis(),
                     rate_limited = is_rate_limit,
                     "retrying embedding API"
@@ -275,27 +279,28 @@ impl OpenAiProvider {
             match self.send_request(&url, &body).await {
                 Ok(vectors) => return Ok(vectors),
                 Err(e) => {
-                    // Don't retry auth or context-size errors; they won't
-                    // resolve with the same request. Context-size errors are
-                    // handled by embed_batch_resilient which truncates the text.
-                    if matches!(e, EmbeddingError::AuthError { .. }) || is_context_size_error(&e) {
+                    // A timed-out request may still be running behind a proxy,
+                    // so replaying it can create an abandoned-work queue.
+                    // Context-size errors are handled by embed_batch_resilient.
+                    if !is_retryable_error(&e) {
                         return Err(e);
                     }
+
+                    let retry_limit = retry_limit_for_error(&e, self.config.max_retries);
                     warn!(
-                        attempt = attempt + 1,
-                        max = max_total_retries + 1,
+                        attempt = retries + 1,
+                        max = retry_limit + 1,
                         error = %e,
                         "embedding API call failed"
                     );
+                    if retries >= retry_limit {
+                        return Err(e);
+                    }
                     last_err = Some(e);
+                    retries += 1;
                 }
             }
         }
-
-        Err(last_err.unwrap_or_else(|| EmbeddingError::ApiError {
-            status: 0,
-            message: "all retries exhausted".to_string(),
-        }))
     }
 
     /// Send a single HTTP request and parse the response.
@@ -313,7 +318,11 @@ impl OpenAiProvider {
             .send()
             .await
             .map_err(|e| {
-                if e.is_connect() || e.is_timeout() {
+                if e.is_timeout() {
+                    EmbeddingError::TimeoutError {
+                        message: format!("request to embedding API timed out: {e}"),
+                    }
+                } else if e.is_connect() {
                     EmbeddingError::ConnectionError {
                         message: format!("failed to connect to embedding API: {e}"),
                     }
@@ -355,13 +364,17 @@ impl OpenAiProvider {
             });
         }
 
-        let resp: EmbeddingResponse =
-            response
-                .json()
-                .await
-                .map_err(|e| EmbeddingError::ResponseError {
+        let resp: EmbeddingResponse = response.json().await.map_err(|e| {
+            if e.is_timeout() {
+                EmbeddingError::TimeoutError {
+                    message: format!("timed out reading embedding response: {e}"),
+                }
+            } else {
+                EmbeddingError::ResponseError {
                     message: format!("failed to parse embedding response: {e}"),
-                })?;
+                }
+            }
+        })?;
 
         // Sort by index to ensure correct ordering.
         let mut data = resp.data;
@@ -574,6 +587,21 @@ fn effective_batch_size<P: EmbeddingProvider>(provider: &P, configured_batch_siz
     }
 }
 
+fn retry_limit_for_error(error: &EmbeddingError, configured_retries: u32) -> u32 {
+    if matches!(error, EmbeddingError::RateLimitError { .. }) {
+        configured_retries.saturating_add(4)
+    } else {
+        configured_retries
+    }
+}
+
+fn is_retryable_error(error: &EmbeddingError) -> bool {
+    !matches!(
+        error,
+        EmbeddingError::AuthError { .. } | EmbeddingError::TimeoutError { .. }
+    ) && !is_context_size_error(error)
+}
+
 #[derive(Clone)]
 struct EmbeddingBatchItem {
     original_index: usize,
@@ -585,6 +613,7 @@ fn embedding_error_message(error: &EmbeddingError) -> &str {
     match error {
         EmbeddingError::AuthError { message }
         | EmbeddingError::ConnectionError { message }
+        | EmbeddingError::TimeoutError { message }
         | EmbeddingError::ApiError { message, .. }
         | EmbeddingError::RateLimitError { message }
         | EmbeddingError::ResponseError { message } => message,
@@ -1103,6 +1132,9 @@ pub(crate) mod test_helpers {
                             message: message.clone(),
                         }
                     }
+                    EmbeddingError::TimeoutError { message } => EmbeddingError::TimeoutError {
+                        message: message.clone(),
+                    },
                     EmbeddingError::ApiError { status, message } => EmbeddingError::ApiError {
                         status: *status,
                         message: message.clone(),
@@ -1263,5 +1295,34 @@ mod tests {
         assert_eq!(info.max_tokens, 120000);
         assert_eq!(info.input_tokens, Some(124417));
         assert!(is_context_size_error(&err));
+    }
+
+    #[test]
+    fn rate_limits_receive_only_the_documented_extra_retries() {
+        let error = EmbeddingError::RateLimitError {
+            message: "busy".into(),
+        };
+        assert_eq!(retry_limit_for_error(&error, 3), 7);
+    }
+
+    #[test]
+    fn ordinary_failures_do_not_receive_rate_limit_retries() {
+        let error = EmbeddingError::ConnectionError {
+            message: "refused".into(),
+        };
+        assert_eq!(retry_limit_for_error(&error, 3), 3);
+    }
+
+    #[test]
+    fn timeouts_are_not_retried() {
+        let timeout = EmbeddingError::TimeoutError {
+            message: "upstream may still be working".into(),
+        };
+        let connection = EmbeddingError::ConnectionError {
+            message: "connection refused".into(),
+        };
+
+        assert!(!is_retryable_error(&timeout));
+        assert!(is_retryable_error(&connection));
     }
 }

--- a/crates/vera-core/src/indexing/mod.rs
+++ b/crates/vera-core/src/indexing/mod.rs
@@ -13,7 +13,9 @@ pub use pipeline::{
     FileError, IndexProgress, IndexSummary, index_dir, index_repository,
     index_repository_with_progress,
 };
-pub use update::{UpdateSummary, content_hash, update_repository};
+pub use update::{
+    UpdateProgress, UpdateSummary, content_hash, update_repository, update_repository_with_progress,
+};
 
 /// Truncate embedding vectors to at most `max_dim` dimensions.
 ///

--- a/crates/vera-core/src/indexing/mod.rs
+++ b/crates/vera-core/src/indexing/mod.rs
@@ -14,7 +14,8 @@ pub use pipeline::{
     index_repository_with_progress,
 };
 pub use update::{
-    UpdateProgress, UpdateSummary, content_hash, update_repository, update_repository_with_progress,
+    UpdateOptions, UpdateProgress, UpdateSummary, content_hash, update_repository,
+    update_repository_with_options_and_progress, update_repository_with_progress,
 };
 
 /// Truncate embedding vectors to at most `max_dim` dimensions.

--- a/crates/vera-core/src/indexing/pipeline.rs
+++ b/crates/vera-core/src/indexing/pipeline.rs
@@ -204,8 +204,19 @@ where
     }
 
     // ── 4. Generate embeddings (concurrent batches) ──────────────
-    let batch_size = config.embedding.batch_size;
-    let max_concurrent_requests = config.embedding.max_concurrent_requests;
+    let (batch_size, max_concurrent_requests) = config.embedding.bounded_parallelism();
+    if batch_size != config.embedding.batch_size
+        || max_concurrent_requests != config.embedding.max_concurrent_requests
+    {
+        info!(
+            configured_batch_size = config.embedding.batch_size,
+            configured_concurrency = config.embedding.max_concurrent_requests,
+            max_in_flight_inputs = config.embedding.max_in_flight_inputs,
+            batch_size,
+            max_concurrent_requests,
+            "clamped embedding parallelism to the in-flight input bound"
+        );
+    }
 
     let progress_cb = |done: usize, total: usize| {
         on_progress(IndexProgress::EmbeddingProgress { done, total });

--- a/crates/vera-core/src/indexing/update.rs
+++ b/crates/vera-core/src/indexing/update.rs
@@ -41,10 +41,19 @@ pub struct UpdateSummary {
     pub files_deleted: usize,
     /// Files that were unchanged (skipped).
     pub files_unchanged: usize,
+    /// Added or modified files deferred by the per-run file limit.
+    pub files_deferred: usize,
     /// Total chunks after the update.
     pub total_chunks: u64,
     /// Wall-clock elapsed time in seconds.
     pub elapsed_secs: f64,
+}
+
+/// Optional controls for a single incremental update run.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct UpdateOptions {
+    /// Maximum added or modified files to process. Deletions are always applied.
+    pub max_files: Option<usize>,
 }
 
 /// Progress events emitted during an incremental update.
@@ -58,6 +67,7 @@ pub enum UpdateProgress {
         added: usize,
         deleted: usize,
         unchanged: usize,
+        deferred: usize,
     },
     /// Changed files have been parsed into chunks.
     ParsingDone {
@@ -136,7 +146,15 @@ pub async fn update_repository<P: EmbeddingProvider>(
     config: &VeraConfig,
     model_name: &str,
 ) -> Result<UpdateSummary> {
-    update_repository_with_progress(repo_path, provider, config, model_name, |_| {}).await
+    update_repository_with_options_and_progress(
+        repo_path,
+        provider,
+        config,
+        model_name,
+        &UpdateOptions::default(),
+        |_| {},
+    )
+    .await
 }
 
 /// Incrementally update an index with progress reporting via a callback.
@@ -145,6 +163,30 @@ pub async fn update_repository_with_progress<P, F>(
     provider: &P,
     config: &VeraConfig,
     model_name: &str,
+    on_progress: F,
+) -> Result<UpdateSummary>
+where
+    P: EmbeddingProvider,
+    F: Fn(UpdateProgress) + Send + Sync,
+{
+    update_repository_with_options_and_progress(
+        repo_path,
+        provider,
+        config,
+        model_name,
+        &UpdateOptions::default(),
+        on_progress,
+    )
+    .await
+}
+
+/// Incrementally update an index with per-run options and progress reporting.
+pub async fn update_repository_with_options_and_progress<P, F>(
+    repo_path: &Path,
+    provider: &P,
+    config: &VeraConfig,
+    model_name: &str,
+    options: &UpdateOptions,
     on_progress: F,
 ) -> Result<UpdateSummary>
 where
@@ -281,11 +323,30 @@ where
         }
     }
 
+    modified.sort_by(|left, right| left.0.cmp(&right.0));
+    added.sort_by(|left, right| left.0.cmp(&right.0));
+    deleted.sort();
+
+    let pending_files = modified.len() + added.len();
+    let files_to_process = options
+        .max_files
+        .unwrap_or(pending_files)
+        .min(pending_files);
+    let modified_to_process = modified.len().min(files_to_process);
+    let added_to_process = added
+        .len()
+        .min(files_to_process.saturating_sub(modified_to_process));
+    let files_deferred = pending_files - modified_to_process - added_to_process;
+    modified.truncate(modified_to_process);
+    added.truncate(added_to_process);
+
     info!(
         modified = modified.len(),
         added = added.len(),
         deleted = deleted.len(),
         unchanged,
+        deferred = files_deferred,
+        max_files = options.max_files,
         "file classification complete"
     );
     on_progress(UpdateProgress::ClassificationDone {
@@ -293,6 +354,7 @@ where
         added: added.len(),
         deleted: deleted.len(),
         unchanged,
+        deferred: files_deferred,
     });
 
     // ── 4. Process deletions ─────────────────────────────────────
@@ -490,6 +552,7 @@ where
         files_added: added.len(),
         files_deleted: deleted.len(),
         files_unchanged: unchanged,
+        files_deferred,
         total_chunks,
         elapsed_secs: start.elapsed().as_secs_f64(),
     };
@@ -499,6 +562,7 @@ where
         added = summary.files_added,
         deleted = summary.files_deleted,
         unchanged = summary.files_unchanged,
+        deferred = summary.files_deferred,
         total_chunks = summary.total_chunks,
         elapsed = %format!("{:.2}s", summary.elapsed_secs),
         "incremental update complete"

--- a/crates/vera-core/src/indexing/update.rs
+++ b/crates/vera-core/src/indexing/update.rs
@@ -21,7 +21,7 @@ use tracing::{debug, info, warn};
 
 use crate::config::VeraConfig;
 use crate::discovery;
-use crate::embedding::{EmbeddingProvider, embed_chunks_concurrent};
+use crate::embedding::{EmbeddingProvider, embed_chunks_concurrent_with_progress};
 use crate::parsing;
 use crate::storage::bm25::{Bm25Document, Bm25Index};
 use crate::storage::metadata::MetadataStore;
@@ -45,6 +45,31 @@ pub struct UpdateSummary {
     pub total_chunks: u64,
     /// Wall-clock elapsed time in seconds.
     pub elapsed_secs: f64,
+}
+
+/// Progress events emitted during an incremental update.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum UpdateProgress {
+    /// File discovery complete.
+    DiscoveryDone { file_count: usize },
+    /// Existing and discovered files have been classified.
+    ClassificationDone {
+        modified: usize,
+        added: usize,
+        deleted: usize,
+        unchanged: usize,
+    },
+    /// Changed files have been parsed into chunks.
+    ParsingDone {
+        file_count: usize,
+        chunk_count: usize,
+    },
+    /// An embedding batch finished.
+    EmbeddingProgress { done: usize, total: usize },
+    /// All update embeddings have been generated.
+    EmbeddingDone { count: usize },
+    /// Updated index artifacts have been written to disk.
+    StorageDone,
 }
 
 /// Compute a SHA-256 content hash for a file's contents.
@@ -111,6 +136,21 @@ pub async fn update_repository<P: EmbeddingProvider>(
     config: &VeraConfig,
     model_name: &str,
 ) -> Result<UpdateSummary> {
+    update_repository_with_progress(repo_path, provider, config, model_name, |_| {}).await
+}
+
+/// Incrementally update an index with progress reporting via a callback.
+pub async fn update_repository_with_progress<P, F>(
+    repo_path: &Path,
+    provider: &P,
+    config: &VeraConfig,
+    model_name: &str,
+    on_progress: F,
+) -> Result<UpdateSummary>
+where
+    P: EmbeddingProvider,
+    F: Fn(UpdateProgress) + Send + Sync,
+{
     let start = Instant::now();
 
     // ── 1. Validate path ─────────────────────────────────────────
@@ -138,6 +178,9 @@ pub async fn update_repository<P: EmbeddingProvider>(
     // ── 2. Discover current files on disk ────────────────────────
     let disc =
         discovery::discover_files(&repo_root, &config.indexing).context("file discovery failed")?;
+    on_progress(UpdateProgress::DiscoveryDone {
+        file_count: disc.files.len(),
+    });
 
     // ── 3. Load stored hashes and classify files ─────────────────
     let metadata_path = idx_dir.join("metadata.db");
@@ -245,6 +288,12 @@ pub async fn update_repository<P: EmbeddingProvider>(
         unchanged,
         "file classification complete"
     );
+    on_progress(UpdateProgress::ClassificationDone {
+        modified: modified.len(),
+        added: added.len(),
+        deleted: deleted.len(),
+        unchanged,
+    });
 
     // ── 4. Process deletions ─────────────────────────────────────
     if !deleted.is_empty() {
@@ -333,6 +382,10 @@ pub async fn update_repository<P: EmbeddingProvider>(
             debug!(file = %rel_path, chunks = chunks.len(), refs = refs.len(), "parsed file");
             all_chunks.extend(chunks);
         }
+        on_progress(UpdateProgress::ParsingDone {
+            file_count: files_to_index.len(),
+            chunk_count: all_chunks.len(),
+        });
 
         if !all_chunks.is_empty() {
             // Generate embeddings.
@@ -349,15 +402,22 @@ pub async fn update_repository<P: EmbeddingProvider>(
                     "clamped update embedding parallelism to the in-flight input bound"
                 );
             }
-            let mut embeddings = embed_chunks_concurrent(
+            let progress_cb = |done: usize, total: usize| {
+                on_progress(UpdateProgress::EmbeddingProgress { done, total });
+            };
+            let mut embeddings = embed_chunks_concurrent_with_progress(
                 provider,
                 &all_chunks,
                 batch_size,
                 max_concurrent_requests,
                 config.indexing.max_chunk_bytes,
+                progress_cb,
             )
             .await
             .context("embedding generation failed")?;
+            on_progress(UpdateProgress::EmbeddingDone {
+                count: embeddings.len(),
+            });
 
             // Truncate if needed.
             let final_stored_dim = super::truncate_embeddings(&mut embeddings, stored_dim);
@@ -401,6 +461,8 @@ pub async fn update_repository<P: EmbeddingProvider>(
             bm25_index
                 .insert_batch(&bm25_docs)
                 .context("failed to insert updated BM25 documents")?;
+        } else {
+            on_progress(UpdateProgress::EmbeddingDone { count: 0 });
         }
 
         // Update file hashes for all indexed files.
@@ -409,12 +471,19 @@ pub async fn update_repository<P: EmbeddingProvider>(
                 .set_file_hash(rel_path, hash)
                 .context("failed to update file hash")?;
         }
+    } else {
+        on_progress(UpdateProgress::ParsingDone {
+            file_count: 0,
+            chunk_count: 0,
+        });
+        on_progress(UpdateProgress::EmbeddingDone { count: 0 });
     }
 
     // ── 6. Get final counts ──────────────────────────────────────
     let total_chunks = metadata_store
         .chunk_count()
         .context("failed to count chunks")?;
+    on_progress(UpdateProgress::StorageDone);
 
     let summary = UpdateSummary {
         files_modified: modified.len(),

--- a/crates/vera-core/src/indexing/update.rs
+++ b/crates/vera-core/src/indexing/update.rs
@@ -336,11 +336,24 @@ pub async fn update_repository<P: EmbeddingProvider>(
 
         if !all_chunks.is_empty() {
             // Generate embeddings.
+            let (batch_size, max_concurrent_requests) = config.embedding.bounded_parallelism();
+            if batch_size != config.embedding.batch_size
+                || max_concurrent_requests != config.embedding.max_concurrent_requests
+            {
+                info!(
+                    configured_batch_size = config.embedding.batch_size,
+                    configured_concurrency = config.embedding.max_concurrent_requests,
+                    max_in_flight_inputs = config.embedding.max_in_flight_inputs,
+                    batch_size,
+                    max_concurrent_requests,
+                    "clamped update embedding parallelism to the in-flight input bound"
+                );
+            }
             let mut embeddings = embed_chunks_concurrent(
                 provider,
                 &all_chunks,
-                config.embedding.batch_size,
-                config.embedding.max_concurrent_requests,
+                batch_size,
+                max_concurrent_requests,
                 config.indexing.max_chunk_bytes,
             )
             .await

--- a/crates/vera-core/src/indexing/update_tests.rs
+++ b/crates/vera-core/src/indexing/update_tests.rs
@@ -8,7 +8,9 @@ use tempfile::TempDir;
 use crate::config::VeraConfig;
 use crate::embedding::test_helpers::MockProvider;
 use crate::embedding::{EmbeddingError, EmbeddingProvider};
-use crate::indexing::{index_dir, index_repository, update_repository};
+use crate::indexing::{
+    UpdateProgress, index_dir, index_repository, update_repository, update_repository_with_progress,
+};
 use crate::storage::bm25::Bm25Index;
 use crate::storage::metadata::MetadataStore;
 use crate::storage::vector::VectorStore;
@@ -115,7 +117,7 @@ async fn update_no_changes() {
 }
 
 #[tokio::test]
-async fn update_respects_max_in_flight_input_bound() {
+async fn update_reports_progress_and_respects_max_in_flight_input_bound() {
     let dir = TempDir::new().unwrap();
     fs::write(dir.path().join("main.rs"), "fn main() {}\n").unwrap();
 
@@ -135,12 +137,39 @@ async fn update_respects_max_in_flight_input_bound() {
     config.embedding.max_concurrent_requests = 8;
     config.embedding.max_in_flight_inputs = 2;
 
-    let summary = update_repository(dir.path(), &provider, &config, "mock-model")
+    let events = std::sync::Mutex::new(Vec::new());
+    let summary =
+        update_repository_with_progress(dir.path(), &provider, &config, "mock-model", |event| {
+            events.lock().unwrap().push(event)
+        })
         .await
         .unwrap();
 
     assert_eq!(summary.files_added, 3);
     assert_eq!(provider.largest_batch.load(Ordering::SeqCst), 2);
+
+    let events = events.into_inner().unwrap();
+    assert!(matches!(
+        events.first(),
+        Some(UpdateProgress::DiscoveryDone { .. })
+    ));
+    assert!(
+        events
+            .iter()
+            .any(|event| matches!(event, UpdateProgress::ClassificationDone { added: 3, .. }))
+    );
+    assert!(events.iter().any(|event| matches!(
+        event,
+        UpdateProgress::ParsingDone {
+            file_count: 3,
+            chunk_count
+        } if *chunk_count >= 3
+    )));
+    assert!(events.iter().any(|event| matches!(
+        event,
+        UpdateProgress::EmbeddingProgress { done, total } if done == total && *total >= 3
+    )));
+    assert!(matches!(events.last(), Some(UpdateProgress::StorageDone)));
 }
 
 // ── Update: file modified ───────────────────────────────────────────

--- a/crates/vera-core/src/indexing/update_tests.rs
+++ b/crates/vera-core/src/indexing/update_tests.rs
@@ -1,11 +1,13 @@
 //! Tests for incremental update logic.
 
 use std::fs;
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 use tempfile::TempDir;
 
 use crate::config::VeraConfig;
 use crate::embedding::test_helpers::MockProvider;
+use crate::embedding::{EmbeddingError, EmbeddingProvider};
 use crate::indexing::{index_dir, index_repository, update_repository};
 use crate::storage::bm25::Bm25Index;
 use crate::storage::metadata::MetadataStore;
@@ -15,6 +17,42 @@ use super::content_hash;
 
 fn default_config() -> VeraConfig {
     VeraConfig::default()
+}
+
+struct BatchBoundProvider {
+    max_batch_size: usize,
+    largest_batch: AtomicUsize,
+}
+
+impl BatchBoundProvider {
+    fn new(max_batch_size: usize) -> Self {
+        Self {
+            max_batch_size,
+            largest_batch: AtomicUsize::new(0),
+        }
+    }
+}
+
+impl EmbeddingProvider for BatchBoundProvider {
+    async fn embed_batch(&self, texts: &[String]) -> Result<Vec<Vec<f32>>, EmbeddingError> {
+        self.largest_batch.fetch_max(texts.len(), Ordering::SeqCst);
+        if texts.len() > self.max_batch_size {
+            return Err(EmbeddingError::ApiError {
+                status: 400,
+                message: format!(
+                    "batch contained {} inputs, limit is {}",
+                    texts.len(),
+                    self.max_batch_size
+                ),
+            });
+        }
+
+        Ok(vec![vec![0.0; 8]; texts.len()])
+    }
+
+    fn expected_dim(&self) -> Option<usize> {
+        Some(8)
+    }
 }
 
 // ── Content hash tests ──────────────────────────────────────────────
@@ -74,6 +112,35 @@ async fn update_no_changes() {
         update_summary.total_chunks,
         idx_summary.chunks_created as u64
     );
+}
+
+#[tokio::test]
+async fn update_respects_max_in_flight_input_bound() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("main.rs"), "fn main() {}\n").unwrap();
+
+    let initial_provider = MockProvider::new(8);
+    let initial_config = default_config();
+    index_repository(dir.path(), &initial_provider, &initial_config, "mock-model")
+        .await
+        .unwrap();
+
+    for name in ["one.rs", "two.rs", "three.rs"] {
+        fs::write(dir.path().join(name), format!("fn {}() {{}}\n", &name[..3])).unwrap();
+    }
+
+    let provider = BatchBoundProvider::new(2);
+    let mut config = default_config();
+    config.embedding.batch_size = 128;
+    config.embedding.max_concurrent_requests = 8;
+    config.embedding.max_in_flight_inputs = 2;
+
+    let summary = update_repository(dir.path(), &provider, &config, "mock-model")
+        .await
+        .unwrap();
+
+    assert_eq!(summary.files_added, 3);
+    assert_eq!(provider.largest_batch.load(Ordering::SeqCst), 2);
 }
 
 // ── Update: file modified ───────────────────────────────────────────

--- a/crates/vera-core/src/indexing/update_tests.rs
+++ b/crates/vera-core/src/indexing/update_tests.rs
@@ -9,7 +9,8 @@ use crate::config::VeraConfig;
 use crate::embedding::test_helpers::MockProvider;
 use crate::embedding::{EmbeddingError, EmbeddingProvider};
 use crate::indexing::{
-    UpdateProgress, index_dir, index_repository, update_repository, update_repository_with_progress,
+    UpdateOptions, UpdateProgress, index_dir, index_repository, update_repository,
+    update_repository_with_options_and_progress, update_repository_with_progress,
 };
 use crate::storage::bm25::Bm25Index;
 use crate::storage::metadata::MetadataStore;
@@ -109,6 +110,7 @@ async fn update_no_changes() {
     assert_eq!(update_summary.files_modified, 0);
     assert_eq!(update_summary.files_added, 0);
     assert_eq!(update_summary.files_deleted, 0);
+    assert_eq!(update_summary.files_deferred, 0);
     assert!(update_summary.files_unchanged > 0);
     assert_eq!(
         update_summary.total_chunks,
@@ -146,6 +148,7 @@ async fn update_reports_progress_and_respects_max_in_flight_input_bound() {
         .unwrap();
 
     assert_eq!(summary.files_added, 3);
+    assert_eq!(summary.files_deferred, 0);
     assert_eq!(provider.largest_batch.load(Ordering::SeqCst), 2);
 
     let events = events.into_inner().unwrap();
@@ -170,6 +173,101 @@ async fn update_reports_progress_and_respects_max_in_flight_input_bound() {
         UpdateProgress::EmbeddingProgress { done, total } if done == total && *total >= 3
     )));
     assert!(matches!(events.last(), Some(UpdateProgress::StorageDone)));
+}
+
+#[tokio::test]
+async fn update_max_files_defers_and_resumes_in_path_order() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("main.rs"), "fn main() {}\n").unwrap();
+
+    let provider = MockProvider::new(8);
+    let config = default_config();
+    index_repository(dir.path(), &provider, &config, "mock-model")
+        .await
+        .unwrap();
+
+    for name in ["gamma.rs", "alpha.rs", "beta.rs"] {
+        fs::write(dir.path().join(name), format!("fn {}() {{}}\n", &name[..4])).unwrap();
+    }
+
+    let options = UpdateOptions { max_files: Some(2) };
+    let first = update_repository_with_options_and_progress(
+        dir.path(),
+        &provider,
+        &config,
+        "mock-model",
+        &options,
+        |_| {},
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(first.files_added, 2);
+    assert_eq!(first.files_deferred, 1);
+    let idx = index_dir(&dir.path().canonicalize().unwrap());
+    let metadata = MetadataStore::open(&idx.join("metadata.db")).unwrap();
+    assert!(metadata.get_file_hash("alpha.rs").unwrap().is_some());
+    assert!(metadata.get_file_hash("beta.rs").unwrap().is_some());
+    assert!(metadata.get_file_hash("gamma.rs").unwrap().is_none());
+
+    let second = update_repository_with_options_and_progress(
+        dir.path(),
+        &provider,
+        &config,
+        "mock-model",
+        &options,
+        |_| {},
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(second.files_added, 1);
+    assert_eq!(second.files_deferred, 0);
+    assert!(metadata.get_file_hash("gamma.rs").unwrap().is_some());
+}
+
+#[tokio::test]
+async fn update_max_files_prioritizes_modifications_and_always_deletes() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("modified.rs"), "fn value() -> u8 { 1 }\n").unwrap();
+    fs::write(dir.path().join("deleted.rs"), "fn obsolete() {}\n").unwrap();
+
+    let provider = MockProvider::new(8);
+    let config = default_config();
+    index_repository(dir.path(), &provider, &config, "mock-model")
+        .await
+        .unwrap();
+
+    let modified_content = "fn value() -> u8 { 2 }\n";
+    fs::write(dir.path().join("modified.rs"), modified_content).unwrap();
+    fs::remove_file(dir.path().join("deleted.rs")).unwrap();
+    fs::write(dir.path().join("added.rs"), "fn added() {}\n").unwrap();
+
+    let options = UpdateOptions { max_files: Some(1) };
+    let summary = update_repository_with_options_and_progress(
+        dir.path(),
+        &provider,
+        &config,
+        "mock-model",
+        &options,
+        |_| {},
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(summary.files_modified, 1);
+    assert_eq!(summary.files_added, 0);
+    assert_eq!(summary.files_deleted, 1);
+    assert_eq!(summary.files_deferred, 1);
+
+    let idx = index_dir(&dir.path().canonicalize().unwrap());
+    let metadata = MetadataStore::open(&idx.join("metadata.db")).unwrap();
+    assert_eq!(
+        metadata.get_file_hash("modified.rs").unwrap().as_deref(),
+        Some(content_hash(modified_content).as_str())
+    );
+    assert!(metadata.get_file_hash("deleted.rs").unwrap().is_none());
+    assert!(metadata.get_file_hash("added.rs").unwrap().is_none());
 }
 
 // ── Update: file modified ───────────────────────────────────────────

--- a/crates/vera-core/src/retrieval/search_service.rs
+++ b/crates/vera-core/src/retrieval/search_service.rs
@@ -135,12 +135,8 @@ pub fn execute_search(
     let query_params = params_for_query_type(query_type);
     let rrf_k = query_params.rrf_k;
     let vector_candidates = effective_vector_candidates(fetch_limit, query_params);
-    let rerank_candidates = effective_rerank_candidates(
-        config.retrieval.rerank_candidates,
-        fetch_limit,
-        query,
-        filters,
-    );
+    let rerank_candidates =
+        effective_rerank_candidates(config.retrieval.rerank_candidates, result_limit);
 
     let ranking_stage = if reranker_enabled {
         RankingStage::PostRerank
@@ -160,7 +156,7 @@ pub fn execute_search(
             fetch_limit,
             rrf_k,
             stored_dim,
-            rerank_candidates.max(fetch_limit),
+            rerank_candidates,
             vector_candidates,
         ))?
     } else {
@@ -229,17 +225,8 @@ fn effective_vector_candidates(
     compute_vector_candidates(fetch_limit, query_params.vector_candidate_multiplier)
 }
 
-fn effective_rerank_candidates(
-    base: usize,
-    fetch_limit: usize,
-    query: &str,
-    filters: &SearchFilters,
-) -> usize {
-    if needs_structural_overfetch(query, filters) {
-        return base;
-    }
-
-    base.max(fetch_limit)
+fn effective_rerank_candidates(configured: usize, result_limit: usize) -> usize {
+    configured.max(result_limit)
 }
 
 fn should_skip_reranking(query: &str, filters: &SearchFilters) -> bool {
@@ -547,17 +534,12 @@ mod tests {
     }
 
     #[test]
-    fn effective_candidates_use_base_multipliers() {
-        // Rerank candidates just return base.max(fetch_limit)
-        let filters = SearchFilters::default();
+    fn rerank_candidate_depth_is_independent_of_fetch_depth() {
+        assert_eq!(effective_rerank_candidates(20, 5), 20);
         assert_eq!(
-            effective_rerank_candidates(50, 10, "anything", &filters),
-            50
-        );
-        assert_eq!(effective_rerank_candidates(5, 10, "anything", &filters), 10);
-        assert_eq!(
-            effective_rerank_candidates(50, 160, "file type detection and filtering", &filters),
-            50
+            effective_rerank_candidates(4, 5),
+            5,
+            "reranking must cover enough candidates to return the requested result count"
         );
 
         // Vector candidates use query_params multiplier without inflation


### PR DESCRIPTION
**TL;DR:** Adds `vera update --max-files N` so large incremental backfills can finish in bounded, resumable runs. Deferred files remain eligible for the next update instead of being mistaken for deletions.

Depends on #30, which depends on #29. This branch is the third layer of the local `gh stack`; until its parents merge, the child-only change is commit `ada51b6`.

## Behavior

- Classifies the complete repository before applying the per-run budget.
- Processes modified files before newly added files, with deterministic path ordering inside each group.
- Always applies deletions because they require no embedding work and should not consume the file budget.
- Leaves hashes for deferred modifications unchanged and hashes for deferred additions absent, so the next `vera update --max-files N` naturally continues the remaining work.
- Reports `files_deferred` in progress events, human output, JSON summaries, and tracing.
- Rejects `--max-files 0`; omitting the option preserves unlimited update behavior.

The limit applies to added and modified files, not chunks. This preserves whole-file consistency across metadata, vector, and BM25 stores and avoids introducing partial-file checkpoint state.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p vera-core -p vera-cli` — 719 tests passed
- Continuation test verifies a two-file run indexes deterministic paths and the following run finishes the deferred file.
- Priority test verifies modifications consume the budget before additions while deletions are still applied.
- CLI tests verify a positive limit and reject zero.
- Clippy passes with only the three documented lint classes already present on upstream `master` allowed: `clippy::useless_conversion`, `clippy::len_zero`, and `clippy::cmp_owned`.

## Review focus

- Budget selection after complete discovery/classification, preserving deferred-vs-deleted semantics
- Modified-before-added ordering and possible starvation tradeoff for continuously changing repositories
- `UpdateOptions` and the no-limit wrappers preserving existing API behavior
- `files_deferred` semantics across progress and final summaries


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `vera update --max-files N` to cap added/modified files per run so large backfills finish in bounded, resumable passes. Update now shows progress, supports Ctrl‑C cancellation, and clamps embedding parallelism to prevent abandoned remote work.

- New Features
  - Add `--max-files N` for `vera update`. Prefers modified over added, always applies deletions, uses deterministic path order, and reports `files_deferred`. Default is unlimited; `0` is rejected.
  - Add progress to `vera update` with `--no-progress` opt-out. Events cover discovery, classification, parsing, embedding, and storage; `files_deferred` is included in human and JSON output.
  - Support Ctrl‑C cancellation for `index` and `update` so in-flight work is dropped cleanly.
  - Add `embedding.max_in_flight_inputs` (default 16; override with `VERA_MAX_IN_FLIGHT_INPUTS`) and clamp batch size × concurrency to this bound.

- Bug Fixes
  - Treat embedding timeouts as non‑retryable (`TimeoutError`); only rate limits get +4 retries, others use the configured limit.
  - Rerank candidate depth is now max(configured, result limit), independent of fetch depth.

<sup>Written for commit ada51b641d81189e88ce454360a572c3bec9d072. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/lemon07r/Vera/pull/31?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

