### PR TITLE
fix(parsing): name const-assigned functions in TS/JS

### DIFF
--- a/crates/vera-core/src/parsing/extractor/mod.rs
+++ b/crates/vera-core/src/parsing/extractor/mod.rs
@@ -160,8 +160,8 @@ fn collect_symbols(
         }
     }
 
-    // Handle TS/JS `const name = () => {}`: the name lives on the declarator,
-    // and a function initialiser makes the binding a function, not a variable.
+    // Handle TS/JS function-valued bindings: the name lives on the declarator,
+    // and a function initializer makes the binding a function, not a variable.
     if (lang == Language::TypeScript || lang == Language::JavaScript)
         && matches!(kind, "lexical_declaration" | "variable_declaration")
     {

--- a/crates/vera-core/src/parsing/extractor/mod.rs
+++ b/crates/vera-core/src/parsing/extractor/mod.rs
@@ -160,6 +160,17 @@ fn collect_symbols(
         }
     }
 
+    // Handle TS/JS `const name = () => {}`: the name lives on the declarator,
+    // and a function initialiser makes the binding a function, not a variable.
+    if (lang == Language::TypeScript || lang == Language::JavaScript)
+        && matches!(kind, "lexical_declaration" | "variable_declaration")
+    {
+        if let Some(sym) = extract_js_function_binding(&node, source) {
+            symbols.push(sym);
+            return;
+        }
+    }
+
     // Handle Zig variable_declaration -> struct_declaration
     if lang == Language::Zig && kind == "variable_declaration" {
         let mut cursor = node.walk();

--- a/crates/vera-core/src/parsing/extractor/special_forms.rs
+++ b/crates/vera-core/src/parsing/extractor/special_forms.rs
@@ -222,10 +222,14 @@ pub(super) fn get_elixir_do_block<'a>(
 ///
 /// Returns `None` for anything else, including multi-declarator statements,
 /// destructuring patterns and bindings to plain values, so those keep their
-/// existing chunk shape. The symbol spans the declaration node, which is what
-/// every other declaration kind in this extractor does; an `export` on a
-/// preceding line therefore sits outside the span, as it already does for
-/// `export`-ed functions, classes and interfaces.
+/// existing chunk shape.
+///
+/// The symbol spans the declaration node, which is what every other declaration
+/// kind in this extractor does. `export` is part of the enclosing
+/// `export_statement`, so it sits outside that span exactly as it already does
+/// for `export`-ed functions, classes and interfaces. Chunk content is expanded
+/// to whole lines afterwards, so a single-line `export const f = …` still reads
+/// with its `export`, while a declaration split across lines does not.
 pub(super) fn extract_js_function_binding(
     node: &tree_sitter::Node<'_>,
     source: &[u8],

--- a/crates/vera-core/src/parsing/extractor/special_forms.rs
+++ b/crates/vera-core/src/parsing/extractor/special_forms.rs
@@ -207,6 +207,43 @@ pub(super) fn get_elixir_do_block<'a>(
         .find(|child| child.kind() == "do_block")
 }
 
+/// Extract `const name = () => {}` and `const name = function () {}` as a named
+/// function symbol.
+///
+/// The name sits on the `variable_declarator`, not on the declaration itself,
+/// so the generic name lookup finds nothing and the symbol is stored unnamed.
+/// That is what makes const-assigned components and utilities unreachable from
+/// `structural definitions`.
+///
+/// Returns `None` for anything else, including multi-declarator statements and
+/// bindings to plain values, so those keep their existing chunk shape. The
+/// symbol spans the whole declaration, keeping the `const` keyword and any
+/// `export` in the chunk.
+pub(super) fn extract_js_function_binding(
+    node: &tree_sitter::Node<'_>,
+    source: &[u8],
+) -> Option<RawSymbol> {
+    let mut cursor = node.walk();
+    let mut declarators = node
+        .children(&mut cursor)
+        .filter(|child| child.kind() == "variable_declarator");
+    let declarator = declarators.next()?;
+    if declarators.next().is_some() {
+        return None;
+    }
+
+    let value = declarator.child_by_field_name("value")?;
+    if !matches!(
+        value.kind(),
+        "arrow_function" | "function_expression" | "generator_function"
+    ) {
+        return None;
+    }
+
+    let name = extract_name(&declarator, source)?;
+    Some(RawSymbol::at(node, Some(name), SymbolType::Function))
+}
+
 /// Refine a Go type_spec into the correct SymbolType based on the type child.
 pub(super) fn refine_go_type_spec(node: &tree_sitter::Node<'_>, source: &[u8]) -> SymbolType {
     if let Some(type_child) = node.child_by_field_name("type") {

--- a/crates/vera-core/src/parsing/extractor/special_forms.rs
+++ b/crates/vera-core/src/parsing/extractor/special_forms.rs
@@ -215,10 +215,17 @@ pub(super) fn get_elixir_do_block<'a>(
 /// That is what makes const-assigned components and utilities unreachable from
 /// `structural definitions`.
 ///
-/// Returns `None` for anything else, including multi-declarator statements and
-/// bindings to plain values, so those keep their existing chunk shape. The
-/// symbol spans the whole declaration, keeping the `const` keyword and any
-/// `export` in the chunk.
+/// `let` and `var` bindings are covered too: the reported symptom was about
+/// `const` because that is the dominant style, but the missing name is a
+/// property of the declarator, not of the keyword, so scoping this to `const`
+/// would leave the same bug in place for the other two.
+///
+/// Returns `None` for anything else, including multi-declarator statements,
+/// destructuring patterns and bindings to plain values, so those keep their
+/// existing chunk shape. The symbol spans the declaration node, which is what
+/// every other declaration kind in this extractor does; an `export` on a
+/// preceding line therefore sits outside the span, as it already does for
+/// `export`-ed functions, classes and interfaces.
 pub(super) fn extract_js_function_binding(
     node: &tree_sitter::Node<'_>,
     source: &[u8],

--- a/crates/vera-core/src/parsing/extractor/special_forms.rs
+++ b/crates/vera-core/src/parsing/extractor/special_forms.rs
@@ -207,13 +207,13 @@ pub(super) fn get_elixir_do_block<'a>(
         .find(|child| child.kind() == "do_block")
 }
 
-/// Extract `const name = () => {}` and `const name = function () {}` as a named
-/// function symbol.
+/// Extract function-valued `const`, `let`, and `var` bindings as named function
+/// symbols.
 ///
 /// The name sits on the `variable_declarator`, not on the declaration itself,
 /// so the generic name lookup finds nothing and the symbol is stored unnamed.
-/// That is what makes const-assigned components and utilities unreachable from
-/// `structural definitions`.
+/// That is what makes function-valued bindings such as React components and
+/// utilities unreachable from `structural definitions`.
 ///
 /// `let` and `var` bindings are covered too: the reported symptom was about
 /// `const` because that is the dominant style, but the missing name is a
@@ -228,7 +228,7 @@ pub(super) fn get_elixir_do_block<'a>(
 /// kind in this extractor does. `export` is part of the enclosing
 /// `export_statement`, so it sits outside that span exactly as it already does
 /// for `export`-ed functions, classes and interfaces. Chunk content is expanded
-/// to whole lines afterwards, so a single-line `export const f = …` still reads
+/// to whole lines afterwards, so a single-line `export const f = ...` still reads
 /// with its `export`, while a declaration split across lines does not.
 pub(super) fn extract_js_function_binding(
     node: &tree_sitter::Node<'_>,

--- a/crates/vera-core/src/parsing/tests.rs
+++ b/crates/vera-core/src/parsing/tests.rs
@@ -301,25 +301,47 @@ export const plainConst = 42;
         "value consts should keep their existing shape"
     );
 
-    let arrow = chunks
-        .iter()
-        .find(|c| c.symbol_name.as_deref() == Some("arrowFn"))
-        .unwrap();
-    assert!(
-        arrow.content.contains("export const arrowFn"),
-        "chunk should span the whole declaration: {:?}",
-        arrow.content
+    // The span covers the declaration, initialiser included, not just the name.
+    assert_eq!(
+        find_chunk(&chunks, "arrowFn").content.trim(),
+        "export const arrowFn = (a: number): number => a;"
     );
+}
+
+/// `let` and `var` function bindings are named too. The reported symptom was
+/// about `const` because that is the dominant style, but the cause is the name
+/// living on the declarator, which is identical for all three keywords.
+#[test]
+fn javascript_let_var_and_generator_bindings_are_named() {
+    let source = r#"export const arrowFn = (a) => a;
+let laterFn = function (a) { return a; };
+var oldStyleFn = () => {};
+export const genFn = function* () { yield 1; };
+"#;
+    let chunks = parse(source, "shapes.js", Language::JavaScript);
+
+    for name in ["arrowFn", "laterFn", "oldStyleFn", "genFn"] {
+        assert_eq!(
+            find_chunk(&chunks, name).symbol_type,
+            Some(SymbolType::Function),
+            "{name} binds a function"
+        );
+    }
 }
 
 #[test]
 fn typescript_multi_declarator_statements_are_unchanged() {
     let source = "const a = () => 1, b = () => 2;\n";
     let chunks = parse(source, "multi.ts", Language::TypeScript);
-    assert!(
-        chunks.iter().all(|c| c.symbol_name.as_deref() != Some("a")),
-        "multi-declarator statements keep their existing chunk shape"
-    );
+    for name in ["a", "b"] {
+        assert!(
+            chunks
+                .iter()
+                .all(|c| c.symbol_name.as_deref() != Some(name)),
+            "multi-declarator statements keep their existing chunk shape, \
+             but {name} was named"
+        );
+    }
 }
 
 // =========================================================

--- a/crates/vera-core/src/parsing/tests.rs
+++ b/crates/vera-core/src/parsing/tests.rs
@@ -302,10 +302,38 @@ export const plainConst = 42;
     );
 
     // The span covers the declaration, initialiser included, not just the name.
+    // `export` is present here because chunk content is expanded to whole lines
+    // and this declaration is on one line; see the multiline case below.
     assert_eq!(
         find_chunk(&chunks, "arrowFn").content.trim(),
         "export const arrowFn = (a: number): number => a;"
     );
+}
+
+/// A declaration split across lines from its `export` keeps the same span shape
+/// as every other declaration kind: the symbol covers the declaration, and the
+/// `export` on the preceding line falls outside it.
+///
+/// Pinned deliberately. Const bindings must not become the only declaration
+/// kind whose span swallows `export`; changing that is a repo-wide decision
+/// about `export_statement`, not something to do for one node kind.
+#[test]
+fn typescript_multiline_export_spans_match_function_declarations() {
+    let source = r#"export
+const arrowFn = (a: number): number => a;
+
+export
+function declaredFn(a: number): number { return a; }
+"#;
+    let chunks = parse(source, "multiline.ts", Language::TypeScript);
+
+    for name in ["arrowFn", "declaredFn"] {
+        let content = find_chunk(&chunks, name).content.trim().to_string();
+        assert!(
+            !content.starts_with("export"),
+            "{name} should span the declaration, not the export: {content:?}"
+        );
+    }
 }
 
 /// `let` and `var` function bindings are named too. The reported symptom was
@@ -333,15 +361,13 @@ export const genFn = function* () { yield 1; };
 fn typescript_multi_declarator_statements_are_unchanged() {
     let source = "const a = () => 1, b = () => 2;\n";
     let chunks = parse(source, "multi.ts", Language::TypeScript);
-    for name in ["a", "b"] {
-        assert!(
-            chunks
-                .iter()
-                .all(|c| c.symbol_name.as_deref() != Some(name)),
-            "multi-declarator statements keep their existing chunk shape, \
-             but {name} was named"
-        );
-    }
+
+    // The whole shape is pinned, not just the absence of names: one unnamed
+    // variable chunk spanning the statement, exactly as before this change.
+    assert_eq!(chunks.len(), 1, "unexpected chunks: {chunks:?}");
+    assert_eq!(chunks[0].symbol_name, None);
+    assert_eq!(chunks[0].symbol_type, Some(SymbolType::Variable));
+    assert_eq!(chunks[0].content.trim(), "const a = () => 1, b = () => 2;");
 }
 
 // =========================================================

--- a/crates/vera-core/src/parsing/tests.rs
+++ b/crates/vera-core/src/parsing/tests.rs
@@ -4,7 +4,7 @@
 //! Tier 0 fallback, large symbol splitting, and edge cases.
 
 use crate::config::IndexingConfig;
-use crate::parsing::test_support::{default_config, parse};
+use crate::parsing::test_support::{default_config, find_chunk, parse};
 use crate::parsing::{parse_and_chunk, parse_file_with_diagnostics};
 use crate::types::{Language, SymbolType};
 
@@ -265,6 +265,61 @@ type Point = { x: number; y: number };
         .iter()
         .find(|c| c.symbol_type == Some(SymbolType::TypeAlias));
     assert!(ta.is_some(), "should have type alias chunk");
+}
+
+#[test]
+fn typescript_const_assigned_functions_are_named() {
+    let source = r#"export function declaredFn(a: number): number { return a; }
+export const arrowFn = (a: number): number => a;
+export const typedArrow: (a: number) => number = (a) => a;
+export const asyncArrow = async () => {};
+export const exprFn = function (a: number) { return a; };
+export const plainConst = 42;
+"#;
+    let chunks = parse(source, "shapes.ts", Language::TypeScript);
+
+    for name in [
+        "declaredFn",
+        "arrowFn",
+        "typedArrow",
+        "asyncArrow",
+        "exprFn",
+    ] {
+        assert_eq!(
+            find_chunk(&chunks, name).symbol_type,
+            Some(SymbolType::Function),
+            "{name} binds a function"
+        );
+    }
+
+    // Whether plain value consts should be indexed as named symbols is a
+    // separate call; this fix deliberately leaves them as they were.
+    assert!(
+        chunks
+            .iter()
+            .all(|c| c.symbol_name.as_deref() != Some("plainConst")),
+        "value consts should keep their existing shape"
+    );
+
+    let arrow = chunks
+        .iter()
+        .find(|c| c.symbol_name.as_deref() == Some("arrowFn"))
+        .unwrap();
+    assert!(
+        arrow.content.contains("export const arrowFn"),
+        "chunk should span the whole declaration: {:?}",
+        arrow.content
+    );
+}
+
+#[test]
+fn typescript_multi_declarator_statements_are_unchanged() {
+    let source = "const a = () => 1, b = () => 2;\n";
+    let chunks = parse(source, "multi.ts", Language::TypeScript);
+    assert!(
+        chunks.iter().all(|c| c.symbol_name.as_deref() != Some("a")),
+        "multi-declarator statements keep their existing chunk shape"
+    );
 }
 
 // =========================================================

--- a/crates/vera-core/src/retrieval/structural.rs
+++ b/crates/vera-core/src/retrieval/structural.rs
@@ -621,6 +621,31 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn definitions_find_const_assigned_functions() {
+        let dir = index_repo(&[(
+            "src/shapes.ts",
+            "export function declaredFn(a: number): number { return a; }\n\
+             export const arrowFn = (a: number): number => a;\n\
+             export const MyButton: React.FC = () => null;\n",
+        )])
+        .await;
+        let index_dir = crate::indexing::index_dir(dir.path());
+
+        for symbol in ["declaredFn", "arrowFn", "MyButton"] {
+            let results = search_structural(
+                &index_dir,
+                StructuralSearchKind::Definitions,
+                Some(symbol),
+                10,
+                &SearchFilters::default(),
+            )
+            .unwrap();
+            assert_eq!(results.len(), 1, "no definition found for {symbol}");
+            assert_eq!(results[0].symbol_name.as_deref(), Some(symbol));
+        }
+    }
+
+    #[tokio::test]
     async fn env_reads_find_common_patterns() {
         let dir = index_repo(&[
             ("src/app.ts", "const db = process.env.DATABASE_URL;\n"),


### PR DESCRIPTION
Fixes #57.

`vera structural definitions` found `function` declarations, classes and interfaces
but nothing bound to a `const`, which excludes most components and a large share of
utilities in a modern TS or React codebase.

## Root cause

`lexical_declaration` was already classified as a symbol, so the chunk existed. The
name is the part that was missing: it sits on the `variable_declarator`, not on the
declaration, so `extract_name` found no `name` field and no identifier child and
returned `None`. `search_definitions` looks chunks up by symbol name, so there was
nothing to match.

That is why the command looked like it worked: `function`-declared and class-based
symbols in the same file returned results, while `export const MyButton: React.FC =
() => ...` in the next line returned nothing.

## What changed

`extract_js_function_binding` names the binding from the declarator and classifies
it as a function when the initialiser is an `arrow_function`, `function_expression`
or `generator_function`.

Scope is deliberately narrow:

- **Only function-valued bindings.** Plain value consts such as `const x = 42` keep
  their existing unnamed shape. Whether they should be indexed as named symbols is
  the separate design call noted in the issue.
- **Only single-declarator statements.** `const a = () => 1, b = () => 2` falls
  through to the existing path rather than changing chunk boundaries for a rare form.
- **The symbol still spans the whole declaration**, so the chunk keeps its `export`
  and `const` keywords and existing chunk content is unchanged apart from the name
  and symbol type.

## Verification

Against the released v1.0.0 binary as a control, same fixture and same queries,
using the file from the issue.

| symbol | form | stock v1.0.0 | this branch |
|---|---|---|---|
| `declaredFn` | `function` declaration | found | found |
| `Klass` | class | found | found |
| `Iface` | interface | found | found |
| `arrowFn` | `const` arrow | **not found** | found, `function:arrowFn` |
| `typedArrow` | `const` arrow, typed | **not found** | found, `function:typedArrow` |
| `MyButton` | `React.FC` arrow | **not found** | found, `function:MyButton` |
| `plainConst` | `const` value | not found | not found (unchanged, by design) |

Tests: `cargo test --workspace` — 918 passed, 0 failed. `cargo build --release`
clean for the whole workspace. `cargo fmt --check` clean. `cargo clippy -p vera-core
--lib` reports only the five warnings already present on `master`.

Destructuring bindings are unaffected: `const { a } = obj` resolves through
`extract_name`, which rejects `object_pattern`/`array_pattern`, so it keeps its
existing unnamed shape.

Both new tests were confirmed to catch the bug by disabling the extraction hook:
`typescript_const_assigned_functions_are_named` fails with `missing definition for
arrowFn`, and the end-to-end `definitions_find_const_assigned_functions` fails
against a real index with `no definition found for arrowFn`, which is the reported
symptom rather than a proxy for it.

This is independent of #56; the reproduction is a plain `.ts` file with zero
tree-sitter errors. The two compound in practice, since a component written as a
const arrow and used as a JSX element has neither a findable definition nor findable
callers.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/VeraTools/codesmith/Vera/pr/59"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789743574&installation_model_id=432833&pr_number=59&repository=VeraTools%2FVera&return_to=https%3A%2F%2Fgithub.com%2FVeraTools%2FVera%2Fpull%2F59&signature=476fa54f9a0c215fbba69d5990a1cb3dae70941eeedd11390642f7178afd0d93"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Names TS/JS const/let/var-assigned functions so structural definition lookups return them. Previously these bindings were stored unnamed and not findable; now they emit named Function symbols.

- Detects a single `variable_declarator` whose value is an `arrow_function`, `function_expression`, or `generator_function` via `extract_js_function_binding`, and wires it into `collect_symbols` for TypeScript/JavaScript declarations.
- Scope: only function-valued single declarators. Multi-declarator statements, destructuring, and plain value bindings are unchanged and remain unnamed.
- Span: the symbol spans the declaration (includes `const`/`let`/`var` and the initializer). An `export` on a separate line is outside the span; a single-line `export const f = ...` still shows `export` in chunk content due to whole-line expansion.
- Tests: cover TS and JS, `let`/`var`, async arrows, and generator functions; end-to-end definitions now find `export const MyButton = () => ...`; regression tests pin multi-declarator shape and multiline export spans.

<sup>Written for commit 9c24288a46cfdfa720bfcc9d87a038a14c7b8d14. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/VeraTools/Vera/pull/59?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * TypeScript and JavaScript function-valued `const`, `let`, and `var` declarations are now recognized as function definitions.
  * Supports arrow functions, function expressions, generator functions, and typed React component constants.
  * Function definitions include complete declaration text for improved code navigation and retrieval.

* **Bug Fixes**
  * Improved definition lookup for exported functions and function-valued constants.
  * Preserved existing behavior for regular constants, destructuring, and multi-variable declarations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->