### PR TITLE
fix(parsing): parse .tsx with the tsx grammar and index JSX call sites

### DIFF
--- a/crates/vera-core/src/parsing/languages.rs
+++ b/crates/vera-core/src/parsing/languages.rs
@@ -106,6 +106,26 @@ pub fn tree_sitter_grammar(lang: Language) -> Option<TsLanguage> {
     Some(lang_fn)
 }
 
+/// Returns the tree-sitter grammar to use for a specific file.
+///
+/// TypeScript ships as two grammars upstream because JSX is ambiguous with
+/// type assertions, so `.tsx` must be parsed with `tsx`. Parsing it with
+/// `typescript` puts every JSX element in an error node, which hides JSX call
+/// sites from `references` and `dead-code`. All other languages resolve by
+/// language alone.
+pub fn tree_sitter_grammar_for_path(lang: Language, file_path: &str) -> Option<TsLanguage> {
+    if lang == Language::TypeScript && has_tsx_extension(file_path) {
+        return Some(tree_sitter_typescript::LANGUAGE_TSX.into());
+    }
+    tree_sitter_grammar(lang)
+}
+
+fn has_tsx_extension(file_path: &str) -> bool {
+    std::path::Path::new(file_path)
+        .extension()
+        .is_some_and(|ext| ext.eq_ignore_ascii_case("tsx"))
+}
+
 /// Returns whether a language has tree-sitter grammar support (Tier 1A).
 pub fn has_grammar(lang: Language) -> bool {
     tree_sitter_grammar(lang).is_some()
@@ -183,6 +203,48 @@ mod tests {
             assert!(
                 !has_grammar(lang),
                 "{lang} should NOT have a tree-sitter grammar"
+            );
+        }
+    }
+
+    /// A `.tsx` file must parse without error nodes; the `typescript` grammar
+    /// puts every JSX element in one, which is what hides JSX call sites.
+    #[test]
+    fn tsx_files_parse_jsx_without_errors() {
+        let source = "export function Hello() {\n  return <div className=\"greet\">hi</div>;\n}\n";
+
+        let tsx = tree_sitter_grammar_for_path(Language::TypeScript, "src/jsx.tsx").unwrap();
+        let mut parser = tree_sitter::Parser::new();
+        parser.set_language(&tsx).unwrap();
+        assert!(
+            !parser.parse(source, None).unwrap().root_node().has_error(),
+            "tsx grammar should parse JSX cleanly"
+        );
+
+        let ts = tree_sitter_grammar_for_path(Language::TypeScript, "src/plain.ts").unwrap();
+        let mut parser = tree_sitter::Parser::new();
+        parser.set_language(&ts).unwrap();
+        assert!(
+            parser.parse(source, None).unwrap().root_node().has_error(),
+            "typescript grammar is the one that errors on JSX; if this stops \
+             holding, the tsx split is no longer needed"
+        );
+    }
+
+    #[test]
+    fn non_tsx_paths_keep_their_language_grammar() {
+        let cases = [
+            ("src/plain.ts", Language::TypeScript),
+            ("src/app.mts", Language::TypeScript),
+            ("noext", Language::TypeScript),
+            ("src/main.rs", Language::Rust),
+        ];
+        for (path, lang) in cases {
+            let by_path = tree_sitter_grammar_for_path(lang, path).unwrap();
+            assert_eq!(
+                by_path,
+                tree_sitter_grammar(lang).unwrap(),
+                "{path} should use the plain {lang} grammar"
             );
         }
     }

--- a/crates/vera-core/src/parsing/mod.rs
+++ b/crates/vera-core/src/parsing/mod.rs
@@ -100,7 +100,7 @@ pub fn parse_file_with_diagnostics(
         ));
     }
 
-    let grammar = match languages::tree_sitter_grammar(language) {
+    let grammar = match languages::tree_sitter_grammar_for_path(language, file_path) {
         Some(g) => g,
         None => {
             let chunks = chunker::tier0_line_chunks(source, file_path, language);

--- a/crates/vera-core/src/parsing/references.rs
+++ b/crates/vera-core/src/parsing/references.rs
@@ -95,12 +95,28 @@ fn is_jsx_element_node(kind: &str) -> bool {
 
 /// Whether a JSX tag names a host element rather than a component in scope.
 ///
-/// JSX resolves a tag beginning with a lowercase letter, such as `<div>`, to an
-/// intrinsic element string, and any other, such as `<Foo>` or `<Foo.Bar>`, to a
-/// value in scope. Only the latter is a call site; recording the former would
-/// add an edge per HTML tag in the repository.
-fn is_jsx_host_element(kind: &str, name: &str) -> bool {
-    is_jsx_element_node(kind) && name.starts_with(|ch: char| ch.is_lowercase())
+/// JSX resolves a *bare* tag beginning with a lowercase letter, such as `<div>`,
+/// to an intrinsic element string. Anything else is a value in scope, and only
+/// those are call sites; recording host elements would add an edge per HTML tag
+/// in the repository.
+///
+/// The decision has to come from the tag node, not from the extracted callee.
+/// `extract_callee` returns the rightmost identifier, so `<Icons.arrow />` yields
+/// `arrow`, and judging that name alone would discard a real component
+/// reference. A dotted tag is a member expression on a value in scope whatever
+/// the case of its property.
+fn is_jsx_host_element(node: &tree_sitter::Node, source: &[u8]) -> bool {
+    if !is_jsx_element_node(node.kind()) {
+        return false;
+    }
+    let Some(name) = node.child_by_field_name("name") else {
+        return false;
+    };
+    if name.kind() == "member_expression" {
+        return false;
+    }
+    name.utf8_text(source)
+        .is_ok_and(|text| text.starts_with(|ch: char| ch.is_lowercase()))
 }
 
 /// Extract the callee name from a call node.
@@ -209,7 +225,7 @@ fn collect_calls(
         let node = cursor.node();
         if is_call_node(lang, node.kind()) {
             if let Some(callee) = extract_callee(&node, source) {
-                if !is_jsx_host_element(node.kind(), &callee) {
+                if !is_jsx_host_element(&node, source) {
                     let caller = find_enclosing_symbol(symbols, node.start_byte());
                     refs.push(RawReference {
                         callee,
@@ -346,6 +362,7 @@ export function App() {
         <div className="wrap">
             <Hello name="world" />
             <Panel.Header title="hi"></Panel.Header>
+            <Icons.arrow />
         </div>
     );
 }
@@ -359,6 +376,11 @@ export function App() {
         assert!(
             callees.contains(&"Header"),
             "dotted JSX element should be a call site: {callees:?}"
+        );
+        assert!(
+            callees.contains(&"arrow"),
+            "a dotted tag is a value in scope whatever the case of its \
+             property, so <Icons.arrow /> is a call site: {callees:?}"
         );
         assert!(
             !callees.contains(&"div"),

--- a/crates/vera-core/src/parsing/references.rs
+++ b/crates/vera-core/src/parsing/references.rs
@@ -51,7 +51,7 @@ fn is_call_node(lang: Language, kind: &str) -> bool {
     match lang {
         Language::Rust => matches!(kind, "call_expression" | "macro_invocation"),
         Language::TypeScript | Language::JavaScript => {
-            matches!(kind, "call_expression" | "new_expression")
+            matches!(kind, "call_expression" | "new_expression") || is_jsx_element_node(kind)
         }
         Language::Python => kind == "call",
         Language::Go => kind == "call_expression",
@@ -83,6 +83,24 @@ fn is_call_node(lang: Language, kind: &str) -> bool {
         Language::Elm => kind == "function_call_expr",
         _ => false,
     }
+}
+
+/// Whether a node kind is a JSX element tag that names the component it renders.
+///
+/// `jsx_closing_element` is deliberately excluded so `<Foo></Foo>` records one
+/// reference rather than two.
+fn is_jsx_element_node(kind: &str) -> bool {
+    matches!(kind, "jsx_opening_element" | "jsx_self_closing_element")
+}
+
+/// Whether a JSX tag names a host element rather than a component in scope.
+///
+/// JSX resolves a tag beginning with a lowercase letter, such as `<div>`, to an
+/// intrinsic element string, and any other, such as `<Foo>` or `<Foo.Bar>`, to a
+/// value in scope. Only the latter is a call site; recording the former would
+/// add an edge per HTML tag in the repository.
+fn is_jsx_host_element(kind: &str, name: &str) -> bool {
+    is_jsx_element_node(kind) && name.starts_with(|ch: char| ch.is_lowercase())
 }
 
 /// Extract the callee name from a call node.
@@ -191,12 +209,14 @@ fn collect_calls(
         let node = cursor.node();
         if is_call_node(lang, node.kind()) {
             if let Some(callee) = extract_callee(&node, source) {
-                let caller = find_enclosing_symbol(symbols, node.start_byte());
-                refs.push(RawReference {
-                    callee,
-                    caller,
-                    line: node.start_position().row as u32 + 1,
-                });
+                if !is_jsx_host_element(node.kind(), &callee) {
+                    let caller = find_enclosing_symbol(symbols, node.start_byte());
+                    refs.push(RawReference {
+                        callee,
+                        caller,
+                        line: node.start_position().row as u32 + 1,
+                    });
+                }
             }
         }
         // Depth-first: try child, then sibling, then backtrack.
@@ -220,11 +240,16 @@ fn collect_calls(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::parsing::languages::tree_sitter_grammar;
+    use crate::parsing::languages::tree_sitter_grammar_for_path;
     use tree_sitter::Parser;
 
     fn parse_and_extract(source: &str, lang: Language) -> Vec<RawReference> {
-        let grammar = tree_sitter_grammar(lang).expect("grammar should exist");
+        // An extensionless path resolves to the plain per-language grammar.
+        parse_and_extract_for_path(source, "source", lang)
+    }
+
+    fn parse_and_extract_for_path(source: &str, path: &str, lang: Language) -> Vec<RawReference> {
+        let grammar = tree_sitter_grammar_for_path(lang, path).expect("grammar should exist");
         let mut parser = Parser::new();
         parser.set_language(&grammar).unwrap();
         let tree = parser.parse(source, None).unwrap();
@@ -308,6 +333,57 @@ func foo() {}
         assert!(
             callees.contains(&"foo"),
             "should find foo call: {callees:?}"
+        );
+    }
+
+    #[test]
+    fn tsx_jsx_elements_are_call_sites() {
+        let source = r#"
+import { Hello } from "./jsx";
+
+export function App() {
+    return (
+        <div className="wrap">
+            <Hello name="world" />
+            <Panel.Header title="hi"></Panel.Header>
+        </div>
+    );
+}
+"#;
+        let refs = parse_and_extract_for_path(source, "src/app.tsx", Language::TypeScript);
+        let callees: Vec<&str> = refs.iter().map(|r| r.callee.as_str()).collect();
+        assert!(
+            callees.contains(&"Hello"),
+            "JSX element should be a call site: {callees:?}"
+        );
+        assert!(
+            callees.contains(&"Header"),
+            "dotted JSX element should be a call site: {callees:?}"
+        );
+        assert!(
+            !callees.contains(&"div"),
+            "host elements should not be call sites: {callees:?}"
+        );
+        assert_eq!(
+            refs.iter().filter(|r| r.callee == "Header").count(),
+            1,
+            "paired tags should record one reference, not two"
+        );
+        assert!(
+            refs.iter()
+                .any(|r| r.callee == "Hello" && r.caller.as_deref() == Some("App")),
+            "caller should be App: {refs:?}"
+        );
+    }
+
+    #[test]
+    fn jsx_in_javascript_is_a_call_site() {
+        let source = "export function App() { return <Hello name=\"world\" />; }\n";
+        let refs = parse_and_extract(source, Language::JavaScript);
+        let callees: Vec<&str> = refs.iter().map(|r| r.callee.as_str()).collect();
+        assert!(
+            callees.contains(&"Hello"),
+            "JSX element should be a call site: {callees:?}"
         );
     }
 

--- a/crates/vera-core/src/parsing/references.rs
+++ b/crates/vera-core/src/parsing/references.rs
@@ -100,10 +100,14 @@ fn is_jsx_element_node(kind: &str) -> bool {
 /// and only those are call sites; recording host elements would add an edge per
 /// HTML tag in the repository.
 ///
-/// The test is ASCII-specific on purpose, matching what the transpilers do:
-/// Babel's `isCompatTag` is `/^[a-z]/` and TypeScript's `isIntrinsicJsxName`
-/// compares against `a`..`z`. A Unicode-aware lowercase test would classify
-/// `<éWidget />` as a host element and drop a real component reference.
+/// The rule mirrors TypeScript's `isIntrinsicJsxName`, which is
+/// `first char in a..z || name contains '-'`. Both halves matter:
+///
+/// - the range is ASCII on purpose. A Unicode-aware lowercase test would call
+///   `<éWidget />` a host element and drop a real component reference.
+/// - a hyphen makes the tag intrinsic whatever its case, because that is the
+///   custom-element form and TypeScript emits `<My-element />` as the string
+///   `"My-element"` rather than a value lookup.
 ///
 /// The decision has to come from the tag node, not from the extracted callee.
 /// `extract_callee` returns the rightmost identifier, so `<Icons.arrow />` yields
@@ -120,8 +124,9 @@ fn is_jsx_host_element(node: &tree_sitter::Node, source: &[u8]) -> bool {
     if name.kind() == "member_expression" {
         return false;
     }
-    name.utf8_text(source)
-        .is_ok_and(|text| text.starts_with(|ch: char| ch.is_ascii_lowercase()))
+    name.utf8_text(source).is_ok_and(|text| {
+        text.starts_with(|ch: char| ch.is_ascii_lowercase()) || text.contains('-')
+    })
 }
 
 /// Extract the callee name from a call node.
@@ -369,6 +374,7 @@ export function App() {
             <Panel.Header title="hi"></Panel.Header>
             <Icons.arrow />
             <éWidget />
+            <My-element />
         </div>
     );
 }
@@ -396,6 +402,11 @@ export function App() {
             callees.contains(&"éWidget"),
             "only ASCII a-z marks an intrinsic tag, so <éWidget /> is a \
              component reference: {callees:?}"
+        );
+        assert!(
+            !callees.contains(&"My-element"),
+            "a hyphen makes a tag intrinsic whatever its case, matching \
+             TypeScript's isIntrinsicJsxName: {callees:?}"
         );
         assert_eq!(
             refs.iter().filter(|r| r.callee == "Header").count(),

--- a/crates/vera-core/src/parsing/references.rs
+++ b/crates/vera-core/src/parsing/references.rs
@@ -95,10 +95,15 @@ fn is_jsx_element_node(kind: &str) -> bool {
 
 /// Whether a JSX tag names a host element rather than a component in scope.
 ///
-/// JSX resolves a *bare* tag beginning with a lowercase letter, such as `<div>`,
-/// to an intrinsic element string. Anything else is a value in scope, and only
-/// those are call sites; recording host elements would add an edge per HTML tag
-/// in the repository.
+/// JSX resolves a *bare* tag beginning with a lowercase ASCII letter, such as
+/// `<div>`, to an intrinsic element string. Anything else is a value in scope,
+/// and only those are call sites; recording host elements would add an edge per
+/// HTML tag in the repository.
+///
+/// The test is ASCII-specific on purpose, matching what the transpilers do:
+/// Babel's `isCompatTag` is `/^[a-z]/` and TypeScript's `isIntrinsicJsxName`
+/// compares against `a`..`z`. A Unicode-aware lowercase test would classify
+/// `<éWidget />` as a host element and drop a real component reference.
 ///
 /// The decision has to come from the tag node, not from the extracted callee.
 /// `extract_callee` returns the rightmost identifier, so `<Icons.arrow />` yields
@@ -116,7 +121,7 @@ fn is_jsx_host_element(node: &tree_sitter::Node, source: &[u8]) -> bool {
         return false;
     }
     name.utf8_text(source)
-        .is_ok_and(|text| text.starts_with(|ch: char| ch.is_lowercase()))
+        .is_ok_and(|text| text.starts_with(|ch: char| ch.is_ascii_lowercase()))
 }
 
 /// Extract the callee name from a call node.
@@ -363,6 +368,7 @@ export function App() {
             <Hello name="world" />
             <Panel.Header title="hi"></Panel.Header>
             <Icons.arrow />
+            <éWidget />
         </div>
     );
 }
@@ -385,6 +391,11 @@ export function App() {
         assert!(
             !callees.contains(&"div"),
             "host elements should not be call sites: {callees:?}"
+        );
+        assert!(
+            callees.contains(&"éWidget"),
+            "only ASCII a-z marks an intrinsic tag, so <éWidget /> is a \
+             component reference: {callees:?}"
         );
         assert_eq!(
             refs.iter().filter(|r| r.callee == "Header").count(),

--- a/crates/vera-core/src/parsing/tests.rs
+++ b/crates/vera-core/src/parsing/tests.rs
@@ -370,6 +370,33 @@ fn typescript_multi_declarator_statements_are_unchanged() {
     assert_eq!(chunks[0].content.trim(), "const a = () => 1, b = () => 2;");
 }
 
+#[test]
+fn tsx_files_parse_clean_and_expose_jsx_call_sites() {
+    let source = r#"import { Hello } from "./hello";
+
+export function App() {
+    return <Hello name="world" />;
+}
+"#;
+    let (chunks, refs, diagnostics) = parse_file_with_diagnostics(
+        source,
+        "src/app.tsx",
+        Language::TypeScript,
+        &default_config(),
+    )
+    .unwrap();
+
+    assert!(
+        !diagnostics.tree_has_error,
+        "the tsx grammar should parse JSX without error nodes"
+    );
+    assert!(!chunks.is_empty(), "should produce chunks");
+    assert!(
+        refs.iter().any(|r| r.callee == "Hello"),
+        "JSX usage should be recorded as a call site: {refs:?}"
+    );
+}
+
 // =========================================================
 // Go tests
 // =========================================================

--- a/crates/vera-core/src/retrieval/structural.rs
+++ b/crates/vera-core/src/retrieval/structural.rs
@@ -621,6 +621,59 @@ mod tests {
         assert_eq!(results[0].symbol_name.as_deref(), Some("parse_config"));
     }
 
+    /// Structural search over a JSX-bearing `.tsx` file: the real env read is
+    /// found and attributed, the comment and JSX-attribute decoys are not.
+    ///
+    /// This characterises behaviour rather than guarding the grammar switch.
+    /// It passes under both grammars, which is the point: tree-sitter still
+    /// lexes comments and strings inside an error region, and still recognises
+    /// the enclosing `function_declaration`, so swapping `typescript` for `tsx`
+    /// leaves structural results unchanged. Nothing covered `.tsx` structural
+    /// search before, so the coverage is new either way.
+    #[tokio::test]
+    async fn structural_search_works_in_jsx_bearing_tsx() {
+        let dir = index_repo(&[(
+            "src/Panel.tsx",
+            r#"export function Panel() {
+  // const decoy = process.env.FAKE_URL;
+  const real = process.env.API_URL;
+  return <div title="process.env.FAKE_URL">{real}</div>;
+}
+"#,
+        )])
+        .await;
+        let index_dir = crate::indexing::index_dir(dir.path());
+
+        let real = search_structural(
+            &index_dir,
+            StructuralSearchKind::EnvReads,
+            Some("API_URL"),
+            10,
+            &SearchFilters::default(),
+        )
+        .unwrap();
+        assert_eq!(real.len(), 1, "real env read should be found: {real:?}");
+        assert_eq!(real[0].file_path, "src/Panel.tsx");
+        assert_eq!(
+            real[0].symbol_name.as_deref(),
+            Some("Panel"),
+            "match should be attributed to the enclosing component"
+        );
+
+        let decoy = search_structural(
+            &index_dir,
+            StructuralSearchKind::EnvReads,
+            Some("FAKE_URL"),
+            10,
+            &SearchFilters::default(),
+        )
+        .unwrap();
+        assert!(
+            decoy.is_empty(),
+            "comment and JSX attribute string should be filtered: {decoy:?}"
+        );
+    }
+
     #[tokio::test]
     async fn definitions_find_const_assigned_functions() {
         let dir = index_repo(&[(

--- a/crates/vera-core/src/retrieval/structural.rs
+++ b/crates/vera-core/src/retrieval/structural.rs
@@ -282,7 +282,7 @@ where
         }
 
         let chunks = store.get_chunks_by_file(&file_rel)?;
-        let syntax_filter = SyntaxFilter::new(language, &content);
+        let syntax_filter = SyntaxFilter::new(language, &file_rel, &content);
         for candidate in collect(&file_rel, language, &content, &chunks)? {
             if results.len() >= limit {
                 break;
@@ -376,12 +376,13 @@ struct StructuralMatch {
 struct SyntaxFilter(Option<tree_sitter::Tree>);
 
 impl SyntaxFilter {
-    fn new(language: Language, content: &str) -> Self {
-        let tree = languages::tree_sitter_grammar(language).and_then(|grammar| {
-            let mut parser = Parser::new();
-            parser.set_language(&grammar).ok()?;
-            parser.parse(content, None)
-        });
+    fn new(language: Language, file_path: &str, content: &str) -> Self {
+        let tree =
+            languages::tree_sitter_grammar_for_path(language, file_path).and_then(|grammar| {
+                let mut parser = Parser::new();
+                parser.set_language(&grammar).ok()?;
+                parser.parse(content, None)
+            });
         Self(tree)
     }
 


### PR DESCRIPTION
Fixes #56.

`.tsx` was parsed with the `typescript` tree-sitter grammar. JSX is ambiguous with
type assertions, which is why tree-sitter ships `typescript` and `tsx` as separate
grammars upstream, so every JSX element landed in an error node and the call sites
inside it were never parsed.

The visible symptom was a tree-sitter error count. The cost was that `references`
and `dead-code` returned a confident `No callers found` for components rendered as
`<Foo />` — not reduced confidence, a clean negative, which is the wrong answer to
act on when deciding whether a component is dead.

## What changed

**1. Grammar selection by extension.** `tree_sitter_grammar_for_path` returns the
`tsx` grammar for `.tsx` and defers to the existing per-language mapping for
everything else. It sits beside `tree_sitter_grammar` in `parsing/languages.rs`
and is used from `parse_file_with_diagnostics` and the `structural` syntax filter,
both of which already have the file path.

**2. JSX elements as call sites.** Grammar selection alone does not close the issue.
`is_call_node` recognised only `call_expression` and `new_expression` for TS/JS, so
a cleanly parsed JSX element still was not a call site. `jsx_opening_element` and
`jsx_self_closing_element` are now call nodes; `jsx_closing_element` deliberately is
not, so `<Foo></Foo>` records one reference rather than two.

This half also fixes `.jsx`/`.js`, where the JavaScript grammar already parsed JSX
without errors and the call sites were invisible anyway.

**Host elements stay out of the reference graph.** JSX resolves a tag beginning with
a lowercase letter to an intrinsic element string rather than to a value in scope,
so recording `<div>` would add an edge per HTML tag in the repository.

The `typescript` label in `stats` is unchanged. Splitting it would change reported
language breakdowns, which reads as a separate maintainer call.

## Verification

Against the released v1.0.0 binary as a control, same fixture and same queries. Two
files: `jsx.tsx` defining `Hello`, `app.tsx` rendering `<Hello name="world" />`.

| | stock v1.0.0 | this branch |
|---|---|---|
| `vera references Hello` | `No callers found for 'Hello'.` | `app.tsx:1-4 function:App` |
| `files_with_tree_sitter_errors` | 2 | 0 |
| `files_with_parse_failures` | 0 | 0 |
| `vera references div` | `No callers found` | `No callers found` |

Tests: `cargo test --workspace` — 920 passed, 0 failed. `cargo build --release`
clean for the whole workspace. `cargo fmt --check` clean. `cargo clippy -p vera-core
--lib` reports only the five warnings already present on `master`.

Both halves were confirmed load-bearing by reverting each in turn:

- reverting the `is_call_node` change fails `tsx_jsx_elements_are_call_sites` and
  `jsx_in_javascript_is_a_call_site` with the production symptom, an empty callee
  list
- reverting the grammar selection fails `tsx_files_parse_jsx_without_errors` and
  also `tsx_jsx_elements_are_call_sites`, since the JSX nodes do not exist to match

`tsx_files_parse_jsx_without_errors` also asserts that the `typescript` grammar
still errors on the same JSX source, so the test starts failing if the upstream
split ever stops being necessary.

## Deliberately out of scope

`signatures::extract_signature(content, lang)` takes no path, so it still resolves
the grammar by language alone. Its callers do have a path available — `Chunk` and
`SearchResult` both carry `file_path` — so a `.tsx` chunk can still hit JSX in an
error node when a signature is stripped for `--compact` output or a type-relation
header.

That is the same class of problem, but fixing it means changing a public signature
used from `vera-mcp` and `vera-cli` as well as `vera-core`, which is wider than this
issue. Happy to do it here or in a follow-up, whichever you prefer.

Happy to adjust the shape if you would rather see the language label split too, or
the JSX handling scoped differently.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/VeraTools/codesmith/Vera/pr/58"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789743571&installation_model_id=432833&pr_number=58&repository=VeraTools%2FVera&return_to=https%3A%2F%2Fgithub.com%2FVeraTools%2FVera%2Fpull%2F58&signature=3d7bd0da2461260aa48cc7f8e2e844162d4f6eaeadb7a09b9f7143bb23fdacd2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Parse `.tsx` with the `tsx` grammar and record JSX component renders as call sites so `references`/`dead-code` find component usage. Previously `.tsx` used the `typescript` grammar (JSX parsed as errors) and JSX renders like `<Foo />` were invisible.

- Grammar by path: `tree_sitter_grammar_for_path` returns `tsx` for `.tsx` and is used in `parse_file_with_diagnostics` and structural search’s `SyntaxFilter`.
- JSX as calls: treat `jsx_opening_element` and `jsx_self_closing_element` as calls; exclude `jsx_closing_element`. Also surfaces JSX calls in `.js`/`.jsx`.
- Host-element filter: decide from the tag node; skip bare lowercase ASCII tags or any tag containing a hyphen (e.g., `<div>`, `<My-element />`). Keep dotted tags (e.g., `<Icons.arrow />`) and non-ASCII-leading names (e.g., `<éWidget />`) as component calls.
- Structural search: selects grammar by file path; behavior and attribution on `.tsx` are unchanged. Added a characterization test that finds real env reads and filters comment/JSX-attribute decoys.
- Tests cover grammar selection, JSX call extraction (dotted, ASCII-only lowercase, hyphen rules), `.tsx` structural search. No API or `stats` label changes.

<sup>Written for commit 8c73e5a0bc74a4a054efb488539089397963e7c9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/VeraTools/Vera/pull/58?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved JavaScript and TypeScript JSX support, including `.tsx` files.
  * JSX components are now recognized in extracted references and call sites.
  * JSX host elements are excluded from component reference results.
  * Structural searches now work reliably in JSX-containing TypeScript files.

* **Bug Fixes**
  * Fixed parsing and structural matching for TSX files by selecting the appropriate grammar based on file path.
  * Added coverage for JSX components, dotted tags, caller detection, environment-variable reads, and clean TSX parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->