### PR TITLE
fix(setup): make flag-driven setup work without a terminal

### DIFF
--- a/crates/vera-cli/src/commands/setup.rs
+++ b/crates/vera-cli/src/commands/setup.rs
@@ -701,18 +701,29 @@ fn prompt_required_input(
     Ok(value)
 }
 
+/// Read an env var, treating unset and empty/whitespace-only values the same.
+fn read_api_env_var(key: &str) -> Option<String> {
+    std::env::var(key)
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+}
+
 fn read_required_api_env(
     base_key: &str,
     model_key: &str,
     api_key_key: &str,
 ) -> anyhow::Result<ApiSetupInput> {
     Ok(ApiSetupInput {
-        base_url: std::env::var(base_key)
-            .with_context(|| format!("{base_key} must be set for `vera setup --api`"))?,
-        model_id: std::env::var(model_key)
-            .with_context(|| format!("{model_key} must be set for `vera setup --api`"))?,
-        api_key: std::env::var(api_key_key)
-            .with_context(|| format!("{api_key_key} must be set for `vera setup --api`"))?,
+        base_url: read_api_env_var(base_key).with_context(|| {
+            format!("{base_key} must be set and non-empty for `vera setup --api`")
+        })?,
+        model_id: read_api_env_var(model_key).with_context(|| {
+            format!("{model_key} must be set and non-empty for `vera setup --api`")
+        })?,
+        api_key: read_api_env_var(api_key_key).with_context(|| {
+            format!("{api_key_key} must be set and non-empty for `vera setup --api`")
+        })?,
     })
 }
 
@@ -721,9 +732,9 @@ fn read_optional_api_env(
     model_key: &str,
     api_key_key: &str,
 ) -> anyhow::Result<Option<ApiSetupInput>> {
-    let base = std::env::var(base_key).ok();
-    let model = std::env::var(model_key).ok();
-    let api_key = std::env::var(api_key_key).ok();
+    let base = read_api_env_var(base_key);
+    let model = read_api_env_var(model_key);
+    let api_key = read_api_env_var(api_key_key);
 
     match (base, model, api_key) {
         (Some(base_url), Some(model_id), Some(api_key)) => Ok(Some(ApiSetupInput {

--- a/crates/vera-cli/src/commands/setup.rs
+++ b/crates/vera-cli/src/commands/setup.rs
@@ -1,5 +1,7 @@
 //! `vera setup` — persist a preferred Vera mode and bootstrap first-run state.
 
+use std::io::IsTerminal;
+
 use anyhow::{Context, bail};
 use serde::Serialize;
 use vera_core::config::{InferenceBackend, OnnxExecutionProvider};
@@ -36,10 +38,22 @@ pub fn run(
     embedding_flags: LocalEmbeddingModelFlags,
     allow_wizard: bool,
 ) -> anyhow::Result<()> {
+    // Prompts need a terminal. Without one, every `cliclack` call fails with a
+    // bare "not connected", so decide up front what can run unattended.
+    let interactive = std::io::stdin().is_terminal();
+
     // If no flags at all and interactive, run the full wizard.
     let is_bare_interactive =
         !api && backend.is_none() && !json_output && !yes && !embedding_flags.any_set();
     if allow_wizard && is_bare_interactive && index_path.is_none() {
+        if !interactive {
+            bail!(
+                "`vera setup` with no flags runs an interactive wizard, and no terminal is \
+                 available for prompts.\n\
+                 Hint: pass a backend flag (for example `--onnx-jina-coreml`, \
+                 `--onnx-jina-cuda`, or `--potion-code`), `--api`, or `--yes` to auto-detect one."
+            );
+        }
         return run_wizard();
     }
 
@@ -54,6 +68,12 @@ pub fn run(
             eprintln!("Auto-detected backend: {detected}. Use a backend flag to override.");
         }
         detected
+    } else if !interactive {
+        bail!(
+            "no backend selected and no terminal is available for prompts.\n\
+             Hint: pass a backend flag (for example `--onnx-jina-coreml`, `--onnx-jina-cuda`, \
+             or `--potion-code`), `--api`, or `--yes` to auto-detect one."
+        );
     } else {
         prompt_backend()?
     };
@@ -65,8 +85,11 @@ pub fn run(
         .then(|| resolve_local_embedding_model(&embedding_flags))
         .transpose()?;
 
+    // An explicit backend flag already answers everything the confirmation asks
+    // about, so a non-interactive run has nothing left to confirm.
     if !yes
         && !json_output
+        && interactive
         && !confirm(
             &effective_backend,
             local_embedding_model.as_ref(),
@@ -79,7 +102,15 @@ pub fn run(
         return Ok(());
     }
 
-    let api_setup = should_prompt_api_config(effective_backend, json_output, yes)
+    let needs_api_prompt = should_prompt_api_config(effective_backend, json_output, yes);
+    if needs_api_prompt && !interactive {
+        bail!(
+            "API mode needs endpoint credentials and no terminal is available for prompts.\n\
+             Hint: set EMBEDDING_MODEL_BASE_URL, EMBEDDING_MODEL_ID, and \
+             EMBEDDING_MODEL_API_KEY, then re-run with `--api --yes`."
+        );
+    }
+    let api_setup = (needs_api_prompt && interactive)
         .then(prompt_api_setup)
         .transpose()?;
 

--- a/crates/vera-cli/src/commands/setup.rs
+++ b/crates/vera-cli/src/commands/setup.rs
@@ -26,6 +26,11 @@ pub(crate) struct SetupReport {
     indexed_path: Option<String>,
 }
 
+/// Remedy shown when a non-interactive invocation cannot prompt.
+const NON_INTERACTIVE_HINT: &str = "Hint: pass a backend flag (for example `--onnx-jina-coreml`, \
+     `--onnx-jina-cuda`, or `--potion-code`), `--yes` to auto-detect one, or `--api` with \
+     EMBEDDING_MODEL_BASE_URL, EMBEDDING_MODEL_ID, and EMBEDDING_MODEL_API_KEY set.";
+
 /// `backend`: Some(local backend) for local, None + api=true for API, None + api=false defaults to auto-detect.
 /// `allow_wizard`: bare interactive invocations run the full wizard only for
 /// `vera setup`; `vera backend` always stays in the backend-only flow.
@@ -49,9 +54,7 @@ pub fn run(
         if !interactive {
             bail!(
                 "`vera setup` with no flags runs an interactive wizard, and no terminal is \
-                 available for prompts.\n\
-                 Hint: pass a backend flag (for example `--onnx-jina-coreml`, \
-                 `--onnx-jina-cuda`, or `--potion-code`), `--api`, or `--yes` to auto-detect one."
+                 available for prompts.\n{NON_INTERACTIVE_HINT}"
             );
         }
         return run_wizard();
@@ -70,9 +73,7 @@ pub fn run(
         detected
     } else if !interactive {
         bail!(
-            "no backend selected and no terminal is available for prompts.\n\
-             Hint: pass a backend flag (for example `--onnx-jina-coreml`, `--onnx-jina-cuda`, \
-             or `--potion-code`), `--api`, or `--yes` to auto-detect one."
+            "no backend selected and no terminal is available for prompts.\n{NON_INTERACTIVE_HINT}"
         );
     } else {
         prompt_backend()?
@@ -104,11 +105,14 @@ pub fn run(
 
     let needs_api_prompt = should_prompt_api_config(effective_backend, json_output, yes);
     if needs_api_prompt && !interactive {
-        bail!(
-            "API mode needs endpoint credentials and no terminal is available for prompts.\n\
-             Hint: set EMBEDDING_MODEL_BASE_URL, EMBEDDING_MODEL_ID, and \
-             EMBEDDING_MODEL_API_KEY, then re-run with `--api --yes`."
-        );
+        // With complete credentials in the environment there is nothing left
+        // to prompt for; on a missing variable this error names it.
+        read_required_api_env(
+            "EMBEDDING_MODEL_BASE_URL",
+            "EMBEDDING_MODEL_ID",
+            "EMBEDDING_MODEL_API_KEY",
+        )
+        .context("API mode needs endpoint credentials and no terminal is available for prompts")?;
     }
     let api_setup = (needs_api_prompt && interactive)
         .then(prompt_api_setup)


### PR DESCRIPTION
Closes #37.

## Problem

`vera setup --onnx-jina-coreml` fails with a bare `Error: not connected` whenever stdin is not a TTY:

```
$ vera setup --onnx-jina-coreml < /dev/null
Error: not connected
```

`vera setup --help` presents a backend flag as the way to skip the interactive wizard, and `docs/installation.md` gives `vera setup --onnx-jina-coreml` as *the* Apple Silicon command with no mention that a terminal is required. So CI, provisioning scripts, containers, and coding agents all hit this.

## Cause

The flag does skip the wizard and resolve the backend correctly. What still blocks is the confirmation prompt afterwards:

```rust
if !yes && !json_output && !confirm(&effective_backend, ..., index_path.as_deref())? {
```

`confirm` ends in `cliclack::confirm(msg).interact()`, which errors with `not connected` when there is no terminal. But an explicit backend flag has already answered what that prompt asks: backend, embedding model, and index path are fully determined by the flags at that point.

## Change

Detect an interactive stdin once, then use it to decide what can run unattended:

- **Skip the confirmation** when there is no terminal. A flag-driven run has nothing left to confirm.
- **Replace `not connected` with an actionable error** on the paths that genuinely need a prompt:
  - bare `vera setup`, which enters the wizard
  - no backend selected and no `--yes`/`--json` to auto-detect
  - API mode without credentials

Interactive behaviour is unchanged. Every new branch is gated on there being no terminal.

## Verification

Run with an isolated `VERA_HOME` so no real config was touched, model assets symlinked to avoid re-downloads:

| invocation (stdin closed) | v1.0.0 | this branch |
|---|---|---|
| `setup --onnx-jina-coreml` | `Error: not connected` | completes, writes config |
| `setup` (no flags) | `not connected` mid-wizard | error naming the flags that would work |
| `setup --api` (no creds) | `Error: not connected` | error naming the three env vars and `--api --yes` |

`cargo fmt --check` clean. `cargo clippy -p vera-cli --bin vera` adds no new warnings; the 5 reported all originate in `vera-core` and predate this change. All 82 `vera-cli` tests pass.

## Note on tests

The decision reads process stdin, so it is not unit-testable without threading an `interactive` flag through `setup::run` or injecting a terminal probe. I kept the change minimal rather than reshaping the signature, but happy to refactor for a test if you would prefer that.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/VeraTools/codesmith/Vera/pr/40"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789716280&installation_model_id=432833&pr_number=40&repository=VeraTools%2FVera&return_to=https%3A%2F%2Fgithub.com%2FVeraTools%2FVera%2Fpull%2F40&signature=76af8f042c6deb184e676ffd6dfdf9225484fd02d2cd135cbeb865e846435213"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved setup behavior in non-interactive environments.
  * Added clear guidance when interactive setup steps cannot run.
  * Prevented setup from attempting unavailable prompts.
  * Added validation for required API configuration environment variables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->