### PR TITLE
chore: point repository references at the VeraTools org

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@
 Rust 1.85+ required (see `Cargo.toml` `rust-version` for exact MSRV).
 
 ```bash
-git clone https://github.com/lemon07r/Vera.git
+git clone https://github.com/VeraTools/Vera.git
 cd Vera
 cargo build
 ```

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 
 # Vera
 
-[![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/lemon07r/Vera/blob/master/LICENSE)
+[![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/VeraTools/Vera/blob/master/LICENSE)
 [![Rust](https://img.shields.io/badge/rust-1.85%2B-orange.svg)](https://www.rust-lang.org)
-[![GitHub release](https://img.shields.io/github/v/release/lemon07r/Vera?include_prereleases&sort=semver)](https://github.com/lemon07r/Vera/releases)
+[![GitHub release](https://img.shields.io/github/v/release/VeraTools/Vera?include_prereleases&sort=semver)](https://github.com/VeraTools/Vera/releases)
 [![Languages](https://img.shields.io/badge/languages-65%2B-green.svg)](docs/supported-languages.md)
 
 [Install Guide](docs/installation.md)
@@ -207,7 +207,7 @@ vera agent install --client all
 If you use the [skills CLI](https://github.com/vercel-labs/skills), you can install Vera there too:
 
 ```bash
-npx skills add lemon07r/Vera
+npx skills add VeraTools/Vera
 ```
 
 If you skipped the prompt and want to add the instructions manually, use the snippet in the [Installation Guide](docs/installation.md#set-up-agent-skills).

--- a/crates/vera-cli/src/update_check.rs
+++ b/crates/vera-cli/src/update_check.rs
@@ -18,7 +18,7 @@ use serde::{Deserialize, Serialize};
 const CURRENT_VERSION: &str = env!("CARGO_PKG_VERSION");
 const CHECK_INTERVAL: Duration = Duration::from_secs(24 * 60 * 60);
 const GITHUB_API_TIMEOUT: Duration = Duration::from_secs(5);
-const REPO: &str = "lemon07r/Vera";
+const REPO: &str = "VeraTools/Vera";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum VersionCheckSource {

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -16,25 +16,25 @@ The primary use case is running Vera's MCP server as a background process for yo
 **CPU:**
 
 ```bash
-docker run --rm -i -v $(pwd):/workspace ghcr.io/lemon07r/vera:cpu
+docker run --rm -i -v $(pwd):/workspace ghcr.io/veratools/vera:cpu
 ```
 
 **CUDA (NVIDIA):**
 
 ```bash
-docker run --rm --gpus all -i -v $(pwd):/workspace ghcr.io/lemon07r/vera:cuda
+docker run --rm --gpus all -i -v $(pwd):/workspace ghcr.io/veratools/vera:cuda
 ```
 
 **ROCm (AMD):**
 
 ```bash
-docker run --rm --device=/dev/kfd --device=/dev/dri -i -v $(pwd):/workspace ghcr.io/lemon07r/vera:rocm
+docker run --rm --device=/dev/kfd --device=/dev/dri -i -v $(pwd):/workspace ghcr.io/veratools/vera:rocm
 ```
 
 **OpenVINO (Intel):**
 
 ```bash
-docker run --rm --device=/dev/dri -i -v $(pwd):/workspace ghcr.io/lemon07r/vera:openvino
+docker run --rm --device=/dev/dri -i -v $(pwd):/workspace ghcr.io/veratools/vera:openvino
 ```
 
 The container starts `vera mcp` by default (JSON-RPC over stdio). The `-i` flag keeps stdin open for communication. The volume mount gives Vera access to your project files.
@@ -48,7 +48,7 @@ Point your MCP client (Claude Desktop, Cursor, etc.) at the Docker container:
   "mcpServers": {
     "vera": {
       "command": "docker",
-      "args": ["run", "--rm", "-i", "-v", "/path/to/project:/workspace", "ghcr.io/lemon07r/vera:cpu"]
+      "args": ["run", "--rm", "-i", "-v", "/path/to/project:/workspace", "ghcr.io/veratools/vera:cpu"]
     }
   }
 }
@@ -58,7 +58,7 @@ For GPU variants, add the appropriate device flags to `args`:
 
 ```json
 {
-  "args": ["run", "--rm", "--gpus", "all", "-i", "-v", "/path/to/project:/workspace", "ghcr.io/lemon07r/vera:cuda"]
+  "args": ["run", "--rm", "--gpus", "all", "-i", "-v", "/path/to/project:/workspace", "ghcr.io/veratools/vera:cuda"]
 }
 ```
 
@@ -70,7 +70,7 @@ On first run inside the container, Vera will download ONNX models and the ONNX R
 docker run --rm -i \
   -v $(pwd):/workspace \
   -v vera-models:/root/.vera \
-  ghcr.io/lemon07r/vera:cpu
+  ghcr.io/veratools/vera:cpu
 ```
 
 After the first run, subsequent starts skip the download.
@@ -80,9 +80,9 @@ After the first run, subsequent starts skip the download.
 Override the default `mcp` command to run any Vera command:
 
 ```bash
-docker run --rm -v $(pwd):/workspace ghcr.io/lemon07r/vera:cpu index /workspace
-docker run --rm -v $(pwd):/workspace ghcr.io/lemon07r/vera:cpu search "authentication logic"
-docker run --rm -v $(pwd):/workspace ghcr.io/lemon07r/vera:cpu stats
+docker run --rm -v $(pwd):/workspace ghcr.io/veratools/vera:cpu index /workspace
+docker run --rm -v $(pwd):/workspace ghcr.io/veratools/vera:cpu search "authentication logic"
+docker run --rm -v $(pwd):/workspace ghcr.io/veratools/vera:cpu stats
 ```
 
 ## Building locally

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -18,11 +18,11 @@ The installer downloads the `vera` binary for your platform, writes a shim to a 
 <summary>Other install methods</summary>
 
 **Prebuilt binaries:**
-Download from [GitHub Releases](https://github.com/lemon07r/Vera/releases) for Linux (x86_64, aarch64), macOS (x86_64, aarch64), or Windows (x86_64). For Alpine, NixOS, or minimal containers without glibc, use the `x86_64-unknown-linux-musl` archive (fully static, zero runtime dependencies). The npm/pip wrappers auto-detect musl systems; to force a specific target, set `VERA_TARGET=x86_64-unknown-linux-musl` before running the install command.
+Download from [GitHub Releases](https://github.com/VeraTools/Vera/releases) for Linux (x86_64, aarch64), macOS (x86_64, aarch64), or Windows (x86_64). For Alpine, NixOS, or minimal containers without glibc, use the `x86_64-unknown-linux-musl` archive (fully static, zero runtime dependencies). The npm/pip wrappers auto-detect musl systems; to force a specific target, set `VERA_TARGET=x86_64-unknown-linux-musl` before running the install command.
 
 **Build from source** (Rust 1.85+):
 ```bash
-git clone https://github.com/lemon07r/Vera.git && cd Vera
+git clone https://github.com/VeraTools/Vera.git && cd Vera
 bash scripts/bootstrap-vendored-grammars.sh   # downloads the four grammars that are not tracked in git
 cargo build --release
 cp target/release/vera ~/.local/bin/
@@ -31,7 +31,7 @@ vera setup
 
 **Docker** (MCP server):
 ```bash
-docker run --rm -i -v $(pwd):/workspace ghcr.io/lemon07r/vera:cpu
+docker run --rm -i -v $(pwd):/workspace ghcr.io/veratools/vera:cpu
 ```
 CPU, CUDA, ROCm, and OpenVINO images available. See [docker.md](docker.md).
 
@@ -171,7 +171,7 @@ Use Vera before opening many files or running broad text search when you need to
 <summary>Use the Vercel skills CLI instead</summary>
 
 ```bash
-npx skills add lemon07r/Vera
+npx skills add VeraTools/Vera
 ```
 
 </details>

--- a/packages/npm-cli/README.md
+++ b/packages/npm-cli/README.md
@@ -45,7 +45,7 @@ vera search "authentication logic"
 | Inspect binary upgrades | `vera upgrade` |
 | Install agent skills | `vera agent install` |
 
-For the full backend matrix, model options, Docker setup, and troubleshooting, see the main [README](https://github.com/lemon07r/Vera) and [Installation Guide](https://github.com/lemon07r/Vera/blob/master/docs/installation.md).
+For the full backend matrix, model options, Docker setup, and troubleshooting, see the main [README](https://github.com/VeraTools/Vera) and [Installation Guide](https://github.com/VeraTools/Vera/blob/master/docs/installation.md).
 
 ## What you get
 
@@ -55,4 +55,4 @@ For the full backend matrix, model options, Docker setup, and troubleshooting, s
 - **Git-aware scopes and index debugging**: `--changed` / `--since` / `--base`, `explain-path`, and index health in `vera stats`
 - **Markdown codeblock output** by default with file paths, line ranges, and optional symbol info (use `--json` for compact JSON; `--raw` works with `vera search`, `vera grep`, and `vera references`; `--timing` works with `vera search` and `vera grep`, before or after the subcommand)
 
-For full documentation, including local model options and manual install steps, see the [GitHub repo](https://github.com/lemon07r/Vera).
+For full documentation, including local model options and manual install steps, see the [GitHub repo](https://github.com/VeraTools/Vera).

--- a/packages/npm-cli/bin/vera.js
+++ b/packages/npm-cli/bin/vera.js
@@ -13,7 +13,7 @@ const { spawnSync } = require("node:child_process");
 
 const { version: packageVersion } = require("../package.json");
 
-const DEFAULT_REPO = "lemon07r/Vera";
+const DEFAULT_REPO = "VeraTools/Vera";
 const MAX_REDIRECTS = 5;
 
 function parseArgs(argv) {

--- a/packages/npm-cli/package.json
+++ b/packages/npm-cli/package.json
@@ -3,14 +3,14 @@
   "version": "0.4.0",
   "description": "Bootstrap installer and wrapper for the Vera CLI",
   "license": "MIT",
-  "homepage": "https://github.com/lemon07r/Vera#readme",
+  "homepage": "https://github.com/VeraTools/Vera#readme",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/lemon07r/Vera.git",
+    "url": "git+https://github.com/VeraTools/Vera.git",
     "directory": "packages/npm-cli"
   },
   "bugs": {
-    "url": "https://github.com/lemon07r/Vera/issues"
+    "url": "https://github.com/VeraTools/Vera/issues"
   },
   "bin": "./bin/vera.js",
   "scripts": {

--- a/packages/python-cli/README.md
+++ b/packages/python-cli/README.md
@@ -45,7 +45,7 @@ vera-ai search "authentication logic"
 | Inspect binary upgrades | `vera-ai upgrade` |
 | Install agent skills | `vera-ai agent install` |
 
-For the full backend matrix, model options, Docker setup, and troubleshooting, see the main [README](https://github.com/lemon07r/Vera) and [Installation Guide](https://github.com/lemon07r/Vera/blob/master/docs/installation.md).
+For the full backend matrix, model options, Docker setup, and troubleshooting, see the main [README](https://github.com/VeraTools/Vera) and [Installation Guide](https://github.com/VeraTools/Vera/blob/master/docs/installation.md).
 
 ## What you get
 
@@ -55,4 +55,4 @@ For the full backend matrix, model options, Docker setup, and troubleshooting, s
 - **Git-aware scopes and index debugging**: `--changed` / `--since` / `--base`, `explain-path`, and index health in `vera-ai stats`
 - **Markdown codeblock output** by default with file paths, line ranges, and optional symbol info (use `--json` for compact JSON; `--raw` works with `vera-ai search`, `vera-ai grep`, and `vera-ai references`; `--timing` works with `vera-ai search` and `vera-ai grep`, before or after the subcommand)
 
-For full documentation, including local model options and manual install steps, see the [GitHub repo](https://github.com/lemon07r/Vera).
+For full documentation, including local model options and manual install steps, see the [GitHub repo](https://github.com/VeraTools/Vera).

--- a/packages/python-cli/pyproject.toml
+++ b/packages/python-cli/pyproject.toml
@@ -9,13 +9,13 @@ description = "Bootstrap installer and wrapper for the Vera CLI"
 readme = "README.md"
 requires-python = ">=3.9"
 license = { text = "MIT" }
-authors = [{ name = "lemon07r" }]
+authors = [{ name = "VeraTools" }]
 keywords = ["vera", "cli", "code-search", "agents"]
 
 [project.urls]
-Homepage = "https://github.com/lemon07r/Vera#readme"
-Repository = "https://github.com/lemon07r/Vera"
-Issues = "https://github.com/lemon07r/Vera/issues"
+Homepage = "https://github.com/VeraTools/Vera#readme"
+Repository = "https://github.com/VeraTools/Vera"
+Issues = "https://github.com/VeraTools/Vera/issues"
 
 [project.scripts]
 vera-ai = "vera_ai_wrapper.__main__:main"

--- a/packages/python-cli/src/vera_ai_wrapper/__main__.py
+++ b/packages/python-cli/src/vera_ai_wrapper/__main__.py
@@ -16,7 +16,7 @@ from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
 
 
-DEFAULT_REPO = "lemon07r/Vera"
+DEFAULT_REPO = "VeraTools/Vera"
 MAX_REDIRECTS = 5
 
 


### PR DESCRIPTION
The repo moved from lemon07r/Vera to VeraTools/Vera. GitHub redirects keep old links working, but this updates all hardcoded references to the canonical org.

- `crates/vera-cli/src/update_check.rs`: release-check API now queries VeraTools/Vera (what `vera upgrade` polls)
- `packages/npm-cli/bin/vera.js`, `packages/python-cli/src/vera_ai_wrapper/__main__.py`: release-download repo default
- `packages/npm-cli/package.json`, `packages/python-cli/pyproject.toml`: homepage/repository/issues URLs (and pyproject author now VeraTools; LICENSE copyright attribution intentionally unchanged)
- README, CONTRIBUTING, docs/installation.md, docs/docker.md (incl. ghcr.io/veratools/vera image paths), package READMEs

`rg lemon07r` after this change matches only the LICENSE copyright line. cargo fmt clean; no test asserts the old URL.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/VeraTools/codesmith/Vera/pr/46"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789722520&installation_model_id=432833&pr_number=46&repository=VeraTools%2FVera&return_to=https%3A%2F%2Fgithub.com%2FVeraTools%2FVera%2Fpull%2F46&signature=e89761c014191d2181856587515f591008f52e358ab4d67aa1718c302ece20a5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Point all hardcoded references from `lemon07r/Vera` to `VeraTools/Vera` so upgrade checks, installers, and docs use the canonical repo and GHCR image. Old GitHub links continue to work via redirects.

- CLI behavior: `vera upgrade` and `vera-ai upgrade` now query `VeraTools/Vera`; release downloads default to that repo in `packages/npm-cli` and `packages/python-cli`.
- Docker: docs now reference `ghcr.io/veratools/vera` images; update any local configs using `ghcr.io/lemon07r/vera`.
- Docs/metadata: badges, install instructions, skills CLI snippets, and package metadata (`homepage`, `repository`, `issues`; Python author) now point to `VeraTools`. LICENSE attribution unchanged.
- Sanity check: only the LICENSE still contains `lemon07r`; no code relies on the old path.

<sup>Written for commit f83bad28fe1b3f8fa6e1fb415b0b5257d56e7ed6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/VeraTools/Vera/pull/46?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

