### PR TITLE
ci: migrate release and docker workflows to Blacksmith runners

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,7 @@
+self-hosted-runner:
+  # Blacksmith runner labels (https://docs.blacksmith.sh/blacksmith-runners/overview)
+  labels:
+    - blacksmith-2vcpu-ubuntu-2404
+    - blacksmith-2vcpu-ubuntu-2404-arm
+    - blacksmith-6vcpu-macos-15
+    - blacksmith-2vcpu-windows-2025

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -15,7 +15,7 @@ env:
 jobs:
   build:
     name: Build (${{ matrix.variant }})
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     strategy:
       fail-fast: false
       matrix:
@@ -44,14 +44,16 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: useblacksmith/setup-docker-builder@v2
+        with:
+          cache-key: ${{ matrix.dockerfile }}
 
       - name: Extract version from tag
         id: version
         run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
 
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: useblacksmith/build-push-action@v2
         with:
           context: .
           file: ${{ matrix.dockerfile }}
@@ -59,5 +61,3 @@ jobs:
           tags: |
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LC }}:${{ matrix.tag_suffix }}
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LC }}:${{ steps.version.outputs.version }}-${{ matrix.tag_suffix }}
-          cache-from: type=gha,scope=${{ matrix.variant }}
-          cache-to: type=gha,mode=max,scope=${{ matrix.variant }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,29 +18,29 @@ jobs:
       matrix:
         include:
           - target: x86_64-unknown-linux-gnu
-            os: ubuntu-latest
+            os: blacksmith-2vcpu-ubuntu-2404
             archive: tar.gz
 
           - target: x86_64-unknown-linux-musl
-            os: ubuntu-latest
+            os: blacksmith-2vcpu-ubuntu-2404
             archive: tar.gz
             musl: true
 
           - target: aarch64-unknown-linux-gnu
-            os: ubuntu-latest
-            use_cross: true
+            os: blacksmith-2vcpu-ubuntu-2404-arm
             archive: tar.gz
 
+          # Blacksmith macOS runners are Apple Silicon; x86_64-apple-darwin is cross-compiled via the rust target.
           - target: x86_64-apple-darwin
-            os: macos-14
+            os: blacksmith-6vcpu-macos-15
             archive: tar.gz
 
           - target: aarch64-apple-darwin
-            os: macos-latest
+            os: blacksmith-6vcpu-macos-15
             archive: tar.gz
 
           - target: x86_64-pc-windows-msvc
-            os: windows-latest
+            os: blacksmith-2vcpu-windows-2025
             archive: zip
 
     runs-on: ${{ matrix.os }}
@@ -69,11 +69,9 @@ jobs:
           key: ${{ matrix.target }}
 
       - name: Set up sccache
-        if: ${{ !matrix.use_cross }}
         uses: mozilla-actions/sccache-action@v0.0.9
 
       - name: Configure sccache
-        if: ${{ !matrix.use_cross }}
         shell: bash
         run: |
           echo "SCCACHE_GHA_ENABLED=true" >> "$GITHUB_ENV"
@@ -82,10 +80,6 @@ jobs:
       - name: Download vendored grammars
         shell: bash
         run: bash scripts/bootstrap-vendored-grammars.sh
-
-      - name: Install cross
-        if: matrix.use_cross
-        run: cargo install cross --locked
 
       - name: Install musl tools
         if: matrix.musl
@@ -110,12 +104,7 @@ jobs:
           echo "CXXFLAGS=/MD" >> "$GITHUB_ENV"
 
       - name: Build (native)
-        if: ${{ !matrix.use_cross }}
         run: cargo build --release --target ${{ matrix.target }} -p vera-cli
-
-      - name: Build (cross)
-        if: ${{ matrix.use_cross }}
-        run: cross build --release --target ${{ matrix.target }} -p vera-cli
 
       - name: Package (tar.gz)
         if: matrix.archive == 'tar.gz'
@@ -148,7 +137,7 @@ jobs:
   release:
     name: Create Release
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     env:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       PYPI_API_TOKEN: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
Migrates both tag-triggered workflows from GitHub-hosted runners to Blacksmith.sh runners. The Blacksmith GitHub App is already installed on the VeraTools org (Codesmith footers on open PRs), so jobs can execute once merged.

## Files changed

- `.github/workflows/release.yml`
- `.github/workflows/docker.yml`
- `.github/actionlint.yaml` (new: declares Blacksmith labels so actionlint stays clean)

## Runner mapping (old -> new)

| Job / target | Before | After |
|---|---|---|
| x86_64-unknown-linux-gnu | ubuntu-latest | blacksmith-2vcpu-ubuntu-2404 |
| x86_64-unknown-linux-musl | ubuntu-latest | blacksmith-2vcpu-ubuntu-2404 |
| aarch64-unknown-linux-gnu | ubuntu-latest + cross | **blacksmith-2vcpu-ubuntu-2404-arm (native)** |
| x86_64-apple-darwin | macos-14 (Intel) | blacksmith-6vcpu-macos-15 (cross from Apple Silicon) |
| aarch64-apple-darwin | macos-latest | blacksmith-6vcpu-macos-15 (native) |
| x86_64-pc-windows-msvc | windows-latest | blacksmith-2vcpu-windows-2025 |
| Create Release job | ubuntu-latest | blacksmith-2vcpu-ubuntu-2404 |
| Docker (cpu/cuda/rocm) | ubuntu-latest | blacksmith-2vcpu-ubuntu-2404 |

## Linux ARM: cross -> native

`use_cross`, the `Install cross` step, and the `Build (cross)` step are removed; the ARM build is now a plain `cargo build --release --target aarch64-unknown-linux-gnu` on a native ARM64 runner. The sccache/native-build conditionals referencing `use_cross` were simplified to unconditional.

## Intel macOS on Apple Silicon

Blacksmith only offers Apple Silicon (M4) macOS runners. `x86_64-apple-darwin` now cross-compiles from ARM64: the existing `dtolnay/rust-toolchain` step installs the x86_64 std, and clang/cc-rs handle `-arch x86_64` via the universal SDK. No new steps were needed; a comment marks the matrix entry. **This path is untested until a tag build runs** — first release after merge should verify the artifact with `file` / `lipo -info` (expect `Mach-O 64-bit executable x86_64`).

## Docker caching

`docker/setup-buildx-action@v3` -> `useblacksmith/setup-docker-builder@v2` (with required `cache-key: ${{ matrix.dockerfile }}`, one persistent layer-cache disk per variant) and `docker/build-push-action@v6` -> `useblacksmith/build-push-action@v2`. The `type=gha` cache-from/cache-to lines were removed per Blacksmith docs: exported caches serialize layer blobs every run and skip cache-mount contents; the persistent builder disk supersedes them. GHCR login, tags, the cpu/cuda/rocm matrix, permissions, and push-on-version-tag behavior are unchanged. Note: the first run on Blacksmith is uncached (cold layer cache).

Rust caching is intentionally unchanged: `Swatinem/rust-cache` transparently uses Blacksmith's colocated cache; `sccache` still routes to GitHub's cache backend per Blacksmith docs but remains functional.

## Validation

- YAML parses (python yaml.safe_load) for both workflows.
- `actionlint` v1.7.7: clean with the new label config.
- Runner audit: no GitHub-hosted labels remain in .github/workflows/.
- All 6 release targets, archive names, musl workarounds, MSVC /MD flags, release/changelog/manifest/npm/PyPI logic verified byte-preserved by diff review plus an independent cross-review pass.
- NOT run: an actual Blacksmith execution. Both workflows trigger only on version tags, so no fake tag was pushed; first real run happens at the next release tag.

## Known limitations

- Windows runner is Blacksmith's Windows Server 2025 image (public beta): VS Build Tools 2022 is present (full VS IDE excluded), which is all the MSVC target needs; 7z is part of the GitHub-derived image. Docker Linux containers are not supported on it, but this workflow doesn't use them.
- macOS x86_64 cross-compile is unverified until first tag run (see above).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/VeraTools/codesmith/Vera/pr/45"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789722517&installation_model_id=432833&pr_number=45&repository=VeraTools%2FVera&return_to=https%3A%2F%2Fgithub.com%2FVeraTools%2FVera%2Fpull%2F45&signature=ae6a3a459447dc860087e39ec402d5bef983c0b04a26cb8e6d70d60c7c52bd49"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrates the tag-triggered release and Docker workflows from GitHub-hosted runners to Blacksmith runners for steadier capacity, native ARM64 builds, and persistent Docker layer caching; release outputs, archive names, tagging, and publish steps are unchanged.

- Release matrix now runs on Blacksmith: Linux x86_64 on `blacksmith-2vcpu-ubuntu-2404`; Linux ARM64 builds natively on `blacksmith-2vcpu-ubuntu-2404-arm` (removes `cross` and related conditionals); macOS targets on `blacksmith-6vcpu-macos-15` (x86_64 cross-compiled from Apple Silicon); Windows on `blacksmith-2vcpu-windows-2025`. The Create Release job also runs on `blacksmith-2vcpu-ubuntu-2404`.
- Docker workflow runs on `blacksmith-2vcpu-ubuntu-2404` and switches `docker/setup-buildx-action@v3` -> `useblacksmith/setup-docker-builder@v2` (with `cache-key` per Dockerfile) and `docker/build-push-action@v6` -> `useblacksmith/build-push-action@v2`; removes `type=gha` cache export/import in favor of a persistent builder disk. First run will be a cold cache.
- Added `.github/actionlint.yaml` to declare Blacksmith runner labels.
- Rust caching unchanged: `Swatinem/rust-cache` and `mozilla-actions/sccache-action` remain; `sccache` config is now unconditional after removing `use_cross`.
- Rollout: workflows still trigger only on version tags; no secret or config changes required. On the first tag run, verify the macOS x86_64 artifact with `file` or `lipo -info`.

<sup>Written for commit 345ef3e04a8d1bfc5d2214e35302669e6b33f249. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/VeraTools/Vera/pull/45?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

