### PR TITLE
feat(cli): add --no-progress to vera index and gate progress on an interactive stderr

### DIFF
--- a/crates/vera-cli/src/cli.rs
+++ b/crates/vera-cli/src/cli.rs
@@ -311,6 +311,9 @@ pub enum Commands {
         /// Disable smart default exclusions.
         #[arg(long)]
         no_default_excludes: bool,
+        /// Disable the interactive indexing progress display.
+        #[arg(long)]
+        no_progress: bool,
         /// Show detailed information (e.g. paths of skipped files).
         #[arg(long, short = 'v')]
         verbose: bool,

--- a/crates/vera-cli/src/commands/index.rs
+++ b/crates/vera-cli/src/commands/index.rs
@@ -1,5 +1,6 @@
 //! `vera index <path>` — Index a codebase for search.
 
+use std::io::IsTerminal;
 use std::path::Path;
 use std::sync::Arc;
 
@@ -32,6 +33,7 @@ pub fn run(
     exclude: Vec<String>,
     no_ignore: bool,
     no_default_excludes: bool,
+    no_progress: bool,
     verbose: bool,
     low_vram: bool,
 ) -> anyhow::Result<()> {
@@ -42,6 +44,7 @@ pub fn run(
         exclude,
         no_ignore,
         no_default_excludes,
+        no_progress,
         low_vram,
     )?;
 
@@ -57,6 +60,7 @@ pub fn run(
 }
 
 /// Index a repository and return the resulting summary.
+#[allow(clippy::too_many_arguments)]
 pub fn execute(
     path: &str,
     json_output: bool,
@@ -64,6 +68,7 @@ pub fn execute(
     exclude: Vec<String>,
     no_ignore: bool,
     no_default_excludes: bool,
+    no_progress: bool,
     low_vram: bool,
 ) -> anyhow::Result<vera_core::indexing::IndexSummary> {
     let repo_path = Path::new(path);
@@ -97,8 +102,11 @@ pub fn execute(
         &config, backend,
     ))?;
 
-    // Use progress bar for interactive (non-JSON) output.
-    if json_output {
+    // Show the progress display only for interactive, non-JSON runs. Mirrors
+    // the same decision in `vera update` so both commands behave identically
+    // when piped, redirected, or run with --no-progress.
+    let show_progress = !json_output && !no_progress && std::io::stderr().is_terminal();
+    if !show_progress {
         let cancellation = vera_core::CancellationToken::new();
         let task_cancellation = cancellation.clone();
         let signal_cancellation = cancellation.clone();

--- a/crates/vera-cli/src/commands/setup.rs
+++ b/crates/vera-cli/src/commands/setup.rs
@@ -142,6 +142,7 @@ fn run_wizard() -> anyhow::Result<()> {
             false,
             false,
             false,
+            false,
         )?;
     }
 
@@ -248,6 +249,7 @@ fn configure_backend_with_api_setup(
             json_output,
             effective_backend,
             Vec::new(),
+            false,
             false,
             false,
             false,

--- a/crates/vera-cli/src/main.rs
+++ b/crates/vera-cli/src/main.rs
@@ -148,6 +148,7 @@ fn main() {
             exclude,
             no_ignore,
             no_default_excludes,
+            no_progress,
             verbose,
             low_vram,
         } => {
@@ -159,6 +160,7 @@ fn main() {
                 exclude,
                 no_ignore,
                 no_default_excludes,
+                no_progress,
                 verbose,
                 low_vram,
             )
@@ -652,6 +654,18 @@ mod tests {
         assert!(
             matches!(parse(&["vera", "update", "/tmp/repo"]), Commands::Update { path, .. } if path == "/tmp/repo")
         );
+    }
+
+    #[test]
+    fn cli_parses_index_no_progress_flag() {
+        let command = parse(&["vera", "index", "/tmp/repo", "--no-progress"]);
+        assert!(matches!(
+            command,
+            Commands::Index {
+                no_progress: true,
+                ..
+            }
+        ));
     }
 
     #[test]


### PR DESCRIPTION
Closes #34.

## Problem

`vera index --no-progress` is rejected:

```
$ vera index . --no-progress
error: unexpected argument '--no-progress' found

  tip: a similar argument exists: '--no-ignore'
```

`docs/whats-new-v1.md` documents the flag for "Index and update commands", and the skill installed by `vera agent install` instructs agents to pass it, so agents emit a command that fails outright.

## The gap is two flags wide

`vera update` computes:

```rust
let show_progress = !json_output && !no_progress && std::io::stderr().is_terminal();
```

`vera index` gated its quiet path on `json_output` alone. So besides missing the flag, a piped or redirected index run still drove the cliclack progress display, emitting a stray cursor-movement escape ahead of the summary.

## Change

Add `no_progress` to the `Index` variant and reuse update's condition verbatim, so both commands behave identically when piped, redirected, or asked to be quiet. `--json` output is untouched. The two `commands::index::execute` call sites in `setup.rs` pass `false`, leaving setup's own indexing on the interactive-stderr rule.

## Verification

Against a 2-file git repo:

| invocation | v1.0.0 | this branch |
|---|---|---|
| `index . --no-progress` | `error: unexpected argument` | summary printed |
| `index .` piped | summary prefixed with a `\e[3B` escape | clean summary, no escape |
| `index . --json` | JSON summary | unchanged |

`cargo fmt --check` clean. `cargo clippy -p vera-cli --bin vera` introduces no new warnings; the 5 reported all originate in `vera-core` and predate this change (`pip_package_for_ep`, `CUDA_RUNTIME_LIBRARY_PREFIXES`, `parse_cuda_major_from_runtime_library_entry`, an unused import, an unused variable).

New parse test `cli_parses_index_no_progress_flag` mirrors the existing `cli_parses_update_no_progress_flag`; both pass.

## Alternative

If the intent was for `--no-progress` to belong to `update` only, the docs fix is to scope the sentence in `docs/whats-new-v1.md` and the agent skill snippet instead. Happy to switch to that if preferred.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/VeraTools/codesmith/Vera/pr/39"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789716063&installation_model_id=432833&pr_number=39&repository=VeraTools%2FVera&return_to=https%3A%2F%2Fgithub.com%2FVeraTools%2FVera%2Fpull%2F39&signature=f196c5d714c62f5bfbe185d3b8c773b36cc5b23829810e3190cf603e05e7c1f1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `--no-progress` option to the `index` command.
  * Indexing progress is now displayed only in interactive terminal sessions unless disabled.
  * JSON output and non-interactive runs avoid progress display automatically.

* **Tests**
  * Added coverage confirming the new command-line option is recognized correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->