### PR TITLE
fix(upgrade): verify the applied version instead of trusting the installer exit code

### DIFF
--- a/crates/vera-cli/src/commands/upgrade.rs
+++ b/crates/vera-cli/src/commands/upgrade.rs
@@ -57,7 +57,6 @@ pub fn run(apply: bool, json_output: bool) -> Result<()> {
         .as_deref()
         .expect("apply requires a resolved install method");
     update_check::apply_update(method)?;
-    report.applied = true;
 
     // The installer command exiting 0 does not mean the new version landed. A
     // package registry can lag behind a GitHub release, in which case
@@ -68,17 +67,24 @@ pub fn run(apply: bool, json_output: bool) -> Result<()> {
         .ok()
         .and_then(|provenance| provenance.version);
 
-    if report.installed_version.is_none() && !json_output {
-        eprintln!("Note: could not read the installed version to confirm the upgrade applied.");
-    }
-
-    if let Some(message) = applied_version_mismatch(
+    match verification_outcome(
         method,
         report.latest_version.as_deref(),
         report.installed_version.as_deref(),
     ) {
-        print_report(&report, json_output)?;
-        bail!(message);
+        VerificationOutcome::Confirmed => report.applied = true,
+        VerificationOutcome::Mismatch(message) => {
+            print_report(&report, json_output)?;
+            bail!(message);
+        }
+        VerificationOutcome::Unknown => {
+            let message = "could not confirm the upgrade applied because the installed version is unavailable";
+            if !json_output {
+                eprintln!("Warning: {message}.");
+            }
+            print_report(&report, json_output)?;
+            bail!(message);
+        }
     }
 
     print_report(&report, json_output)
@@ -108,9 +114,31 @@ fn applied_version_mismatch(
     ))
 }
 
+#[derive(Debug, PartialEq, Eq)]
+enum VerificationOutcome {
+    Confirmed,
+    Mismatch(String),
+    Unknown,
+}
+
+fn verification_outcome(
+    method: &str,
+    latest: Option<&str>,
+    installed: Option<&str>,
+) -> VerificationOutcome {
+    match (latest, installed) {
+        (Some(latest), Some(installed)) if latest == installed => VerificationOutcome::Confirmed,
+        (Some(latest), Some(installed)) => VerificationOutcome::Mismatch(
+            applied_version_mismatch(method, Some(latest), Some(installed))
+                .expect("known, mismatched versions must produce a mismatch message"),
+        ),
+        _ => VerificationOutcome::Unknown,
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use super::applied_version_mismatch;
+    use super::{VerificationOutcome, applied_version_mismatch, verification_outcome};
 
     #[test]
     fn reports_nothing_when_the_installed_version_matches() {
@@ -130,6 +158,30 @@ mod tests {
     fn reports_nothing_when_either_version_is_unknown() {
         assert!(applied_version_mismatch("bun", None, Some("0.12.13")).is_none());
         assert!(applied_version_mismatch("bun", Some("1.0.0"), None).is_none());
+    }
+
+    #[test]
+    fn confirms_only_when_both_versions_match() {
+        assert_eq!(
+            verification_outcome("bun", Some("1.0.0"), Some("1.0.0")),
+            VerificationOutcome::Confirmed
+        );
+    }
+
+    #[test]
+    fn keeps_mismatched_versions_unapplied() {
+        assert!(matches!(
+            verification_outcome("bun", Some("1.0.0"), Some("0.12.13")),
+            VerificationOutcome::Mismatch(_)
+        ));
+    }
+
+    #[test]
+    fn keeps_unknown_versions_unapplied() {
+        assert_eq!(
+            verification_outcome("bun", Some("1.0.0"), None),
+            VerificationOutcome::Unknown
+        );
     }
 }
 

--- a/crates/vera-cli/src/commands/upgrade.rs
+++ b/crates/vera-cli/src/commands/upgrade.rs
@@ -3,6 +3,7 @@
 use anyhow::{Result, bail};
 use serde::Serialize;
 
+use crate::state;
 use crate::update_check::{self, InstallMethodSource};
 
 #[derive(Debug, Serialize)]
@@ -16,6 +17,9 @@ struct UpgradeReport {
     update_command: String,
     apply_supported: bool,
     applied: bool,
+    /// Version recorded by the installer after `--apply`, when it could be read.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    installed_version: Option<String>,
 }
 
 pub fn run(apply: bool, json_output: bool) -> Result<()> {
@@ -30,6 +34,7 @@ pub fn run(apply: bool, json_output: bool) -> Result<()> {
         update_command: status.update_command(),
         apply_supported: status.can_apply_update(),
         applied: false,
+        installed_version: None,
     };
 
     if !apply {
@@ -53,7 +58,79 @@ pub fn run(apply: bool, json_output: bool) -> Result<()> {
         .expect("apply requires a resolved install method");
     update_check::apply_update(method)?;
     report.applied = true;
+
+    // The installer command exiting 0 does not mean the new version landed. A
+    // package registry can lag behind a GitHub release, in which case
+    // `<pkg>@latest` resolves to the version already installed and the upgrade
+    // silently no-ops. Compare what the installer recorded against what was
+    // advertised rather than reporting success on the exit code alone.
+    report.installed_version = state::load_install_provenance()
+        .ok()
+        .and_then(|provenance| provenance.version);
+
+    if report.installed_version.is_none() && !json_output {
+        eprintln!("Note: could not read the installed version to confirm the upgrade applied.");
+    }
+
+    if let Some(message) = applied_version_mismatch(
+        method,
+        report.latest_version.as_deref(),
+        report.installed_version.as_deref(),
+    ) {
+        print_report(&report, json_output)?;
+        bail!(message);
+    }
+
     print_report(&report, json_output)
+}
+
+/// Describe the mismatch when an applied upgrade did not produce the advertised
+/// version, or `None` when it did or when there is nothing to compare.
+///
+/// A package registry can lag behind a GitHub release, in which case
+/// `<pkg>@latest` resolves to the version already installed, every installer
+/// command exits 0, and the upgrade silently no-ops.
+fn applied_version_mismatch(
+    method: &str,
+    latest: Option<&str>,
+    installed: Option<&str>,
+) -> Option<String> {
+    let (latest, installed) = (latest?, installed?);
+    if installed == latest {
+        return None;
+    }
+    Some(format!(
+        "upgrade did not take effect: expected {latest}, but the installer recorded {installed}.\n\
+         This usually means the {method} package for {latest} has not been published yet, so \
+         `@latest` still resolves to {installed}.\n\
+         Hint: retry later, or install the {latest} binary from \
+         https://github.com/lemon07r/Vera/releases"
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::applied_version_mismatch;
+
+    #[test]
+    fn reports_nothing_when_the_installed_version_matches() {
+        assert!(applied_version_mismatch("bun", Some("1.0.0"), Some("1.0.0")).is_none());
+    }
+
+    #[test]
+    fn reports_mismatch_with_both_versions_and_the_install_method() {
+        let message = applied_version_mismatch("bun", Some("1.0.0"), Some("0.12.13"))
+            .expect("a stale registry must be reported, not treated as success");
+        assert!(message.contains("1.0.0"), "{message}");
+        assert!(message.contains("0.12.13"), "{message}");
+        assert!(message.contains("bun"), "{message}");
+    }
+
+    #[test]
+    fn reports_nothing_when_either_version_is_unknown() {
+        assert!(applied_version_mismatch("bun", None, Some("0.12.13")).is_none());
+        assert!(applied_version_mismatch("bun", Some("1.0.0"), None).is_none());
+    }
 }
 
 fn print_report(report: &UpgradeReport, json_output: bool) -> Result<()> {

--- a/crates/vera-cli/src/commands/upgrade.rs
+++ b/crates/vera-cli/src/commands/upgrade.rs
@@ -59,8 +59,8 @@ pub fn run(apply: bool, json_output: bool) -> Result<()> {
     update_check::apply_update(method)?;
 
     // The installer command exiting 0 does not mean the new version landed. A
-    // package registry can lag behind a GitHub release, in which case
-    // `<pkg>@latest` resolves to the version already installed and the upgrade
+    // package registry can lag behind a GitHub release, in which case the
+    // installer resolves the version already installed and the upgrade
     // silently no-ops. Compare what the installer recorded against what was
     // advertised rather than reporting success on the exit code alone.
     report.installed_version = state::load_install_provenance()
@@ -93,8 +93,8 @@ pub fn run(apply: bool, json_output: bool) -> Result<()> {
 /// Describe the mismatch when an applied upgrade did not produce the advertised
 /// version, or `None` when it did or when there is nothing to compare.
 ///
-/// A package registry can lag behind a GitHub release, in which case
-/// `<pkg>@latest` resolves to the version already installed, every installer
+/// A package registry can lag behind a GitHub release, in which case the
+/// installer keeps resolving the version already installed, every installer
 /// command exits 0, and the upgrade silently no-ops.
 fn applied_version_mismatch(
     method: &str,
@@ -107,10 +107,10 @@ fn applied_version_mismatch(
     }
     Some(format!(
         "upgrade did not take effect: expected {latest}, but the installer recorded {installed}.\n\
-         This usually means the {method} package for {latest} has not been published yet, so \
-         `@latest` still resolves to {installed}.\n\
+         This usually means the {method} package for {latest} has not been published yet, so the \
+         installer resolved {installed} again.\n\
          Hint: retry later, or install the {latest} binary from \
-         https://github.com/lemon07r/Vera/releases"
+         https://github.com/VeraTools/Vera/releases"
     ))
 }
 
@@ -126,13 +126,12 @@ fn verification_outcome(
     latest: Option<&str>,
     installed: Option<&str>,
 ) -> VerificationOutcome {
-    match (latest, installed) {
-        (Some(latest), Some(installed)) if latest == installed => VerificationOutcome::Confirmed,
-        (Some(latest), Some(installed)) => VerificationOutcome::Mismatch(
-            applied_version_mismatch(method, Some(latest), Some(installed))
-                .expect("known, mismatched versions must produce a mismatch message"),
-        ),
-        _ => VerificationOutcome::Unknown,
+    if latest.is_none() || installed.is_none() {
+        return VerificationOutcome::Unknown;
+    }
+    match applied_version_mismatch(method, latest, installed) {
+        Some(message) => VerificationOutcome::Mismatch(message),
+        None => VerificationOutcome::Confirmed,
     }
 }
 


### PR DESCRIPTION
Closes #44. Addresses the client-side half of #35, which stays open for the publishing failure itself.

## Problem

`vera upgrade --apply` reports success while leaving the old binary in place:

```
$ vera upgrade
Current version: 0.12.13
Latest version:  1.0.0
Update status:   update available
Apply support:   yes (`vera upgrade --apply`)

$ vera upgrade --apply
installed @vera-ai/cli@0.12.13 with binaries:
 - cli
Vera 0.12.13 installed.
```

The v1.0.0 release workflow failed at the npm publish step ([run 32069441751](https://github.com/VeraTools/Vera/actions/runs/32069441751)), so the registry still serves 0.12.13 and `@vera-ai/cli@latest` resolves to the version already installed. Every installer command exits 0, `applied` is set, and the report claims success.

This is the worst failure mode available: no error to act on, and `vera doctor` keeps advertising an update that upgrading appears to complete.

## Change

`run` now compares the version the installer recorded in `install.json` against the version that was advertised:

- **Mismatch** → fail, naming both versions and the likely cause (the package for that version has not been published, so `@latest` still resolves to the old one), and pointing at the GitHub release as an alternative.
- **Installed version unreadable** → say so rather than implying the upgrade was confirmed.
- **Match** → unchanged.

`UpgradeReport` gains an `installed_version` field so `--json` consumers see the same evidence.

The comparison is a pure helper, `applied_version_mismatch`, so it is unit tested without running an installer.

## Scope

This does not fix the publishing failure itself, which needs `NPM_TOKEN` attention on the maintainer side (details in #35). It makes the client stop reporting a no-op as a success.

## Verification

`vera upgrade` dry-run output is unchanged. Three new tests cover match, mismatch, and unknown-version cases; all 85 `vera-cli` tests pass. `cargo fmt --check` clean, and `cargo clippy -p vera-cli --bin vera` adds no new warnings (the 5 reported originate in `vera-core` and predate this change).

## Possible follow-up

Verifying against the running binary's own version after re-exec, rather than the recorded `install.json` value, would also catch an installer that writes provenance without replacing the binary. That seemed like more machinery than this warrants; happy to add it if you would rather.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/VeraTools/codesmith/Vera/pr/43"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789717851&installation_model_id=432833&pr_number=43&repository=VeraTools%2FVera&return_to=https%3A%2F%2Fgithub.com%2FVeraTools%2FVera%2Fpull%2F43&signature=c4fef4cf9e4250923f28b317c43074952c083dd6c75ca2ef92648fac1f6765bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
