### PR TITLE
ci: size runners to the macOS baseline, self-heal docker cache corruption

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -2,12 +2,8 @@ self-hosted-runner:
   # Blacksmith runner labels (https://docs.blacksmith.sh/blacksmith-runners/overview)
   labels:
     - blacksmith-2vcpu-ubuntu-2404
-    - blacksmith-2vcpu-ubuntu-2404-arm
-    - blacksmith-4vcpu-ubuntu-2404
-    - blacksmith-4vcpu-ubuntu-2404-arm
     - blacksmith-8vcpu-ubuntu-2404
-    - blacksmith-8vcpu-ubuntu-2404-arm
+    - blacksmith-16vcpu-ubuntu-2404
+    - blacksmith-16vcpu-ubuntu-2404-arm
     - blacksmith-6vcpu-macos-15
-    - blacksmith-2vcpu-windows-2025
-    - blacksmith-4vcpu-windows-2025
-    - blacksmith-8vcpu-windows-2025
+    - blacksmith-16vcpu-windows-2025

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -129,6 +129,26 @@ jobs:
           echo "version=${REF#v}" >> "$GITHUB_OUTPUT"
 
       - name: Build and push
+        id: publish
+        continue-on-error: true
+        uses: useblacksmith/build-push-action@v2
+        with:
+          context: .
+          file: ${{ matrix.dockerfile }}
+          push: true
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LC }}:${{ matrix.tag_suffix }}
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LC }}:${{ steps.version.outputs.version }}-${{ matrix.tag_suffix }}
+
+      # A corrupted base-image layer on the builder's sticky disk fails the
+      # build with "unexpected commit digest". Pruning evicts it and forces a
+      # clean re-pull; only runs after a failure, so healthy builds keep cache.
+      - name: Repair builder cache
+        if: steps.publish.outcome == 'failure'
+        run: docker buildx prune -af
+
+      - name: Build and push (retry after repair)
+        if: steps.publish.outcome == 'failure'
         uses: useblacksmith/build-push-action@v2
         with:
           context: .

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,24 +15,26 @@ jobs:
     name: Build (${{ matrix.target }})
     strategy:
       fail-fast: false
-      # Runner sizes are tuned to equalize wall-clock (slowest job gates the
-      # release). Baseline measured on 2vcpu at v1.0.1: arm 856s, windows 749s,
-      # musl 633s, gnu 554s (macOS: ~160s on 6vcpu). Observed 2->8vcpu scaling
-      # is ~3.2x, so the band below lands at ~3-5 min per target. No macOS
-      # label smaller than 6vcpu exists.
+      # Runner sizes are tuned so every target finishes near the macOS
+      # baseline (~160s on 6vcpu, the smallest macOS label). Baselines measured
+      # on 2vcpu at v1.0.1: arm 856s, windows 749s, musl 633s, gnu 554s.
+      # Observed scaling: gnu compiles in 172s on 8vcpu (measured, warm
+      # sccache); 16vcpu estimated ~4-4.5x over 2vcpu. Resulting band is
+      # roughly 2.7-3.5 min per target; nothing is sized to beat the macOS
+      # floor, since the release waits for it anyway.
       matrix:
         include:
           - target: x86_64-unknown-linux-gnu
-            os: blacksmith-4vcpu-ubuntu-2404
+            os: blacksmith-8vcpu-ubuntu-2404
             archive: tar.gz
 
           - target: x86_64-unknown-linux-musl
-            os: blacksmith-8vcpu-ubuntu-2404
+            os: blacksmith-16vcpu-ubuntu-2404
             archive: tar.gz
             musl: true
 
           - target: aarch64-unknown-linux-gnu
-            os: blacksmith-8vcpu-ubuntu-2404-arm
+            os: blacksmith-16vcpu-ubuntu-2404-arm
             archive: tar.gz
 
           # Blacksmith macOS runners are Apple Silicon; x86_64-apple-darwin is cross-compiled via the rust target.
@@ -45,7 +47,7 @@ jobs:
             archive: tar.gz
 
           - target: x86_64-pc-windows-msvc
-            os: blacksmith-8vcpu-windows-2025
+            os: blacksmith-16vcpu-windows-2025
             archive: zip
 
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
## Runner tuning principle

macOS is the fixed floor: the smallest Blacksmith macOS label is 6vcpu (~160s builds), so the release can never finish faster than ~2.7 min. Every other target is sized to land at that baseline — not faster (wasted vcpus), not slower (gates the release).

| Target | 2vcpu baseline (v1.0.1) | New size | Est. |
|--------|------------------------|----------|------|
| linux-gnu | 554s | 8vcpu | ~172s (measured via docker compile job) |
| musl | 633s (incl. ~90s fixed setup) | 16vcpu | ~3.5 min |
| aarch64-linux | 856s | 16vcpu-arm | ~3.2 min |
| windows-msvc | 749s | 16vcpu | ~2.8 min |
| macOS x2 | ~160s @6vcpu | unchanged | ~2.7 min (anchor) |

The 16vcpu labels were smoke-verified (all three picked up and ran). Sizing rationale with the measured baselines lives in a comment above the matrix.

## Docker repair-retry

The rocm publish has now failed 3 times with the identical error: `failed commit on ref "layer-sha256:4c8a4cb..." unexpected commit digest`. Same layer ref across the v1 cache-key, the fresh docker-v2 key, and a solo rerun — so it is a corrupted base-image layer (`rocm/dev-ubuntu-24.04:6.4.4-complete`) sitting on the persistent builder's disk, not a concurrency race and not fixed by rotating the cache-key.

`build-push-action` now runs with `continue-on-error`, and on failure the job prunes the builder (`docker buildx prune -af`, evicting the corrupt layer) and retries once. Healthy builds never pay for this; sick ones self-heal instead of failing the release.

This PR is also the vehicle for backfilling `1.0.1-rocm`: after merge I will re-dispatch the workflow for tag v1.0.1, which exercises the repair path immediately.

## Validation

- actionlint clean; label set in .github/actionlint.yaml pruned to exactly the used labels.
- Retry logic only restructures when the action runs, not what it publishes (same tags, same context).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/VeraTools/codesmith/Vera/pr/51"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sizes release runners to the macOS baseline and adds a self-healing Docker publish retry. Other targets now finish near the ~160s macOS floor, and Docker publishes recover from corrupted base-image layers instead of failing the release.

- Runner sizing: `gnu` to `blacksmith-8vcpu-ubuntu-2404` (172s measured), `musl` to `blacksmith-16vcpu-ubuntu-2404`, `aarch64` to `blacksmith-16vcpu-ubuntu-2404-arm`, `windows` to `blacksmith-16vcpu-windows-2025`; macOS unchanged. This removes slow-target gating without overprovisioning faster targets. `actionlint.yaml` labels pruned to match.
- Docker repair-retry: the first `useblacksmith/build-push-action@v2` run uses `continue-on-error`; on failure we run `docker buildx prune -af` and retry once. This fixes the recurring “unexpected commit digest” caused by a corrupt layer in `rocm/dev-ubuntu-24.04:6.4.4-complete`. Healthy builds keep cache and do not pay the prune cost.
- Rollout: after merge, re-dispatch the workflow for tag `v1.0.1` to backfill `1.0.1-rocm`. No tag format or artifact changes.

<sup>Written for commit 3c99e4c1b8c22b2cbbea85ca46426cbce81e61fe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/VeraTools/Vera/pull/51?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

