### PR TITLE
chore: add CodeRabbit configuration tuned to project guidelines

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,45 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+language: en
+reviews:
+  # profile/tools/finishing_touches and chat.auto_reply are Pro-tier fields;
+  # on the free tier CodeRabbit ignores them and reviews continue with the
+  # remaining settings (path_instructions, toggles) unchanged.
+  profile: assertive
+  request_changes_workflow: true
+  high_level_summary: true
+  poem: false
+  collapse_walkthrough: true
+  sequence_diagrams: false
+  review_status: true
+  path_instructions:
+    - path: "crates/vera-core/src/retrieval/**"
+      instructions: |
+        Ranking/retrieval changes must obey the repo's benchmark-integrity rules: no heuristic tuning that only helps isolated benchmark tasks, every signal needs a mechanism-level rationale grounded in how developers search code, and behavior changes require Semble benchmark verification. Flag any ranking change that lacks justification or tests.
+    - path: "crates/**"
+      instructions: |
+        Enforce the repo's Rust guidelines: minimal LOC, no duplicated logic (suggest extraction), simple readable code over clever code, anyhow::Result in CLI code and thiserror in vera-core, tracing for logging, tests in #[cfg(test)] modules at file bottom. Rust edition 2024, MSRV 1.85.
+    - path: "**/*.md"
+      instructions: |
+        Docs must follow the repo's documentation rules: no em-dashes in user-facing docs, no hedging or banned words (comprehensive, robust, seamless, leverage, utilize, facilitate, empower, cutting-edge, state-of-the-art, holistic), one fact in exactly one place, and docs must be updated in the same PR as the behavior they describe. Flag stale claims (test counts, version numbers) that contradict code.
+    - path: ".github/workflows/**"
+      instructions: |
+        This repo runs CI on Blacksmith runners (blacksmith-* labels; see .github/actionlint.yaml). Do not flag blacksmith-* runner labels as unknown. Release workflows must preserve the 6 Rust targets and archive names vera-<target>.(tar.gz|zip).
+    - path: "eval/**"
+      instructions: |
+        Benchmark harness changes must not weaken integrity: no hardcoded expected answers, no silent skipping of failed tasks, metrics math must stay consistent across scripts (see benchmarks/scripts/bench_common.py).
+  tools:
+    actionlint:
+      enabled: true
+    shellcheck:
+      enabled: true
+    markdownlint:
+      enabled: true
+    ruff:
+      enabled: true
+  finishing_touches:
+    docstrings:
+      enabled: false
+    unit_tests:
+      enabled: false
+chat:
+  auto_reply: true


### PR DESCRIPTION
Tunes CodeRabbit to this repo instead of running it with generic defaults.

- **Assertive profile + request-changes workflow**: it should catch things, not rubber-stamp.
- **Path instructions** encoding repo rules: benchmark-integrity requirements for `retrieval/**` (mechanism rationale + Semble verification for ranking changes), minimal-LOC/no-duplication Rust conventions for `crates/**`, docs tone/freshness rules for `*.md`, Blacksmith runner awareness for workflows, benchmark-harness integrity for `eval/**`.
- **Integrated linters**: actionlint, shellcheck, markdownlint, ruff run inside reviews.
- **Noise off**: no poems, no sequence diagrams, collapsed walkthroughs; docstring/unit-test generation explicitly disabled (churn, against minimal-LOC).
- **Free-tier safe**: Pro-gated fields (profile, tools, finishing_touches, chat auto-reply) are marked with a comment; CodeRabbit ignores them post-trial and the rest keeps working.

Validated against the published v2 JSON schema (keys + types) and yaml.safe_load.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/VeraTools/codesmith/Vera/pr/48"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789725093&installation_model_id=432833&pr_number=48&repository=VeraTools%2FVera&return_to=https%3A%2F%2Fgithub.com%2FVeraTools%2FVera%2Fpull%2F48&signature=6eab2ba309c38b99c45187d2242f132da4e937bcf6ee905ca329eb70d79655e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a project-specific `.coderabbit.yaml` so CodeRabbit enforces our repo rules instead of generic defaults. Reviews switch to an assertive, request-changes workflow with integrated linters; auto-generation of docstrings and unit tests is disabled to avoid churn.

- Review focus:
  - Check path globs and intent:
    - `crates/vera-core/src/retrieval/**`: require mechanism-level rationale for ranking changes and Semble benchmark verification.
    - `crates/**`: Rust conventions (edition 2024, MSRV 1.85, `anyhow::Result` for CLI, `thiserror` in core, `tracing`, tests in `#[cfg(test)]` at file end).
    - `**/*.md`: docs tone/freshness rules and single-source-of-truth.
    - `.github/workflows/**`: allow Blacksmith runner labels and preserve release targets and `vera-<target>.(tar.gz|zip)` archives.
    - `eval/**`: keep benchmark harness integrity; metrics consistent with `benchmarks/scripts/bench_common.py`.
  - Confirm tool enablement matches expectations: `actionlint`, `shellcheck`, `markdownlint`, `ruff`.
  - Note: Pro-tier fields (profile/tools finishing touches, chat auto-reply) are included but ignored on free tier; remaining settings still apply.

<sup>Written for commit 83fff87ce6802afb7200d8e5473f77466545082c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/VeraTools/Vera/pull/48?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

