### PR TITLE
ci: reuse release binary for docker images, drop redundant cache

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -26,9 +26,10 @@ jobs:
     name: Build (${{ matrix.variant }})
     runs-on: blacksmith-2vcpu-ubuntu-2404
     # Job-level groups are repository-global: a manual republish cannot race
-    # the release workflow's docker job on the mutable :cpu/:cuda/:rocm tags.
+    # the release workflow's docker job on the same variant's mutable tag.
+    # Scoped per variant so cpu/cuda/rocm can still publish in parallel.
     concurrency:
-      group: docker-image-publication
+      group: docker-image-publication-${{ matrix.variant }}
       cancel-in-progress: false
     strategy:
       fail-fast: false

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -106,7 +106,8 @@ jobs:
       # Healthy builds never pay for this.
       - name: Repair builder cache
         if: steps.publish.outcome == 'failure'
-        run: docker buildx prune -af
+        # Best-effort: a prune failure must not block the daemon retry below.
+        run: docker buildx prune -af || true
 
       - name: Build and push (retry via docker daemon)
         if: steps.publish.outcome == 'failure'

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,16 +1,11 @@
 name: Docker
 
-# Serialize image publication: a manual republish and a tag push must not
-# race on the same mutable :cpu/:cuda/:rocm tags.
-concurrency:
-  group: docker-image-publication
-  cancel-in-progress: false
-
+# Manual recovery path only: republish images for an existing release tag
+# (e.g. after a transient failure) without re-tagging. Normal tag pushes
+# publish images from the release workflow, which reuses the exact binary it
+# already built. The binary here is downloaded from the published release
+# assets, so this workflow never compiles.
 on:
-  push:
-    tags: ['v*.*.*']
-  # Manual recovery path: republish images for an existing tag (e.g. after a
-  # transient build failure) without re-tagging the release.
   workflow_dispatch:
     inputs:
       tag:
@@ -27,55 +22,14 @@ env:
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
-  # The Dockerfiles package a prebuilt binary; build it once here instead of
-  # compiling the workspace inside every image variant.
-  binary:
-    name: Build Linux binary
-    runs-on: blacksmith-8vcpu-ubuntu-2404
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ inputs.tag || github.ref }}
-
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-
-      - uses: Swatinem/rust-cache@v2
-        with:
-          key: docker-linux-x86_64
-
-      - name: Set up sccache
-        uses: mozilla-actions/sccache-action@v0.0.9
-
-      - name: Configure sccache
-        run: |
-          echo "SCCACHE_GHA_ENABLED=true" >> "$GITHUB_ENV"
-          echo "RUSTC_WRAPPER=sccache" >> "$GITHUB_ENV"
-
-      - name: Download vendored grammars
-        run: bash scripts/bootstrap-vendored-grammars.sh
-
-      - name: Set version from tag
-        env:
-          REF: ${{ inputs.tag || github.ref_name }}
-        run: |
-          sed -i "s/^version = \".*\"/version = \"${REF#v}\"/" Cargo.toml
-          cargo generate-lockfile
-
-      - name: Build
-        run: cargo build --release -p vera-cli
-
-      - name: Upload binary
-        uses: actions/upload-artifact@v4
-        with:
-          name: vera-linux-binary
-          path: target/release/vera
-          retention-days: 1
-
   build:
     name: Build (${{ matrix.variant }})
-    needs: binary
     runs-on: blacksmith-2vcpu-ubuntu-2404
+    # Job-level groups are repository-global: a manual republish cannot race
+    # the release workflow's docker job on the mutable :cpu/:cuda/:rocm tags.
+    concurrency:
+      group: docker-image-publication
+      cancel-in-progress: false
     strategy:
       fail-fast: false
       matrix:
@@ -91,18 +45,20 @@ jobs:
             tag_suffix: rocm
 
     steps:
-      # Checkout the workflow's own ref: on a tag push that is the tag itself,
-      # on manual dispatch it is master (current Dockerfiles), while the
-      # binary job above builds from the requested tag.
+      # Checkout the dispatch ref (master): current Dockerfiles package the
+      # binary downloaded from the requested tag's release assets.
       - uses: actions/checkout@v4
 
-      - name: Download binary
-        uses: actions/download-artifact@v4
-        with:
-          name: vera-linux-binary
-          path: dist
-
-      - run: chmod +x dist/vera
+      - name: Download release binary
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ inputs.tag }}
+        run: |
+          gh release download "$TAG" --pattern 'vera-x86_64-unknown-linux-gnu.tar.gz' --dir artifacts --clobber
+          mkdir -p dist
+          tar xzf artifacts/vera-x86_64-unknown-linux-gnu.tar.gz -C artifacts
+          cp artifacts/vera-x86_64-unknown-linux-gnu/vera dist/vera
+          chmod +x dist/vera
 
       - name: Lowercase image name
         run: echo "IMAGE_NAME_LC=${IMAGE_NAME,,}" >> "$GITHUB_ENV"
@@ -124,9 +80,8 @@ jobs:
       - name: Extract version
         id: version
         env:
-          REF: ${{ inputs.tag || github.ref_name }}
-        run: |
-          echo "version=${REF#v}" >> "$GITHUB_OUTPUT"
+          REF: ${{ inputs.tag }}
+        run: echo "version=${REF#v}" >> "$GITHUB_OUTPUT"
 
       - name: Build and push
         id: publish

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -98,20 +98,24 @@ jobs:
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LC }}:${{ matrix.tag_suffix }}
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LC }}:${{ steps.version.outputs.version }}-${{ matrix.tag_suffix }}
 
-      # A corrupted base-image layer on the builder's sticky disk fails the
-      # build with "unexpected commit digest". Pruning evicts it and forces a
-      # clean re-pull; only runs after a failure, so healthy builds keep cache.
+      # Fallback when the buildkit path fails (seen: "unexpected commit digest"
+      # on a rocm base layer whose computed digest varied per run, i.e. fetch
+      # corruption in the sticky-builder pull path, not a poisoned cache).
+      # The retry prunes the builder, then builds via the runner's own docker
+      # daemon, an ephemeral store with a separate registry fetch path.
+      # Healthy builds never pay for this.
       - name: Repair builder cache
         if: steps.publish.outcome == 'failure'
         run: docker buildx prune -af
 
-      - name: Build and push (retry after repair)
+      - name: Build and push (retry via docker daemon)
         if: steps.publish.outcome == 'failure'
-        uses: useblacksmith/build-push-action@v2
-        with:
-          context: .
-          file: ${{ matrix.dockerfile }}
-          push: true
-          tags: |
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LC }}:${{ matrix.tag_suffix }}
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LC }}:${{ steps.version.outputs.version }}-${{ matrix.tag_suffix }}
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          TAG_SUFFIX: ${{ matrix.tag_suffix }}
+          DOCKERFILE: ${{ matrix.dockerfile }}
+        run: |
+          IMAGE="${REGISTRY}/${IMAGE_NAME_LC}"
+          docker build -f "$DOCKERFILE" -t "$IMAGE:$TAG_SUFFIX" -t "$IMAGE:$VERSION-$TAG_SUFFIX" .
+          docker push "$IMAGE:$TAG_SUFFIX"
+          docker push "$IMAGE:$VERSION-$TAG_SUFFIX"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -46,9 +46,11 @@ jobs:
             tag_suffix: rocm
 
     steps:
-      # Checkout the dispatch ref (master): current Dockerfiles package the
-      # binary downloaded from the requested tag's release assets.
+      # Checkout the requested tag so the Dockerfiles match what the release
+      # workflow published for it, regardless of which ref was dispatched.
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag }}
 
       - name: Download release binary
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,9 +6,12 @@ on:
 
 permissions:
   contents: write
+  packages: write
 
 env:
   CARGO_TERM_COLOR: always
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
 
 jobs:
   build:
@@ -70,10 +73,6 @@ jobs:
             sed -i "s/^version = \".*\"/version = \"$VERSION\"/" Cargo.toml
           fi
           cargo generate-lockfile
-
-      - uses: Swatinem/rust-cache@v2
-        with:
-          key: ${{ matrix.target }}
 
       - name: Set up sccache
         uses: mozilla-actions/sccache-action@v0.0.9
@@ -278,3 +277,94 @@ jobs:
           python -m pip install --upgrade build twine
           python -m build packages/python-cli
           python -m twine upload --non-interactive packages/python-cli/dist/*
+
+  # Images package the exact binary published in the release assets, so no
+  # separate compile is needed. Runs as soon as the linux-gnu build finishes,
+  # in parallel with the other targets.
+  docker:
+    name: Docker (${{ matrix.variant }})
+    needs: build
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+    concurrency:
+      group: docker-image-publication
+      cancel-in-progress: false
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - variant: cpu
+            dockerfile: docker/Dockerfile.cpu
+            tag_suffix: cpu
+          - variant: cuda
+            dockerfile: docker/Dockerfile.cuda
+            tag_suffix: cuda
+          - variant: rocm
+            dockerfile: docker/Dockerfile.rocm
+            tag_suffix: rocm
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download Linux binary artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: x86_64-unknown-linux-gnu
+          path: artifacts
+
+      - name: Stage binary
+        run: |
+          mkdir -p dist
+          tar xzf artifacts/vera-x86_64-unknown-linux-gnu.tar.gz -C artifacts
+          cp artifacts/vera-x86_64-unknown-linux-gnu/vera dist/vera
+          chmod +x dist/vera
+
+      - name: Lowercase image name
+        run: echo "IMAGE_NAME_LC=${IMAGE_NAME,,}" >> "$GITHUB_ENV"
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: useblacksmith/setup-docker-builder@v2
+        with:
+          # v2 keys: fresh builders. The v1 rocm builder held a corrupted
+          # layer cache that failed the v1.0.1 publish with digest mismatches.
+          cache-key: docker-v2-${{ matrix.variant }}
+
+      - name: Extract version
+        id: version
+        run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Build and push
+        id: publish
+        continue-on-error: true
+        uses: useblacksmith/build-push-action@v2
+        with:
+          context: .
+          file: ${{ matrix.dockerfile }}
+          push: true
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LC }}:${{ matrix.tag_suffix }}
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LC }}:${{ steps.version.outputs.version }}-${{ matrix.tag_suffix }}
+
+      # A corrupted base-image layer on the builder's sticky disk fails the
+      # build with "unexpected commit digest". Pruning evicts it and forces a
+      # clean re-pull; only runs after a failure, so healthy builds keep cache.
+      - name: Repair builder cache
+        if: steps.publish.outcome == 'failure'
+        run: docker buildx prune -af
+
+      - name: Build and push (retry after repair)
+        if: steps.publish.outcome == 'failure'
+        uses: useblacksmith/build-push-action@v2
+        with:
+          context: .
+          file: ${{ matrix.dockerfile }}
+          push: true
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LC }}:${{ matrix.tag_suffix }}
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LC }}:${{ steps.version.outputs.version }}-${{ matrix.tag_suffix }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,8 +5,7 @@ on:
     tags: ['v*.*.*']
 
 permissions:
-  contents: write
-  packages: write
+  contents: read
 
 env:
   CARGO_TERM_COLOR: always
@@ -144,6 +143,8 @@ jobs:
     name: Create Release
     needs: build
     runs-on: blacksmith-2vcpu-ubuntu-2404
+    permissions:
+      contents: write
     env:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       PYPI_API_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
@@ -279,14 +280,20 @@ jobs:
           python -m twine upload --non-interactive packages/python-cli/dist/*
 
   # Images package the exact binary published in the release assets, so no
-  # separate compile is needed. Runs as soon as the linux-gnu build finishes,
-  # in parallel with the other targets.
+  # separate compile is needed. `needs: build` waits for the whole build
+  # matrix, but runner sizes are tuned so all targets finish within the same
+  # ~3 min band, so the extra wait over a dedicated linux-gnu job is marginal.
   docker:
     name: Docker (${{ matrix.variant }})
     needs: build
     runs-on: blacksmith-2vcpu-ubuntu-2404
+    permissions:
+      contents: read
+      packages: write
+    # Scoped per variant: blocks concurrent publishes of the same mutable
+    # tag across workflows while letting cpu/cuda/rocm publish in parallel.
     concurrency:
-      group: docker-image-publication
+      group: docker-image-publication-${{ matrix.variant }}
       cancel-in-progress: false
     strategy:
       fail-fast: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -366,7 +366,8 @@ jobs:
       # Healthy builds never pay for this.
       - name: Repair builder cache
         if: steps.publish.outcome == 'failure'
-        run: docker buildx prune -af
+        # Best-effort: a prune failure must not block the daemon retry below.
+        run: docker buildx prune -af || true
 
       - name: Build and push (retry via docker daemon)
         if: steps.publish.outcome == 'failure'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -358,20 +358,24 @@ jobs:
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LC }}:${{ matrix.tag_suffix }}
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LC }}:${{ steps.version.outputs.version }}-${{ matrix.tag_suffix }}
 
-      # A corrupted base-image layer on the builder's sticky disk fails the
-      # build with "unexpected commit digest". Pruning evicts it and forces a
-      # clean re-pull; only runs after a failure, so healthy builds keep cache.
+      # Fallback when the buildkit path fails (seen: "unexpected commit digest"
+      # on a rocm base layer whose computed digest varied per run, i.e. fetch
+      # corruption in the sticky-builder pull path, not a poisoned cache).
+      # The retry prunes the builder, then builds via the runner's own docker
+      # daemon, an ephemeral store with a separate registry fetch path.
+      # Healthy builds never pay for this.
       - name: Repair builder cache
         if: steps.publish.outcome == 'failure'
         run: docker buildx prune -af
 
-      - name: Build and push (retry after repair)
+      - name: Build and push (retry via docker daemon)
         if: steps.publish.outcome == 'failure'
-        uses: useblacksmith/build-push-action@v2
-        with:
-          context: .
-          file: ${{ matrix.dockerfile }}
-          push: true
-          tags: |
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LC }}:${{ matrix.tag_suffix }}
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LC }}:${{ steps.version.outputs.version }}-${{ matrix.tag_suffix }}
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          TAG_SUFFIX: ${{ matrix.tag_suffix }}
+          DOCKERFILE: ${{ matrix.dockerfile }}
+        run: |
+          IMAGE="${REGISTRY}/${IMAGE_NAME_LC}"
+          docker build -f "$DOCKERFILE" -t "$IMAGE:$TAG_SUFFIX" -t "$IMAGE:$VERSION-$TAG_SUFFIX" .
+          docker push "$IMAGE:$TAG_SUFFIX"
+          docker push "$IMAGE:$VERSION-$TAG_SUFFIX"


### PR DESCRIPTION
## Why

Blacksmith free tier is 3000 x64-2vcpu-equivalent minutes/month (bigger runners consume proportionally more; ARM x0.625, Windows x2, macOS x20 per wall-minute). Usage is already 349/3000 after v1.0.1 + backfills. This PR cuts the per-release cost and wall-clock further:

## Changes

**release.yml**
- New `docker` job (needs: build): publishes all three image variants using the `x86_64-unknown-linux-gnu` artifact the build job already produces. Eliminates the duplicate 8vcpu compile that docker.yml ran on every tag (~12 equiv-min saved, and images now start publishing ~3 min into the release instead of after a separate compile).
- Removes `Swatinem/rust-cache` from release builds: the version sed + `cargo generate-lockfile` changes Cargo.lock on every tag, so the lockfile-keyed restore always missed and every job paid a multi-GB cache save for zero hits. sccache (keyed on compiler inputs, not the lockfile) keeps dependency cache hits across tags.
- Side benefit: image binaries now carry the tag version (the release build applies the version sed; the old in-container docker builds shipped whatever was in Cargo.toml).

**docker.yml** — dispatch-only recovery path
- No longer triggers on tag push (the release workflow owns that path).
- The compile job is gone: the recovery flow downloads `vera-x86_64-unknown-linux-gnu.tar.gz` from the published release assets instead of rebuilding.
- Publish serialization moves from workflow-level to a job-level `docker-image-publication` group, which is repository-global, so a manual republish cannot race the release workflow's docker job on the mutable `:cpu/:cuda/:rocm` tags.

## What does NOT change

Runner sizes from #51 (anchored to the ~2.7 min macOS floor), the repair-retry against builder cache corruption, image contents, and published tags.

## Cost context (equiv-min per release)

macOS (~108) and Windows (~45) dominate and are structural (smallest mac runner is 6vcpu at 20x; Windows bills 2x). This PR removes the remaining avoidable spend: the duplicate compile and the dead cache saves. If we ever need deeper cuts, the only real levers left are dropping x86_64-apple-darwin (Intel mac) from the matrix or cross-compiling Windows from Linux — both product decisions, not config tweaks.

## Validation

- actionlint + YAML parse clean.
- Tag path can't be exercised until the next release; the dispatch path replaces the currently-running backfill flow and will be exercised if any image republish is needed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/VeraTools/codesmith/Vera/pr/52"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Publishes Docker images from `release.yml` using the existing `x86_64-unknown-linux-gnu` artifact; previously `docker.yml` rebuilt the binary per tag. This removes a duplicate Linux compile, makes image binaries report the tag version, and hardens against buildkit digest errors with a best-effort prune and guaranteed daemon retry.

- `release.yml`: new docker job builds `cpu`/`cuda`/`rocm` images from the Linux artifact, logs in to `ghcr.io`, and uses per-variant `docker-image-publication-${{ matrix.variant }}` concurrency across workflows. On buildkit failure, it prunes the builder best-effort and retries via the runner’s docker daemon; healthy builds keep using the builder cache. Workflow default is `contents: read`; image publish grants `packages: write`.
- `docker.yml`: dispatch-only recovery. Checks out the requested tag, downloads `vera-x86_64-unknown-linux-gnu.tar.gz` from that tag’s release assets, never compiles, and uses the same per-variant concurrency and retry path.
- Build changes: remove `Swatinem/rust-cache`; keep `sccache`. Behavior unchanged for image contents, tags, and runner sizes. To republish an image, run `docker.yml` with a tag.

<sup>Written for commit 9fcc0c178b79dbf0b98254f40298a617be7d93e2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/VeraTools/Vera/pull/52?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated publishing of CPU, CUDA, and ROCm Docker images to the GitHub Container Registry.
  * Added support for manually rebuilding Docker images from a selected release.

* **Improvements**
  * Docker images now use the selected release version and corresponding binary automatically.
  * Improved build reliability with automatic retries after build-cache cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->