### PR TITLE
ci: move musl build to 8vcpu to tighten wall-clock band

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,11 @@ jobs:
     name: Build (${{ matrix.target }})
     strategy:
       fail-fast: false
+      # Runner sizes are tuned to equalize wall-clock (slowest job gates the
+      # release). Baseline measured on 2vcpu at v1.0.1: arm 856s, windows 749s,
+      # musl 633s, gnu 554s (macOS: ~160s on 6vcpu). Observed 2->8vcpu scaling
+      # is ~3.2x, so the band below lands at ~3-5 min per target. No macOS
+      # label smaller than 6vcpu exists.
       matrix:
         include:
           - target: x86_64-unknown-linux-gnu
@@ -22,7 +27,7 @@ jobs:
             archive: tar.gz
 
           - target: x86_64-unknown-linux-musl
-            os: blacksmith-4vcpu-ubuntu-2404
+            os: blacksmith-8vcpu-ubuntu-2404
             archive: tar.gz
             musl: true
 


### PR DESCRIPTION
Follow-up tuning to #49 based on the observed v1.0.1 timings and the 3.2x scaling measured on the 8vcpu Docker compile (172s vs 554s on 2vcpu).

musl on 4vcpu projected to ~6.5 min (compile ~302s scaling + ~90s fixed musl-tools setup), the clear outlier against arm/windows on 8vcpu (~4.3-4.5 min) and gnu on 4vcpu (~5.1 min). Moving musl to 8vcpu puts every target in a ~3-5 min band.

The sizing rationale with measured baselines is now a comment above the matrix so the next tuning pass has the data inline.

actionlint clean; label blacksmith-8vcpu-ubuntu-2404 smoke-verified earlier.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/VeraTools/codesmith/Vera/pr/50"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves the musl release job from a 4‑vCPU to an 8‑vCPU runner to equalize CI wall‑clock time across targets. Previously musl took ~6.5 min on `blacksmith-4vcpu-ubuntu-2404`; now it should land ~4–5 min on `blacksmith-8vcpu-ubuntu-2404`, aligning with arm/windows and removing the slowest‑job gate.

**Review notes**
- Changes only the `os` for `x86_64-unknown-linux-musl` in `.github/workflows/release.yml`; build flags and artifacts are unchanged.
- Rationale and baseline timings (2→8 vCPU ~3.2× speedup) are documented in a comment above the matrix for future tuning.
- No rollout or migration required.

<sup>Written for commit db5dbab223862a1694cef712e93f730f3abf38d0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/VeraTools/Vera/pull/50?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

