### PR TITLE
ci: speed up release builds, fix rocm docker publish

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -3,5 +3,9 @@ self-hosted-runner:
   labels:
     - blacksmith-2vcpu-ubuntu-2404
     - blacksmith-2vcpu-ubuntu-2404-arm
+    - blacksmith-4vcpu-ubuntu-2404
+    - blacksmith-4vcpu-ubuntu-2404-arm
+    - blacksmith-8vcpu-ubuntu-2404
     - blacksmith-6vcpu-macos-15
     - blacksmith-2vcpu-windows-2025
+    - blacksmith-4vcpu-windows-2025

--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -6,6 +6,8 @@ self-hosted-runner:
     - blacksmith-4vcpu-ubuntu-2404
     - blacksmith-4vcpu-ubuntu-2404-arm
     - blacksmith-8vcpu-ubuntu-2404
+    - blacksmith-8vcpu-ubuntu-2404-arm
     - blacksmith-6vcpu-macos-15
     - blacksmith-2vcpu-windows-2025
     - blacksmith-4vcpu-windows-2025
+    - blacksmith-8vcpu-windows-2025

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,5 +1,11 @@
 name: Docker
 
+# Serialize image publication: a manual republish and a tag push must not
+# race on the same mutable :cpu/:cuda/:rocm tags.
+concurrency:
+  group: docker-image-publication
+  cancel-in-progress: false
+
 on:
   push:
     tags: ['v*.*.*']
@@ -50,8 +56,9 @@ jobs:
         run: bash scripts/bootstrap-vendored-grammars.sh
 
       - name: Set version from tag
+        env:
+          REF: ${{ inputs.tag || github.ref_name }}
         run: |
-          REF="${{ inputs.tag || github.ref_name }}"
           sed -i "s/^version = \".*\"/version = \"${REF#v}\"/" Cargo.toml
           cargo generate-lockfile
 
@@ -116,8 +123,9 @@ jobs:
 
       - name: Extract version
         id: version
+        env:
+          REF: ${{ inputs.tag || github.ref_name }}
         run: |
-          REF="${{ inputs.tag || github.ref_name }}"
           echo "version=${REF#v}" >> "$GITHUB_OUTPUT"
 
       - name: Build and push

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,6 +3,14 @@ name: Docker
 on:
   push:
     tags: ['v*.*.*']
+  # Manual recovery path: republish images for an existing tag (e.g. after a
+  # transient build failure) without re-tagging the release.
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag to build images for (e.g. v1.0.1)'
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -13,8 +21,53 @@ env:
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
+  # The Dockerfiles package a prebuilt binary; build it once here instead of
+  # compiling the workspace inside every image variant.
+  binary:
+    name: Build Linux binary
+    runs-on: blacksmith-8vcpu-ubuntu-2404
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag || github.ref }}
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: docker-linux-x86_64
+
+      - name: Set up sccache
+        uses: mozilla-actions/sccache-action@v0.0.9
+
+      - name: Configure sccache
+        run: |
+          echo "SCCACHE_GHA_ENABLED=true" >> "$GITHUB_ENV"
+          echo "RUSTC_WRAPPER=sccache" >> "$GITHUB_ENV"
+
+      - name: Download vendored grammars
+        run: bash scripts/bootstrap-vendored-grammars.sh
+
+      - name: Set version from tag
+        run: |
+          REF="${{ inputs.tag || github.ref_name }}"
+          sed -i "s/^version = \".*\"/version = \"${REF#v}\"/" Cargo.toml
+          cargo generate-lockfile
+
+      - name: Build
+        run: cargo build --release -p vera-cli
+
+      - name: Upload binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: vera-linux-binary
+          path: target/release/vera
+          retention-days: 1
+
   build:
     name: Build (${{ matrix.variant }})
+    needs: binary
     runs-on: blacksmith-2vcpu-ubuntu-2404
     strategy:
       fail-fast: false
@@ -31,7 +84,18 @@ jobs:
             tag_suffix: rocm
 
     steps:
+      # Checkout the workflow's own ref: on a tag push that is the tag itself,
+      # on manual dispatch it is master (current Dockerfiles), while the
+      # binary job above builds from the requested tag.
       - uses: actions/checkout@v4
+
+      - name: Download binary
+        uses: actions/download-artifact@v4
+        with:
+          name: vera-linux-binary
+          path: dist
+
+      - run: chmod +x dist/vera
 
       - name: Lowercase image name
         run: echo "IMAGE_NAME_LC=${IMAGE_NAME,,}" >> "$GITHUB_ENV"
@@ -46,11 +110,15 @@ jobs:
       - name: Set up Docker Buildx
         uses: useblacksmith/setup-docker-builder@v2
         with:
-          cache-key: ${{ matrix.dockerfile }}
+          # v2 keys: fresh builders. The v1 rocm builder held a corrupted
+          # layer cache that failed the v1.0.1 publish with digest mismatches.
+          cache-key: docker-v2-${{ matrix.variant }}
 
-      - name: Extract version from tag
+      - name: Extract version
         id: version
-        run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+        run: |
+          REF="${{ inputs.tag || github.ref_name }}"
+          echo "version=${REF#v}" >> "$GITHUB_OUTPUT"
 
       - name: Build and push
         uses: useblacksmith/build-push-action@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,16 +18,16 @@ jobs:
       matrix:
         include:
           - target: x86_64-unknown-linux-gnu
-            os: blacksmith-2vcpu-ubuntu-2404
+            os: blacksmith-4vcpu-ubuntu-2404
             archive: tar.gz
 
           - target: x86_64-unknown-linux-musl
-            os: blacksmith-2vcpu-ubuntu-2404
+            os: blacksmith-4vcpu-ubuntu-2404
             archive: tar.gz
             musl: true
 
           - target: aarch64-unknown-linux-gnu
-            os: blacksmith-2vcpu-ubuntu-2404-arm
+            os: blacksmith-4vcpu-ubuntu-2404-arm
             archive: tar.gz
 
           # Blacksmith macOS runners are Apple Silicon; x86_64-apple-darwin is cross-compiled via the rust target.
@@ -40,7 +40,7 @@ jobs:
             archive: tar.gz
 
           - target: x86_64-pc-windows-msvc
-            os: blacksmith-2vcpu-windows-2025
+            os: blacksmith-4vcpu-windows-2025
             archive: zip
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
             musl: true
 
           - target: aarch64-unknown-linux-gnu
-            os: blacksmith-4vcpu-ubuntu-2404-arm
+            os: blacksmith-8vcpu-ubuntu-2404-arm
             archive: tar.gz
 
           # Blacksmith macOS runners are Apple Silicon; x86_64-apple-darwin is cross-compiled via the rust target.
@@ -40,7 +40,7 @@ jobs:
             archive: tar.gz
 
           - target: x86_64-pc-windows-msvc
-            os: blacksmith-4vcpu-windows-2025
+            os: blacksmith-8vcpu-windows-2025
             archive: zip
 
     runs-on: ${{ matrix.os }}

--- a/docker/Dockerfile.cpu
+++ b/docker/Dockerfile.cpu
@@ -1,5 +1,6 @@
 # Vera CPU Docker image
-# Packages a prebuilt binary. CI builds it once per release; to build locally:
+# Packages a prebuilt binary. CI builds it once per release; to build locally
+# (must be a Linux x86_64 build; on macOS/Windows use a Linux container, see docs/docker.md):
 #   ./scripts/bootstrap-vendored-grammars.sh
 #   cargo build --release -p vera-cli && mkdir -p dist && cp target/release/vera dist/
 #   docker build -f docker/Dockerfile.cpu -t vera:cpu .

--- a/docker/Dockerfile.cpu
+++ b/docker/Dockerfile.cpu
@@ -1,5 +1,6 @@
 # Vera CPU Docker image
 # Packages a prebuilt binary. CI builds it once per release; to build locally:
+#   ./scripts/bootstrap-vendored-grammars.sh
 #   cargo build --release -p vera-cli && mkdir -p dist && cp target/release/vera dist/
 #   docker build -f docker/Dockerfile.cpu -t vera:cpu .
 

--- a/docker/Dockerfile.cpu
+++ b/docker/Dockerfile.cpu
@@ -1,23 +1,15 @@
 # Vera CPU Docker image
-# Usage: docker build -f docker/Dockerfile.cpu -t vera:cpu .
+# Packages a prebuilt binary. CI builds it once per release; to build locally:
+#   cargo build --release -p vera-cli && mkdir -p dist && cp target/release/vera dist/
+#   docker build -f docker/Dockerfile.cpu -t vera:cpu .
 
-# --- Build stage ---
-FROM rust:1.94.1-trixie AS builder
-
-WORKDIR /build
-COPY . .
-
-RUN bash scripts/bootstrap-vendored-grammars.sh
-RUN cargo build --release -p vera-cli -p vera-mcp
-
-# --- Runtime stage ---
 FROM debian:trixie-slim
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates curl && \
     rm -rf /var/lib/apt/lists/*
 
-COPY --from=builder /build/target/release/vera /usr/local/bin/vera
+COPY dist/vera /usr/local/bin/vera
 
 ENV VERA_LOCAL=1
 

--- a/docker/Dockerfile.cuda
+++ b/docker/Dockerfile.cuda
@@ -1,5 +1,6 @@
 # Vera CUDA Docker image (NVIDIA GPU)
-# Packages a prebuilt binary. CI builds it once per release; to build locally:
+# Packages a prebuilt binary. CI builds it once per release; to build locally
+# (must be a Linux x86_64 build; on macOS/Windows use a Linux container, see docs/docker.md):
 #   ./scripts/bootstrap-vendored-grammars.sh
 #   cargo build --release -p vera-cli && mkdir -p dist && cp target/release/vera dist/
 #   docker build -f docker/Dockerfile.cuda -t vera:cuda .

--- a/docker/Dockerfile.cuda
+++ b/docker/Dockerfile.cuda
@@ -1,24 +1,15 @@
 # Vera CUDA Docker image (NVIDIA GPU)
-# Usage: docker build -f docker/Dockerfile.cuda -t vera:cuda .
-# Run:   docker run --gpus all -i -v $(pwd):/workspace vera:cuda mcp
+# Packages a prebuilt binary. CI builds it once per release; to build locally:
+#   cargo build --release -p vera-cli && mkdir -p dist && cp target/release/vera dist/
+#   docker build -f docker/Dockerfile.cuda -t vera:cuda .
 
-# --- Build stage ---
-FROM rust:1.94.1-trixie AS builder
-
-WORKDIR /build
-COPY . .
-
-RUN bash scripts/bootstrap-vendored-grammars.sh
-RUN cargo build --release -p vera-cli -p vera-mcp
-
-# --- Runtime stage ---
 FROM nvidia/cuda:13.1.1-runtime-ubuntu24.04
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates curl && \
     rm -rf /var/lib/apt/lists/*
 
-COPY --from=builder /build/target/release/vera /usr/local/bin/vera
+COPY dist/vera /usr/local/bin/vera
 
 ENV VERA_LOCAL=1
 

--- a/docker/Dockerfile.cuda
+++ b/docker/Dockerfile.cuda
@@ -1,5 +1,6 @@
 # Vera CUDA Docker image (NVIDIA GPU)
 # Packages a prebuilt binary. CI builds it once per release; to build locally:
+#   ./scripts/bootstrap-vendored-grammars.sh
 #   cargo build --release -p vera-cli && mkdir -p dist && cp target/release/vera dist/
 #   docker build -f docker/Dockerfile.cuda -t vera:cuda .
 

--- a/docker/Dockerfile.openvino
+++ b/docker/Dockerfile.openvino
@@ -1,5 +1,6 @@
 # Vera OpenVINO Docker image (Intel GPU/iGPU acceleration)
-# Packages a prebuilt binary. CI builds it once per release; to build locally:
+# Packages a prebuilt binary. CI builds it once per release; to build locally
+# (must be a Linux x86_64 build; on macOS/Windows use a Linux container, see docs/docker.md):
 #   ./scripts/bootstrap-vendored-grammars.sh
 #   cargo build --release -p vera-cli && mkdir -p dist && cp target/release/vera dist/
 #   docker build -f docker/Dockerfile.openvino -t vera:openvino .

--- a/docker/Dockerfile.openvino
+++ b/docker/Dockerfile.openvino
@@ -1,16 +1,8 @@
 # Vera OpenVINO Docker image (Intel GPU/iGPU acceleration)
-# Usage: docker build -f docker/Dockerfile.openvino -t vera:openvino .
+# Packages a prebuilt binary. CI builds it once per release; to build locally:
+#   cargo build --release -p vera-cli && mkdir -p dist && cp target/release/vera dist/
+#   docker build -f docker/Dockerfile.openvino -t vera:openvino .
 
-# --- Build stage ---
-FROM rust:1.94.1-trixie AS builder
-
-WORKDIR /build
-COPY . .
-
-RUN bash scripts/bootstrap-vendored-grammars.sh
-RUN cargo build --release -p vera-cli -p vera-mcp
-
-# --- Runtime stage ---
 FROM debian:trixie-slim
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -19,7 +11,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     ocl-icd-libopencl1 intel-opencl-icd \
     && rm -rf /var/lib/apt/lists/*
 
-COPY --from=builder /build/target/release/vera /usr/local/bin/vera
+COPY dist/vera /usr/local/bin/vera
 
 ENV VERA_LOCAL=1
 

--- a/docker/Dockerfile.openvino
+++ b/docker/Dockerfile.openvino
@@ -1,5 +1,6 @@
 # Vera OpenVINO Docker image (Intel GPU/iGPU acceleration)
 # Packages a prebuilt binary. CI builds it once per release; to build locally:
+#   ./scripts/bootstrap-vendored-grammars.sh
 #   cargo build --release -p vera-cli && mkdir -p dist && cp target/release/vera dist/
 #   docker build -f docker/Dockerfile.openvino -t vera:openvino .
 

--- a/docker/Dockerfile.rocm
+++ b/docker/Dockerfile.rocm
@@ -1,5 +1,6 @@
 # Vera ROCm Docker image (AMD GPU)
-# Packages a prebuilt binary. CI builds it once per release; to build locally:
+# Packages a prebuilt binary. CI builds it once per release; to build locally
+# (must be a Linux x86_64 build; on macOS/Windows use a Linux container, see docs/docker.md):
 #   ./scripts/bootstrap-vendored-grammars.sh
 #   cargo build --release -p vera-cli && mkdir -p dist && cp target/release/vera dist/
 #   docker build -f docker/Dockerfile.rocm -t vera:rocm .

--- a/docker/Dockerfile.rocm
+++ b/docker/Dockerfile.rocm
@@ -1,5 +1,6 @@
 # Vera ROCm Docker image (AMD GPU)
 # Packages a prebuilt binary. CI builds it once per release; to build locally:
+#   ./scripts/bootstrap-vendored-grammars.sh
 #   cargo build --release -p vera-cli && mkdir -p dist && cp target/release/vera dist/
 #   docker build -f docker/Dockerfile.rocm -t vera:rocm .
 # Run:   docker run --device=/dev/kfd --device=/dev/dri -i -v $(pwd):/workspace vera:rocm mcp

--- a/docker/Dockerfile.rocm
+++ b/docker/Dockerfile.rocm
@@ -1,24 +1,16 @@
 # Vera ROCm Docker image (AMD GPU)
-# Usage: docker build -f docker/Dockerfile.rocm -t vera:rocm .
+# Packages a prebuilt binary. CI builds it once per release; to build locally:
+#   cargo build --release -p vera-cli && mkdir -p dist && cp target/release/vera dist/
+#   docker build -f docker/Dockerfile.rocm -t vera:rocm .
 # Run:   docker run --device=/dev/kfd --device=/dev/dri -i -v $(pwd):/workspace vera:rocm mcp
 
-# --- Build stage ---
-FROM rust:1.94.1-trixie AS builder
-
-WORKDIR /build
-COPY . .
-
-RUN bash scripts/bootstrap-vendored-grammars.sh
-RUN cargo build --release -p vera-cli -p vera-mcp
-
-# --- Runtime stage ---
 FROM rocm/dev-ubuntu-24.04:6.4.4-complete
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates curl && \
     rm -rf /var/lib/apt/lists/*
 
-COPY --from=builder /build/target/release/vera /usr/local/bin/vera
+COPY dist/vera /usr/local/bin/vera
 
 ENV VERA_LOCAL=1
 

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -87,7 +87,7 @@ docker run --rm -v $(pwd):/workspace ghcr.io/veratools/vera:cpu stats
 
 ## Building locally
 
-The Dockerfiles package a prebuilt binary, so build it first. From the repo root:
+The Dockerfiles package a prebuilt binary, so build it first. The binary must be a Linux build matching the image architecture (the published images are linux/amd64), so run the build on a Linux x86_64 machine, or on macOS/Windows inside a Linux container, e.g. `docker run --rm -v $(pwd):/src -w /src rust:latest bash -c './scripts/bootstrap-vendored-grammars.sh && cargo build --release -p vera-cli'`. From the repo root:
 
 ```bash
 ./scripts/bootstrap-vendored-grammars.sh  # downloads grammars required by vera-core's build script

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -87,9 +87,12 @@ docker run --rm -v $(pwd):/workspace ghcr.io/veratools/vera:cpu stats
 
 ## Building locally
 
-From the repo root:
+The Dockerfiles package a prebuilt binary, so build it first. From the repo root:
 
 ```bash
+cargo build --release -p vera-cli
+mkdir -p dist && cp target/release/vera dist/
+
 docker build -f docker/Dockerfile.cpu -t vera:cpu .
 docker build -f docker/Dockerfile.cuda -t vera:cuda .
 docker build -f docker/Dockerfile.rocm -t vera:rocm .

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -90,6 +90,7 @@ docker run --rm -v $(pwd):/workspace ghcr.io/veratools/vera:cpu stats
 The Dockerfiles package a prebuilt binary, so build it first. From the repo root:
 
 ```bash
+./scripts/bootstrap-vendored-grammars.sh  # downloads grammars required by vera-core's build script
 cargo build --release -p vera-cli
 mkdir -p dist && cp target/release/vera dist/
 


### PR DESCRIPTION
## Why

v1.0.1 on Blacksmith exposed two problems:

1. **Speed/balance**: release wall-clock was 14.3 min, bounded by the slowest 2vcpu job while faster jobs idled. Docker took 25+ min per variant because every image recompiled the entire workspace in-container.
2. **Correctness**: the rocm publish failed twice with `failed commit on ref "layer-sha256:..." unexpected commit digest` — the same layer ref both times, i.e. a poisoned entry in the persistent builder's cache, not a flake. `1.0.1-rocm` is currently missing from GHCR.

## Runner rebalancing (measured v1.0.1 durations)

| Target | Was (2vcpu unless noted) | Now | Est. |
|--------|--------------------------|-----|------|
| aarch64-linux-gnu | 856s (critical path) | 8vcpu-arm | ~295s |
| windows-msvc | 749s | 8vcpu | ~258s |
| musl | 633s | 4vcpu | ~372s (apt setup floors it; new critical path) |
| linux-gnu | 554s | 4vcpu | ~326s |
| macOS aarch64 | 166s @6vcpu | 6vcpu (unchanged) | ~166s |
| macOS x86_64 | 156s @6vcpu | 6vcpu (unchanged) | ~156s |

Everything lands in a ~2.7-6.2 min band instead of 2.6-14.3 min. No smaller macOS label exists (`blacksmith-4vcpu-macos-15` smoke-tested: never picked up), and shrinking macOS below 6vcpu wouldn't help wall-clock anyway since it was never the bottleneck. Docker's compile job runs on 8vcpu (~3 min), so its total (~5 min) also stays under the musl path.

## Docker changes

- New `binary` job compiles `vera` once (8vcpu, sccache + rust-cache); the three package jobs download it and only pull the base image + `COPY dist/vera`. The variants already built byte-identical binaries (same `cargo build --release`, no feature flags), so image behavior is unchanged.
- `cache-key: docker-v2-<variant>` provisions fresh builders, leaving the poisoned rocm cache behind.
- `workflow_dispatch` with a `tag` input to republish images for an existing tag without re-tagging; binary builds from the tag, packaging uses the workflow's own ref. Used to backfill `1.0.1-rocm` after merge.
- Concurrency group serializes publishes so a manual republish can't race a tag push on the mutable `:cpu/:cuda/:rocm` tags.
- Tag value passed via `env:` instead of inline template expansion (script-injection hardening).

## Dockerfiles (cpu, cuda, rocm, openvino)

Builder stage removed; each packages `dist/vera`. Headers and `docs/docker.md` document the local flow: `bootstrap-vendored-grammars.sh` (needed on fresh clones), `cargo build --release -p vera-cli`, copy to `dist/`, then `docker build`.

## Validation

- actionlint clean; YAML parses.
- Smoke runs on every new label (`4vcpu-ubuntu-2404`, `4vcpu-ubuntu-2404-arm`, `8vcpu-ubuntu-2404`, `8vcpu-ubuntu-2404-arm`, `8vcpu-windows-2025`): all picked up and succeeded. `4vcpu-macos-15` does not exist.
- Full publish path exercised right after merge via the new dispatch trigger (`1.0.1-rocm` backfill).