### PR TITLE
fix(cli): stop agent sync from overwriting user-edited markdown

### DIFF
--- a/crates/vera-cli/src/commands/agent.rs
+++ b/crates/vera-cli/src/commands/agent.rs
@@ -921,14 +921,20 @@ fn skill_path_for(
 }
 
 fn sync(json_output: bool) -> anyhow::Result<()> {
-    sync_with_options(json_output, true)
+    sync_with_options(json_output, true, false)
 }
 
+/// Automatic staleness sync: refresh skill installs only, without touching
+/// project markdown or writing over the user's command output.
 pub(crate) fn sync_skills_only() -> anyhow::Result<()> {
-    sync_with_options(false, false)
+    sync_with_options(false, false, true)
 }
 
-fn sync_with_options(json_output: bool, refresh_project_snippets: bool) -> anyhow::Result<()> {
+fn sync_with_options(
+    json_output: bool,
+    refresh_project_snippets: bool,
+    quiet: bool,
+) -> anyhow::Result<()> {
     let home = state::user_home_dir()?;
     let project_cwd = std::env::current_dir().ok();
     let current_version = env!("CARGO_PKG_VERSION");
@@ -958,6 +964,10 @@ fn sync_with_options(json_output: bool, refresh_project_snippets: bool) -> anyho
     } else {
         Vec::new()
     };
+
+    if quiet {
+        return Ok(());
+    }
 
     if json_output {
         let reports: Vec<_> = updated
@@ -1166,7 +1176,7 @@ fn refresh_vera_snippet_in_markdown(existing: &str) -> Option<String> {
         let end_marker = content_start + end_marker;
         let mut content = String::with_capacity(existing.len());
         content.push_str(&existing[..content_start]);
-        content.push_str(marked_snippet_body());
+        content.push_str(&adapt_line_endings(marked_snippet_body(), existing));
         content.push_str(&existing[end_marker..]);
         return Some(content);
     }
@@ -1186,6 +1196,7 @@ fn refresh_vera_snippet_in_markdown(existing: &str) -> Option<String> {
     let section = &existing[start..end];
 
     let legacy_snippet = legacy_agents_md_snippet();
+    let legacy_snippet = adapt_line_endings(&legacy_snippet, existing);
     if !section.contains(AGENTS_MD_SNIPPET_INTRO) || section.trim_end() != legacy_snippet.trim_end()
     {
         return None;
@@ -1193,7 +1204,7 @@ fn refresh_vera_snippet_in_markdown(existing: &str) -> Option<String> {
 
     let section_without_trailing_whitespace = section.trim_end();
     let trailing_whitespace = &section[section_without_trailing_whitespace.len()..];
-    let mut replacement = String::from(AGENTS_MD_SNIPPET.trim_end());
+    let mut replacement = adapt_line_endings(AGENTS_MD_SNIPPET.trim_end(), existing).into_owned();
     if trailing_whitespace.is_empty() {
         replacement.push('\n');
     } else {
@@ -1221,6 +1232,15 @@ fn legacy_agents_md_snippet() -> String {
     AGENTS_MD_SNIPPET
         .replace(&format!("{VERA_SNIPPET_BEGIN_MARKER}\n\n"), "")
         .replace(&format!("\n{VERA_SNIPPET_END_MARKER}"), "")
+}
+
+/// Match generated content's line endings to the target file's.
+fn adapt_line_endings<'a>(generated: &'a str, file: &str) -> std::borrow::Cow<'a, str> {
+    if file.contains("\r\n") {
+        std::borrow::Cow::Owned(generated.replace('\n', "\r\n"))
+    } else {
+        std::borrow::Cow::Borrowed(generated)
+    }
 }
 
 fn markdown_marker_start(existing: &str, marker: &str) -> Option<usize> {
@@ -1524,6 +1544,37 @@ mod tests {
         assert!(updated.contains(VERA_SNIPPET_BEGIN_MARKER));
         assert!(updated.contains(VERA_SNIPPET_END_MARKER));
         assert!(updated.contains("# Guidelines\n\nRun tests first.\n"));
+    }
+
+    #[test]
+    fn refresh_vera_snippet_in_markdown_preserves_crlf_line_endings() {
+        let existing = format!(
+            "# Repo\r\n\r\n{VERA_SNIPPET_BEGIN_MARKER}\r\n\r\nOld generated content.\r\n{VERA_SNIPPET_END_MARKER}\r\n"
+        );
+
+        let updated = refresh_vera_snippet_in_markdown(&existing).unwrap();
+
+        assert!(updated.contains(marked_snippet_body().lines().next().unwrap()));
+        assert!(!updated.contains("Old generated content."));
+        // No bare LF: every line feed is part of a CRLF pair.
+        assert_eq!(
+            updated.matches('\n').count(),
+            updated.matches("\r\n").count()
+        );
+    }
+
+    #[test]
+    fn refresh_vera_snippet_in_markdown_migrates_crlf_legacy_section() {
+        let legacy = legacy_agents_md_snippet().replace('\n', "\r\n");
+        let existing = format!("# Repo\r\n\r\n{}\r\n", legacy.trim_end());
+
+        let updated = refresh_vera_snippet_in_markdown(&existing).unwrap();
+
+        assert!(updated.contains(VERA_SNIPPET_BEGIN_MARKER));
+        assert_eq!(
+            updated.matches('\n').count(),
+            updated.matches("\r\n").count()
+        );
     }
 
     #[test]

--- a/crates/vera-cli/src/commands/agent.rs
+++ b/crates/vera-cli/src/commands/agent.rs
@@ -921,6 +921,14 @@ fn skill_path_for(
 }
 
 fn sync(json_output: bool) -> anyhow::Result<()> {
+    sync_with_options(json_output, true)
+}
+
+pub(crate) fn sync_skills_only() -> anyhow::Result<()> {
+    sync_with_options(false, false)
+}
+
+fn sync_with_options(json_output: bool, refresh_project_snippets: bool) -> anyhow::Result<()> {
     let home = state::user_home_dir()?;
     let project_cwd = std::env::current_dir().ok();
     let current_version = env!("CARGO_PKG_VERSION");
@@ -939,13 +947,17 @@ fn sync(json_output: bool) -> anyhow::Result<()> {
         updated.push(location.path.clone());
     }
 
-    // Refresh managed markdown snippets whenever a project directory is
-    // available, regardless of which skill installs were stale.
-    let refreshed_snippets = project_cwd
-        .as_deref()
-        .map(|cwd| refresh_existing_vera_snippets(&find_agent_configs(cwd)))
-        .transpose()?
-        .unwrap_or_default();
+    let refreshed_snippets = if refresh_project_snippets {
+        // Refresh managed markdown snippets whenever a project directory is
+        // available, regardless of which skill installs were stale.
+        project_cwd
+            .as_deref()
+            .map(|cwd| refresh_existing_vera_snippets(&find_agent_configs(cwd)))
+            .transpose()?
+            .unwrap_or_default()
+    } else {
+        Vec::new()
+    };
 
     if json_output {
         let reports: Vec<_> = updated
@@ -988,10 +1000,14 @@ fn sync(json_output: bool) -> anyhow::Result<()> {
 }
 
 /// The snippet Vera offers to inject into agent config files.
+const VERA_SNIPPET_BEGIN_MARKER: &str = "<!-- vera:begin -->";
+const VERA_SNIPPET_END_MARKER: &str = "<!-- vera:end -->";
 const AGENTS_MD_SNIPPET_HEADING: &str = "## Code Search";
 const AGENTS_MD_SNIPPET_INTRO: &str = "Use Vera before opening many files or running broad text search when you need to find where logic lives or how a feature works.";
 
 const AGENTS_MD_SNIPPET: &str = r#"## Code Search
+
+<!-- vera:begin -->
 
 Use Vera before opening many files or running broad text search when you need to find where logic lives or how a feature works.
 
@@ -1007,6 +1023,7 @@ Use Vera before opening many files or running broad text search when you need to
 - Narrow `vera search` or `vera grep` with `--lang`, `--path`, `--type`, or `--scope docs`
 - `vera watch .` to auto-update the index, or `vera update .` after edits (`vera index .` if `.vera/` is missing)
 - For detailed usage, query patterns, and troubleshooting, read the Vera skill file installed by `vera agent install`
+<!-- vera:end -->
 "#;
 
 #[derive(Debug, Clone, Copy)]
@@ -1142,6 +1159,18 @@ fn refresh_vera_snippet(existing: &str, file_name: &str) -> Option<String> {
 }
 
 fn refresh_vera_snippet_in_markdown(existing: &str) -> Option<String> {
+    if let Some(begin) = markdown_marker_start(existing, VERA_SNIPPET_BEGIN_MARKER) {
+        let content_start = begin + VERA_SNIPPET_BEGIN_MARKER.len();
+        let end_marker =
+            markdown_marker_start(&existing[content_start..], VERA_SNIPPET_END_MARKER)?;
+        let end_marker = content_start + end_marker;
+        let mut content = String::with_capacity(existing.len());
+        content.push_str(&existing[..content_start]);
+        content.push_str(marked_snippet_body());
+        content.push_str(&existing[end_marker..]);
+        return Some(content);
+    }
+
     let start = markdown_section_start(existing, AGENTS_MD_SNIPPET_HEADING)?;
     // The managed section ends at the next heading of equal or higher level
     // (`## ` or `# `). Deeper headings (`### ` and below) stay in the section.
@@ -1155,36 +1184,65 @@ fn refresh_vera_snippet_in_markdown(existing: &str) -> Option<String> {
         })
         .unwrap_or(existing.len());
     let section = &existing[start..end];
-    if !section.contains(AGENTS_MD_SNIPPET_INTRO) {
+
+    let legacy_snippet = legacy_agents_md_snippet();
+    if !section.contains(AGENTS_MD_SNIPPET_INTRO) || section.trim_end() != legacy_snippet.trim_end()
+    {
         return None;
     }
 
-    let before = existing[..start].trim_end_matches('\n');
-    let after = existing[end..].trim_start_matches('\n');
-    let mut content = String::new();
-    if !before.is_empty() {
-        content.push_str(before);
-        content.push_str("\n\n");
-    }
-    content.push_str(AGENTS_MD_SNIPPET.trim_end());
-    if !after.is_empty() {
-        content.push_str("\n\n");
-        content.push_str(after);
+    let section_without_trailing_whitespace = section.trim_end();
+    let trailing_whitespace = &section[section_without_trailing_whitespace.len()..];
+    let mut replacement = String::from(AGENTS_MD_SNIPPET.trim_end());
+    if trailing_whitespace.is_empty() {
+        replacement.push('\n');
     } else {
-        content.push('\n');
+        replacement.push_str(trailing_whitespace);
     }
-    if !content.ends_with('\n') {
-        content.push('\n');
-    }
+
+    let mut content = String::with_capacity(existing.len());
+    content.push_str(&existing[..start]);
+    content.push_str(&replacement);
+    content.push_str(&existing[end..]);
     Some(content)
 }
 
-fn markdown_section_start(existing: &str, heading: &str) -> Option<usize> {
-    if existing.starts_with(heading) {
-        return Some(0);
-    }
+fn marked_snippet_body() -> &'static str {
+    let (_, body) = AGENTS_MD_SNIPPET
+        .split_once(VERA_SNIPPET_BEGIN_MARKER)
+        .expect("AGENTS_MD_SNIPPET must contain the begin marker");
+    let (body, _) = body
+        .split_once(VERA_SNIPPET_END_MARKER)
+        .expect("AGENTS_MD_SNIPPET must contain the end marker");
+    body
+}
 
-    existing.find(&format!("\n{heading}")).map(|idx| idx + 1)
+fn legacy_agents_md_snippet() -> String {
+    AGENTS_MD_SNIPPET
+        .replace(&format!("{VERA_SNIPPET_BEGIN_MARKER}\n\n"), "")
+        .replace(&format!("\n{VERA_SNIPPET_END_MARKER}"), "")
+}
+
+fn markdown_marker_start(existing: &str, marker: &str) -> Option<usize> {
+    let mut offset = 0;
+    for line in existing.split_inclusive('\n') {
+        if line.trim_end() == marker {
+            return Some(offset);
+        }
+        offset += line.len();
+    }
+    None
+}
+
+fn markdown_section_start(existing: &str, heading: &str) -> Option<usize> {
+    let mut offset = 0;
+    for line in existing.split_inclusive('\n') {
+        if line.trim_end() == heading {
+            return Some(offset);
+        }
+        offset += line.len();
+    }
+    None
 }
 
 fn insert_vera_snippet_into_markdown(existing: &str) -> String {
@@ -1437,39 +1495,58 @@ mod tests {
     }
 
     #[test]
-    fn refresh_vera_snippet_in_markdown_replaces_stale_managed_section() {
-        let existing = "# Repository Guidelines\n\n## Code Search\n\nUse Vera before opening many files or running broad text search when you need to find where logic lives or how a feature works.\n\n- `vera search \"query\"` for semantic code search. Describe behavior: \"JWT validation\", not \"auth\".\n- `vera grep \"pattern\"` for exact text or regex\n- `vera references <symbol>` for callers and callees\n- `vera overview` for a project summary (languages, entry points, hotspots)\n- `vera search --deep \"query\"` for RAG-fusion query expansion + merged ranking\n- Narrow results with `--lang`, `--path`, `--type`, or `--scope docs`\n- `vera watch .` to auto-update the index, or `vera update .` after edits (`vera index .` if `.vera/` is missing)\n- For detailed usage, query patterns, and troubleshooting, read the Vera skill file installed by `vera agent install`\n\n## Build\n\nRun tests.\n";
-
-        let updated = refresh_vera_snippet_in_markdown(existing).unwrap();
-
-        assert!(updated.contains(AGENTS_MD_SNIPPET.trim_end()));
-        assert!(!updated.contains("- `vera grep \"pattern\"` for exact text or regex\n"));
-        assert!(
-            !updated.contains(
-                "- Narrow results with `--lang`, `--path`, `--type`, or `--scope docs`\n"
-            )
+    fn refresh_vera_snippet_in_markdown_refreshes_marked_region() {
+        let existing = format!(
+            "# Repository Guidelines\n\n## Code Search\n\nUser-owned context.\n{VERA_SNIPPET_BEGIN_MARKER}\n\nOld generated content.\n{VERA_SNIPPET_END_MARKER}\n\nUser-owned note.\n\n## Build\n\nRun tests.\n"
         );
-        assert!(updated.contains("## Build\n\nRun tests.\n"));
+
+        let updated = refresh_vera_snippet_in_markdown(&existing).unwrap();
+
+        assert!(updated.contains(&format!(
+            "{VERA_SNIPPET_BEGIN_MARKER}{}{VERA_SNIPPET_END_MARKER}",
+            marked_snippet_body()
+        )));
+        assert!(updated.contains("User-owned context.\n"));
+        assert!(updated.contains("User-owned note.\n"));
+        assert!(!updated.contains("Old generated content."));
     }
 
     #[test]
-    fn refresh_vera_snippet_in_markdown_preserves_following_top_level_section() {
+    fn refresh_vera_snippet_in_markdown_migrates_identical_legacy_section() {
         let existing = format!(
-            "{}\n\n# Guidelines\n\nRun tests first.\n",
-            AGENTS_MD_SNIPPET.trim_end()
+            "# Repository Guidelines\n\n{}\n\n# Guidelines\n\nRun tests first.\n",
+            legacy_agents_md_snippet().trim_end()
         );
 
         let updated = refresh_vera_snippet_in_markdown(&existing).unwrap();
 
         assert!(updated.contains(AGENTS_MD_SNIPPET.trim_end()));
+        assert!(updated.contains(VERA_SNIPPET_BEGIN_MARKER));
+        assert!(updated.contains(VERA_SNIPPET_END_MARKER));
         assert!(updated.contains("# Guidelines\n\nRun tests first.\n"));
     }
 
     #[test]
-    fn refresh_vera_snippet_in_markdown_skips_custom_code_search_section() {
-        let existing = "# Repository Guidelines\n\n## Code Search\n\nUse ripgrep first.\n\n## Build\n\nRun tests.\n";
+    fn refresh_vera_snippet_in_markdown_skips_edited_legacy_section() {
+        let edited = legacy_agents_md_snippet().replace(
+            "- `vera grep \"pattern\"` for exact text or regex in indexed files",
+            "- Use my preferred search tool instead",
+        );
+        let existing = format!(
+            "# Repository Guidelines\n\n{}\n\n## Build\n\nRun tests.\n",
+            edited.trim_end()
+        );
 
-        assert!(refresh_vera_snippet_in_markdown(existing).is_none());
+        assert!(refresh_vera_snippet_in_markdown(&existing).is_none());
+    }
+
+    #[test]
+    fn refresh_vera_snippet_in_markdown_skips_similar_edited_heading() {
+        let existing = format!(
+            "# Repository Guidelines\n\n## Code Search (Vera)\n\n{AGENTS_MD_SNIPPET_INTRO}\n\n- Use my preferred search tool instead.\n\n## Build\n\nRun tests.\n"
+        );
+
+        assert!(refresh_vera_snippet_in_markdown(&existing).is_none());
     }
 
     #[test]

--- a/crates/vera-cli/src/update_check.rs
+++ b/crates/vera-cli/src/update_check.rs
@@ -110,12 +110,7 @@ fn check_skill_staleness() {
     }
 
     // Auto-sync stale skills silently instead of nagging the user.
-    match crate::commands::agent::run(
-        crate::commands::agent::AgentCommand::Sync,
-        None,
-        None,
-        false,
-    ) {
+    match crate::commands::agent::sync_skills_only() {
         Ok(()) => {}
         Err(_) => {
             // Fall back to a hint if auto-sync fails.

--- a/docs/features.md
+++ b/docs/features.md
@@ -251,7 +251,7 @@ During setup, Vera offers to add a usage snippet to your project's agent config 
 
 ### Syncing Stale Skills
 
-`vera agent sync` refreshes stale agent skill installs to match the current binary version and updates marked project snippets. When Vera notices stale installs during normal CLI use, it refreshes skills only and leaves project markdown unchanged.
+`vera agent sync` refreshes stale agent skill installs to match the current binary version and updates Vera-owned project markdown snippets: sections wrapped in `<!-- vera:begin -->` / `<!-- vera:end -->` markers, plus unmarked legacy sections whose text still matches the generated snippet exactly (these are migrated into markers on sync). Editing anything in the section, or deleting it, takes it out of sync scope permanently. When Vera notices stale installs during normal CLI use, it refreshes skill files only, silently, and leaves project markdown unchanged.
 
 ## CLI Tooling
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -251,7 +251,7 @@ During setup, Vera offers to add a usage snippet to your project's agent config 
 
 ### Syncing Stale Skills
 
-`vera agent sync` refreshes stale agent skill installs to match the current binary version. When Vera notices stale installs during normal CLI use, it runs the same sync automatically. Project syncs also refresh managed markdown agent-config snippets such as `AGENTS.md`, `CLAUDE.md`, and `COPILOT.md`.
+`vera agent sync` refreshes stale agent skill installs to match the current binary version and updates marked project snippets. When Vera notices stale installs during normal CLI use, it refreshes skills only and leaves project markdown unchanged.
 
 ## CLI Tooling
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -147,6 +147,8 @@ This is optional but recommended if you use AI coding agents. The interactive fl
 ```markdown
 ## Code Search
 
+<!-- vera:begin -->
+
 Use Vera before opening many files or running broad text search when you need to find where logic lives or how a feature works.
 
 - `vera search "query"` for semantic code search. Describe behavior: "JWT validation", not "auth". If one phrasing misses, try 2-3 varied queries or add `--intent "goal"`.
@@ -161,6 +163,7 @@ Use Vera before opening many files or running broad text search when you need to
 - Narrow `vera search` or `vera grep` with `--lang`, `--path`, `--type`, or `--scope docs`
 - `vera watch .` to auto-update the index, or `vera update .` after edits (`vera index .` if `.vera/` is missing)
 - For detailed usage, query patterns, and troubleshooting, read the Vera skill file installed by `vera agent install`
+<!-- vera:end -->
 ```
 
 `vera structural impls <symbol>` only finds explicit declarations such as `implements`, `extends`, `with`, `:`, or `impl Trait for Type`. It does not infer implicit interface satisfaction.

--- a/skills/vera/references/install.md
+++ b/skills/vera/references/install.md
@@ -64,7 +64,7 @@ The `agents` client writes to the cross-agent `.agents/skills/` directory, which
 ```sh
 vera upgrade              # show update plan
 vera upgrade --apply      # execute the binary upgrade
-vera agent sync           # sync skill files and refresh managed project snippets
+vera agent sync           # sync skill files and refresh marked project snippets
 ```
 
 ## Uninstalling

--- a/skills/vera/references/install.md
+++ b/skills/vera/references/install.md
@@ -64,7 +64,7 @@ The `agents` client writes to the cross-agent `.agents/skills/` directory, which
 ```sh
 vera upgrade              # show update plan
 vera upgrade --apply      # execute the binary upgrade
-vera agent sync           # sync skill files and refresh marked project snippets
+vera agent sync           # sync skill files and refresh Vera-owned project snippets (marked, or verbatim legacy ones)
 ```
 
 ## Uninstalling


### PR DESCRIPTION
Closes #36.

## Problem

`vera agent sync` matched project markdown sections by heading prefix (`## Code Search` also matched `## Code Search (Vera)`) plus the presence of one intro sentence, then replaced the entire section with the canned snippet — destroying hand edits with no prompt or backup. Worse, `check_skill_staleness` auto-ran the same sync from unrelated commands (`doctor`, `stats`, `search`, ...), so any version skew rewrote user files as a side effect.

## Fix

1. **Managed-block markers.** Generated snippets now carry `<!-- vera:begin -->` / `<!-- vera:end -->`. Refresh replaces only content inside a marked region; user content around it (including custom heading suffixes) is preserved. Users opt out permanently by deleting the markers.
2. **Safe legacy migration.** Unmarked legacy sections are refreshed only when byte-identical (modulo trailing whitespace) to the known generated snippet; anything user-edited is left untouched. Heading matching is now exact-line, not prefix.
3. **Skill-only auto-sync.** `check_skill_staleness` now calls a `sync_skills_only()` path that never reads or writes project markdown. Explicit `vera agent sync` still refreshes marked/migratable snippets.

## Behavior change to note

Automatic staleness sync no longer updates project markdown at all — only explicit `vera agent sync` does. This is deliberate: silent modification of user-authored files was the bug.

## Verification

4 new/rewritten tests cover: marked-region refresh, edited-legacy preservation, identical-legacy migration, edited-heading-variant preservation. 14 agent tests pass; clippy/fmt clean. docs/installation.md snippet updated with markers; docs/features.md describes the new sync behavior.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/VeraTools/codesmith/Vera/pr/47"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789724855&installation_model_id=432833&pr_number=47&repository=VeraTools%2FVera&return_to=https%3A%2F%2Fgithub.com%2FVeraTools%2FVera%2Fpull%2F47&signature=4fca7fa16106d6228e56d8f1596ba3d9f8fb274dc922efffc99e00c580a25cc3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops `vera agent sync` from overwriting user-edited markdown. Previously, both explicit sync and automatic staleness checks could replace whole sections via prefix heading matching; now explicit sync updates only Vera-owned regions (or safely migrates verbatim legacy text), and auto-sync refreshes skills only and is silent.

- Adds managed markers `<!-- vera:begin -->` / `<!-- vera:end -->`; refresh replaces only the marked body, preserving surrounding content and custom heading suffixes. Delete the markers to opt out.
- Legacy sections update only when byte-identical to the known snippet (ignoring trailing whitespace); heading matching is exact-line (`## Code Search` only), so similar headings are untouched.
- Routes automatic staleness checks through `sync_skills_only()`: no project markdown reads/writes and no stdout output after unrelated commands.
- Refresh is CRLF-safe: generated content matches the file’s line endings, and legacy detection works on CRLF files.
- Docs show the markers and behavior; tests cover marked refresh, identical-legacy migration, edited/variant-heading preservation, and CRLF files.

<sup>Written for commit 2b8bc1a2e8695676ff404a35fe2ee6c794212417. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/VeraTools/Vera/pull/47?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

