### PR TITLE
fix(storage): clamp KNN k to the sqlite-vec limit instead of losing vector search

### DIFF
--- a/crates/vera-core/src/retrieval/vector.rs
+++ b/crates/vera-core/src/retrieval/vector.rs
@@ -25,7 +25,7 @@ pub enum VectorSearchError {
     },
 
     /// Storage or metadata error.
-    #[error("storage error: {0}")]
+    #[error("storage error: {0:#}")]
     StorageError(#[from] anyhow::Error),
 }
 

--- a/crates/vera-core/src/retrieval/vector.rs
+++ b/crates/vera-core/src/retrieval/vector.rs
@@ -171,6 +171,7 @@ mod tests {
     use super::*;
     use crate::embedding::test_helpers::MockProvider;
     use crate::types::{Chunk, Language, SymbolType};
+    use anyhow::Context;
 
     /// Create sample chunks with semantic variety for testing.
     fn sample_chunks() -> Vec<Chunk> {
@@ -316,6 +317,15 @@ mod tests {
                 scores[i],
             );
         }
+    }
+
+    #[test]
+    fn storage_error_display_includes_error_chain() {
+        let error = anyhow::anyhow!("root cause").context("outer context");
+        let display = VectorSearchError::StorageError(error).to_string();
+
+        assert!(display.contains("outer context"));
+        assert!(display.contains("root cause"));
     }
 
     // ── generate_query_embedding tests ───────────────────────────────

--- a/crates/vera-core/src/storage/vector.rs
+++ b/crates/vera-core/src/storage/vector.rs
@@ -207,6 +207,13 @@ impl VectorStore {
         // it on natural-language queries, and the whole vector arm would then be
         // dropped in favour of BM25-only results. Ask for as many as the backend
         // allows instead.
+        if limit > MAX_KNN_K {
+            tracing::debug!(
+                requested = limit,
+                clamped = MAX_KNN_K,
+                "clamping vector search limit to sqlite-vec KNN cap"
+            );
+        }
         let limit = limit.min(MAX_KNN_K);
 
         let mut stmt = self

--- a/crates/vera-core/src/storage/vector.rs
+++ b/crates/vera-core/src/storage/vector.rs
@@ -14,6 +14,10 @@ pub struct VectorStore {
     dim: usize,
 }
 
+/// Maximum `k` sqlite-vec accepts in a KNN query. Requesting more is a hard
+/// error from the extension, not a soft limit.
+const MAX_KNN_K: usize = 4096;
+
 /// A single vector search result: chunk ID and distance score.
 #[derive(Debug, Clone)]
 pub struct VectorSearchResult {
@@ -196,6 +200,14 @@ impl VectorStore {
                 query.len()
             );
         }
+
+        // sqlite-vec reads this LIMIT as the KNN `k` and rejects anything above
+        // MAX_KNN_K with "k value in knn query too large". Callers scale the
+        // candidate pool from the query type and result limit, which can exceed
+        // it on natural-language queries, and the whole vector arm would then be
+        // dropped in favour of BM25-only results. Ask for as many as the backend
+        // allows instead.
+        let limit = limit.min(MAX_KNN_K);
 
         let mut stmt = self
             .conn
@@ -390,6 +402,22 @@ mod tests {
         assert!(!results.is_empty());
         assert_eq!(results[0].chunk_id, "c1");
         assert!(results[0].distance < 0.001); // Self-match should be ~0 distance.
+    }
+
+    #[test]
+    fn search_clamps_limit_above_sqlite_vec_knn_cap() {
+        let store = VectorStore::open_in_memory(4).unwrap();
+        for i in 0..10 {
+            let v = vec![i as f32, 0.0, 0.0, 0.0];
+            store.insert(&format!("c{i}"), &v).unwrap();
+        }
+
+        // Without clamping, sqlite-vec fails the query outright with
+        // "k value in knn query too large".
+        let results = store
+            .search(&[5.0, 0.0, 0.0, 0.0], MAX_KNN_K + 1)
+            .expect("oversized k must be clamped, not rejected");
+        assert_eq!(results.len(), 10);
     }
 
     #[test]


### PR DESCRIPTION
Closes #38.

## Root cause

`VectorStore::search` passes its `limit` straight into the SQL `LIMIT`, which sqlite-vec reads as the KNN `k` and hard-rejects above 4096:

```
k value in knn query too large, provided 4260 and the limit is 4096: Error code 1: SQL logic error
```

Callers scale the candidate pool from the query type and result limit, in three compounding steps:

1. `compute_vector_candidates(limit, multiplier)` in `retrieval/hybrid.rs`
2. `run_hybrid_search` multiplies again by 4 for natural-language queries (`hybrid.rs:135`)
3. `vector_search_with_stores` adds a further 50% overfetch (`retrieval/vector.rs:64`)

On a 4790-chunk index a five-word query reached 4260. The vector arm was then dropped entirely and only BM25 results were returned, for exactly the conversational queries hybrid retrieval exists to serve.

## Why it was invisible

`VectorSearchError::StorageError` formats its inner `anyhow::Error` with `{0}`, which prints only the outermost context and discards the cause chain. Every failure surfaced as the useless:

```
error=storage error: vector search failed
```

Switching to `{0:#}` exposes the real cause. That one-character change is what made this diagnosable at all, so it is included here.

## Change

- Clamp `k` to `MAX_KNN_K` (4096) in `VectorStore::search`. Requesting 4096 candidates rather than 4260 is imperceptible; losing vector search entirely is not.
- Format the storage error with `{0:#}` so future failures are diagnosable from the log rather than requiring a patched build.

I put the clamp at the storage layer because 4096 is a property of the sqlite-vec backend, not of any caller's pool arithmetic. Clamping there fixes every current and future caller at once.

## Verification

Repeated runs on a 4790-chunk index, counting only the fallback warning:

| query | v1.0.0 | this branch |
|---|---|---|
| `fusion` | ok | ok |
| `hybrid fusion work` | ok | ok |
| `how does hybrid fusion work` | **BM25-only** | ok |
| `cross-encoder reranking of search candidates` | **BM25-only** | ok |

`search_clamps_limit_above_sqlite_vec_knn_cap` fails without the clamp with the production error (`k value in knn query too large, provided 4097 and the limit is 4096`) and passes with it. All 13 `storage::vector` tests pass. `cargo fmt --check` clean.

## Note

Clamping keeps a large pool silently smaller than requested. If you would rather callers not build oversized pools in the first place, the alternative is to bound the multipliers in `hybrid.rs` against index size and keep the storage layer strict. Happy to switch. The error-format change is worth having either way.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/VeraTools/codesmith/Vera/pr/42"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789717390&installation_model_id=432833&pr_number=42&repository=VeraTools%2FVera&return_to=https%3A%2F%2Fgithub.com%2FVeraTools%2FVera%2Fpull%2F42&signature=3978d6d4d206977c06b5ee31e7a2f6d50a17788a6ade5f2a621a09f4ec2e210a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->