### PR TITLE
Fix post-merge indexing review regressions

### DIFF
--- a/crates/vera-cli/src/helpers.rs
+++ b/crates/vera-cli/src/helpers.rs
@@ -26,6 +26,7 @@ where
     Signal: std::future::Future<Output = ()>,
 {
     tokio::select! {
+        biased;
         result = operation => result,
         _ = signal => anyhow::bail!("{operation_name} cancelled"),
     }
@@ -518,16 +519,18 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn operation_result_wins_before_cancellation() {
-        let result = cancel_on_signal(
-            async { Ok::<_, anyhow::Error>(42) },
-            std::future::pending(),
-            "test operation",
-        )
-        .await
-        .unwrap();
+    async fn ready_operation_error_wins_over_ready_signal() {
+        for _ in 0..64 {
+            let error = cancel_on_signal(
+                async { Err::<(), _>(anyhow::anyhow!("provider failed")) },
+                std::future::ready(()),
+                "test operation",
+            )
+            .await
+            .unwrap_err();
 
-        assert_eq!(result, 42);
+            assert_eq!(error.to_string(), "provider failed");
+        }
     }
 
     #[tokio::test]

--- a/crates/vera-core/src/cancellation.rs
+++ b/crates/vera-core/src/cancellation.rs
@@ -1,23 +1,33 @@
-use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, Ordering};
+use tokio_util::sync::CancellationToken as AsyncCancellationToken;
 
 /// Cooperative cancellation shared across indexing pipeline stages.
+///
+/// Clones observe the same permanent cancellation signal. Indexing stages use
+/// the async token to stop active provider work before publishing artifacts.
 #[derive(Debug, Clone, Default)]
 pub struct CancellationToken {
-    cancelled: Arc<AtomicBool>,
+    inner: AsyncCancellationToken,
 }
 
 impl CancellationToken {
+    /// Create a token in the active state.
     pub fn new() -> Self {
         Self::default()
     }
 
+    /// Cancel this token and every clone derived from it.
     pub fn cancel(&self) {
-        self.cancelled.store(true, Ordering::Release);
+        self.inner.cancel();
     }
 
+    /// Return whether this token or one of its clones has been cancelled.
     pub fn is_cancelled(&self) -> bool {
-        self.cancelled.load(Ordering::Acquire)
+        self.inner.is_cancelled()
+    }
+
+    /// Borrow the async signal used by provider requests.
+    pub(crate) fn as_async_token(&self) -> &AsyncCancellationToken {
+        &self.inner
     }
 
     pub(crate) fn check(&self) -> anyhow::Result<()> {

--- a/crates/vera-core/src/embedding/mod.rs
+++ b/crates/vera-core/src/embedding/mod.rs
@@ -9,6 +9,7 @@
 
 mod provider;
 
+pub(crate) use provider::embed_chunks_concurrent_with_progress_and_cancellation;
 pub use provider::{
     CachedEmbeddingProvider, EmbeddingError, EmbeddingProvider, EmbeddingProviderConfig,
     OpenAiProvider, embed_chunks_concurrent, embed_chunks_concurrent_with_progress,

--- a/crates/vera-core/src/embedding/provider.rs
+++ b/crates/vera-core/src/embedding/provider.rs
@@ -365,15 +365,17 @@ impl OpenAiProvider {
         let status = response.status().as_u16();
 
         if status == 401 || status == 403 {
-            let text = read_response_text(response, "failed to read authentication error response")
-                .await?;
+            let text =
+                read_error_response_text(response, "failed to read authentication error response")
+                    .await?;
             return Err(EmbeddingError::AuthError {
                 message: sanitize_error_message(&text),
             });
         }
 
         if status == 429 {
-            let text = read_response_text(response, "failed to read rate limit response").await?;
+            let text =
+                read_error_response_text(response, "failed to read rate limit response").await?;
             return Err(EmbeddingError::RateLimitError {
                 message: sanitize_error_message(&text),
             });
@@ -381,7 +383,8 @@ impl OpenAiProvider {
 
         if !response.status().is_success() {
             let text =
-                read_response_text(response, "failed to read embedding error response").await?;
+                read_error_response_text(response, "failed to read embedding error response")
+                    .await?;
             // Some providers return 400 with "Unable to process" for transient
             // overload conditions. Treat these as rate limits so they get retried.
             if status == 400 && text.contains("Unable to process") {
@@ -432,14 +435,15 @@ fn response_read_error(error: reqwest::Error, context: &str) -> EmbeddingError {
     }
 }
 
-async fn read_response_text(
+async fn read_error_response_text(
     response: reqwest::Response,
     context: &str,
 ) -> Result<String, EmbeddingError> {
-    response
-        .text()
-        .await
-        .map_err(|error| response_read_error(error, context))
+    match response.text().await {
+        Ok(text) => Ok(text),
+        Err(error) if error.is_timeout() => Err(response_read_error(error, context)),
+        Err(error) => Ok(format!("{context}: {error}")),
+    }
 }
 
 impl EmbeddingProvider for OpenAiProvider {
@@ -872,14 +876,24 @@ fn shrink_text_for_context_limit(
 async fn embed_batch_resilient<P: EmbeddingProvider>(
     provider: &P,
     items: Vec<EmbeddingBatchItem>,
+    cancel: &CancellationToken,
 ) -> Result<Vec<(usize, String, Vec<f32>)>, EmbeddingError> {
     let mut pending = vec![items];
     let mut completed = Vec::new();
 
     while let Some(batch) = pending.pop() {
+        if cancel.is_cancelled() {
+            return Err(EmbeddingError::Cancelled);
+        }
         let texts: Vec<String> = batch.iter().map(|item| item.text.clone()).collect();
 
-        match provider.embed_batch(&texts).await {
+        let result = tokio::select! {
+            biased;
+            result = provider.embed_batch_cancellable(&texts, cancel) => result,
+            _ = cancel.cancelled() => Err(EmbeddingError::Cancelled),
+        };
+
+        match result {
             Ok(vectors) => {
                 completed.extend(
                     batch
@@ -971,6 +985,36 @@ where
     P: EmbeddingProvider,
     F: Fn(usize, usize),
 {
+    embed_chunks_concurrent_with_progress_and_cancellation(
+        provider,
+        chunks,
+        batch_size,
+        max_concurrent,
+        max_chunk_bytes,
+        &CancellationToken::new(),
+        on_progress,
+    )
+    .await
+}
+
+/// Embed chunks concurrently while allowing the caller to cancel active batches.
+///
+/// The token remains owned by the indexing operation. Cancellation drops every
+/// active provider future and returns [`EmbeddingError::Cancelled`] without
+/// reporting further progress.
+pub(crate) async fn embed_chunks_concurrent_with_progress_and_cancellation<P, F>(
+    provider: &P,
+    chunks: &[Chunk],
+    batch_size: usize,
+    max_concurrent: usize,
+    max_chunk_bytes: usize,
+    cancel: &CancellationToken,
+    on_progress: F,
+) -> Result<Vec<(String, Vec<f32>)>, EmbeddingError>
+where
+    P: EmbeddingProvider,
+    F: Fn(usize, usize),
+{
     if chunks.is_empty() {
         return Ok(Vec::new());
     }
@@ -1016,7 +1060,7 @@ where
                 let batch_idx = group_start + i;
                 async move {
                     debug!(batch = batch_idx + 1, total_batches, "embedding batch");
-                    embed_batch_resilient(provider, items.clone()).await
+                    embed_batch_resilient(provider, items.clone(), cancel).await
                 }
             })
             .collect();
@@ -1192,6 +1236,30 @@ mod tests {
     use std::sync::Arc;
     use std::sync::atomic::{AtomicUsize, Ordering};
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    async fn provider_with_truncated_error_body(
+        status: &'static str,
+    ) -> (OpenAiProvider, tokio::task::JoinHandle<()>) {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let mut request = [0_u8; 2048];
+            let _ = stream.read(&mut request).await;
+            let response = format!(
+                "HTTP/1.1 {status}\r\nContent-Length: 32\r\nConnection: close\r\n\r\nshort"
+            );
+            stream.write_all(response.as_bytes()).await.unwrap();
+            stream.shutdown().await.unwrap();
+        });
+        let config = EmbeddingProviderConfig::new(
+            format!("http://{address}"),
+            "test-model".into(),
+            "test-key".into(),
+        )
+        .with_max_retries(0);
+        (OpenAiProvider::new(config).unwrap(), server)
+    }
 
     struct CancellationAwareProvider;
 
@@ -1440,5 +1508,41 @@ mod tests {
         assert!(matches!(error, EmbeddingError::TimeoutError { .. }));
         assert_eq!(request_count.load(Ordering::SeqCst), 1);
         server.abort();
+    }
+
+    #[tokio::test]
+    async fn truncated_auth_body_preserves_authentication_classification() {
+        let (provider, server) = provider_with_truncated_error_body("401 Unauthorized").await;
+        let texts = ["input".to_string()];
+        let body = EmbeddingRequest {
+            model: &provider.config.model_id,
+            input: &texts,
+        };
+
+        let error = provider
+            .send_request(&provider.endpoint_url(), &body)
+            .await
+            .unwrap_err();
+
+        assert!(matches!(error, EmbeddingError::AuthError { .. }));
+        server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn truncated_rate_limit_body_preserves_rate_limit_classification() {
+        let (provider, server) = provider_with_truncated_error_body("429 Too Many Requests").await;
+        let texts = ["input".to_string()];
+        let body = EmbeddingRequest {
+            model: &provider.config.model_id,
+            input: &texts,
+        };
+
+        let error = provider
+            .send_request(&provider.endpoint_url(), &body)
+            .await
+            .unwrap_err();
+
+        assert!(matches!(error, EmbeddingError::RateLimitError { .. }));
+        server.await.unwrap();
     }
 }

--- a/crates/vera-core/src/embedding/provider.rs
+++ b/crates/vera-core/src/embedding/provider.rs
@@ -1067,7 +1067,12 @@ where
 
         let results = futures::future::join_all(futures).await;
         for result in results {
+            // Batch errors (real provider failures or Cancelled) win over a
+            // pending cancellation so the caller sees the actual failure.
             let batch_results = result?;
+            if cancel.is_cancelled() {
+                return Err(EmbeddingError::Cancelled);
+            }
             done_count += batch_results.len();
             all_results.extend(batch_results);
             on_progress(done_count, total);
@@ -1259,6 +1264,29 @@ mod tests {
         )
         .with_max_retries(0);
         (OpenAiProvider::new(config).unwrap(), server)
+    }
+
+    /// Cancels the token mid-request but still returns vectors, modelling an
+    /// embedding response that completes at the same moment cancellation fires.
+    struct CancelThenSucceedProvider;
+
+    impl EmbeddingProvider for CancelThenSucceedProvider {
+        async fn embed_batch(&self, texts: &[String]) -> Result<Vec<Vec<f32>>, EmbeddingError> {
+            Ok(vec![vec![0.0; 8]; texts.len()])
+        }
+
+        async fn embed_batch_cancellable(
+            &self,
+            texts: &[String],
+            cancel: &CancellationToken,
+        ) -> Result<Vec<Vec<f32>>, EmbeddingError> {
+            cancel.cancel();
+            self.embed_batch(texts).await
+        }
+
+        fn expected_dim(&self) -> Option<usize> {
+            Some(8)
+        }
     }
 
     struct CancellationAwareProvider;
@@ -1544,5 +1572,36 @@ mod tests {
 
         assert!(matches!(error, EmbeddingError::RateLimitError { .. }));
         server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn cancellation_after_completed_batch_suppresses_further_progress() {
+        let chunks = vec![crate::types::Chunk {
+            id: "chunk-0".to_string(),
+            file_path: "src/main.rs".to_string(),
+            line_start: 1,
+            line_end: 1,
+            content: "fn main() {}".to_string(),
+            language: crate::types::Language::Rust,
+            symbol_type: None,
+            symbol_name: None,
+        }];
+        let progress_events = AtomicUsize::new(0);
+
+        let result = embed_chunks_concurrent_with_progress_and_cancellation(
+            &CancelThenSucceedProvider,
+            &chunks,
+            1,
+            1,
+            0,
+            &CancellationToken::new(),
+            |_, _| {
+                progress_events.fetch_add(1, Ordering::SeqCst);
+            },
+        )
+        .await;
+
+        assert!(matches!(result, Err(EmbeddingError::Cancelled)));
+        assert_eq!(progress_events.load(Ordering::SeqCst), 0);
     }
 }

--- a/crates/vera-core/src/indexing/pipeline.rs
+++ b/crates/vera-core/src/indexing/pipeline.rs
@@ -15,7 +15,9 @@ use tracing::{debug, info, warn};
 use crate::CancellationToken;
 use crate::config::VeraConfig;
 use crate::discovery::{self, DiscoveryResult};
-use crate::embedding::{EmbeddingProvider, embed_chunks_concurrent_with_progress_and_cancellation};
+use crate::embedding::{
+    EmbeddingError, EmbeddingProvider, embed_chunks_concurrent_with_progress_and_cancellation,
+};
 use crate::indexing::update::content_hash;
 use crate::parsing;
 use crate::parsing::references::RawReference;
@@ -291,8 +293,18 @@ where
         progress_cb,
     )
     .await;
+    let mut embeddings = match embedding_result {
+        Ok(embeddings) => embeddings,
+        Err(error) => {
+            // A completed provider error outranks a simultaneous cancellation,
+            // mirroring the biased select in the CLI's cancel_on_signal.
+            if matches!(error, EmbeddingError::Cancelled) {
+                cancellation.check()?;
+            }
+            return Err(error).context("embedding generation failed");
+        }
+    };
     cancellation.check()?;
-    let mut embeddings = embedding_result.context("embedding generation failed")?;
 
     // Truncate vectors if max_stored_dim is configured.
     let stored_dim = super::truncate_embeddings(&mut embeddings, config.embedding.max_stored_dim);

--- a/crates/vera-core/src/indexing/pipeline.rs
+++ b/crates/vera-core/src/indexing/pipeline.rs
@@ -15,7 +15,7 @@ use tracing::{debug, info, warn};
 use crate::CancellationToken;
 use crate::config::VeraConfig;
 use crate::discovery::{self, DiscoveryResult};
-use crate::embedding::{EmbeddingProvider, embed_chunks_concurrent_with_progress};
+use crate::embedding::{EmbeddingProvider, embed_chunks_concurrent_with_progress_and_cancellation};
 use crate::indexing::update::content_hash;
 use crate::parsing;
 use crate::parsing::references::RawReference;
@@ -281,17 +281,18 @@ where
     let progress_cb = |done: usize, total: usize| {
         on_progress(IndexProgress::EmbeddingProgress { done, total });
     };
-    let mut embeddings = embed_chunks_concurrent_with_progress(
+    let embedding_result = embed_chunks_concurrent_with_progress_and_cancellation(
         provider,
         &all_chunks,
         batch_size,
         max_concurrent_requests,
         config.indexing.max_chunk_bytes,
+        cancellation.as_async_token(),
         progress_cb,
     )
-    .await
-    .context("embedding generation failed")?;
+    .await;
     cancellation.check()?;
+    let mut embeddings = embedding_result.context("embedding generation failed")?;
 
     // Truncate vectors if max_stored_dim is configured.
     let stored_dim = super::truncate_embeddings(&mut embeddings, config.embedding.max_stored_dim);
@@ -305,6 +306,8 @@ where
     });
 
     // ── 5. Store everything on disk ──────────────────────────────
+    // Publication is synchronous, so cancellation must win before any artifact is replaced.
+    cancellation.check()?;
     let idx_dir = index_dir(&repo_root);
     store_index(
         &idx_dir,

--- a/crates/vera-core/src/indexing/pipeline_tests.rs
+++ b/crates/vera-core/src/indexing/pipeline_tests.rs
@@ -36,6 +36,32 @@ impl EmbeddingProvider for BlockingProvider {
     }
 }
 
+/// Cancels the token mid-request and then fails, modelling a provider error
+/// that completes at the same moment cancellation fires.
+struct CancelThenFailProvider;
+
+impl EmbeddingProvider for CancelThenFailProvider {
+    async fn embed_batch(&self, _texts: &[String]) -> Result<Vec<Vec<f32>>, EmbeddingError> {
+        Err(EmbeddingError::ApiError {
+            status: 500,
+            message: "provider exploded".to_string(),
+        })
+    }
+
+    async fn embed_batch_cancellable(
+        &self,
+        texts: &[String],
+        cancel: &tokio_util::sync::CancellationToken,
+    ) -> Result<Vec<Vec<f32>>, EmbeddingError> {
+        cancel.cancel();
+        self.embed_batch(texts).await
+    }
+
+    fn expected_dim(&self) -> Option<usize> {
+        Some(8)
+    }
+}
+
 #[tokio::test]
 async fn index_simple_repo() {
     let dir = TempDir::new().unwrap();
@@ -154,6 +180,29 @@ async fn cancellation_after_embedding_does_not_publish_index_artifacts() {
 
     assert!(error.to_string().contains("operation cancelled"));
     assert!(!dir.path().join(".vera").exists());
+}
+
+#[tokio::test]
+async fn provider_error_wins_over_simultaneous_cancellation() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("main.rs"), "fn main() {}\n").unwrap();
+    let config = default_config();
+
+    let error = super::index_repository_with_progress_and_cancellation(
+        dir.path(),
+        &CancelThenFailProvider,
+        &config,
+        "mock-model",
+        |_| {},
+        &CancellationToken::new(),
+    )
+    .await
+    .unwrap_err();
+
+    assert!(
+        error.to_string().contains("embedding generation failed"),
+        "provider error should win over the simultaneous cancellation: {error}"
+    );
 }
 
 #[tokio::test]

--- a/crates/vera-core/src/indexing/pipeline_tests.rs
+++ b/crates/vera-core/src/indexing/pipeline_tests.rs
@@ -2,6 +2,8 @@
 
 use std::fs;
 use std::path::Path;
+use std::sync::Arc;
+use std::time::Duration;
 
 use tempfile::TempDir;
 
@@ -9,12 +11,29 @@ use super::*;
 use crate::CancellationToken;
 use crate::config::VeraConfig;
 use crate::embedding::test_helpers::MockProvider;
+use crate::embedding::{EmbeddingError, EmbeddingProvider};
 use crate::storage::bm25::Bm25Index;
 use crate::storage::metadata::MetadataStore;
 use crate::storage::vector::VectorStore;
 
 fn default_config() -> VeraConfig {
     VeraConfig::default()
+}
+
+#[derive(Clone)]
+struct BlockingProvider {
+    started: Arc<tokio::sync::Notify>,
+}
+
+impl EmbeddingProvider for BlockingProvider {
+    async fn embed_batch(&self, _texts: &[String]) -> Result<Vec<Vec<f32>>, EmbeddingError> {
+        self.started.notify_one();
+        std::future::pending().await
+    }
+
+    fn expected_dim(&self) -> Option<usize> {
+        Some(8)
+    }
 }
 
 #[tokio::test]
@@ -71,6 +90,70 @@ async fn pre_cancelled_index_stops_before_creating_artifacts() {
 
     assert!(error.to_string().contains("operation cancelled"));
     assert!(!index_dir(dir.path()).exists());
+}
+
+#[tokio::test]
+async fn cancellation_stops_an_in_flight_embedding_request() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("main.rs"), "fn main() {}\n").unwrap();
+    let started = Arc::new(tokio::sync::Notify::new());
+    let provider = BlockingProvider {
+        started: started.clone(),
+    };
+    let config = default_config();
+    let cancellation = CancellationToken::new();
+    let task_cancellation = cancellation.clone();
+    let path = dir.path().to_path_buf();
+
+    let task = tokio::spawn(async move {
+        super::index_repository_with_progress_and_cancellation(
+            &path,
+            &provider,
+            &config,
+            "mock-model",
+            |_| {},
+            &task_cancellation,
+        )
+        .await
+    });
+    started.notified().await;
+    cancellation.cancel();
+
+    let error = tokio::time::timeout(Duration::from_millis(250), task)
+        .await
+        .expect("cancellation must stop the active embedding request")
+        .unwrap()
+        .unwrap_err();
+    assert!(error.to_string().contains("cancel"));
+    assert!(!dir.path().join(".vera").exists());
+}
+
+#[tokio::test]
+async fn cancellation_after_embedding_does_not_publish_index_artifacts() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("main.rs"), "fn main() {}\n").unwrap();
+    let provider = MockProvider::new(8);
+    let config = default_config();
+    let cancellation = CancellationToken::new();
+    let progress_cancellation = cancellation.clone();
+
+    let error = super::index_repository_with_progress_and_cancellation(
+        dir.path(),
+        &provider,
+        &config,
+        "mock-model",
+        move |event| {
+            if matches!(event, IndexProgress::EmbeddingDone { .. }) {
+                progress_cancellation.cancel();
+            }
+        },
+        &cancellation,
+    )
+    .await
+    .unwrap_err();
+
+    assert!(error.to_string().contains("operation cancelled"));
+    assert!(!dir.path().join(".vera").exists());
 }
 
 #[tokio::test]

--- a/crates/vera-core/src/indexing/update.rs
+++ b/crates/vera-core/src/indexing/update.rs
@@ -3,6 +3,9 @@
 //! Detects changed files via content hashing, then re-indexes only
 //! modified/new files and removes deleted files from the index.
 //!
+//! Parsing and embedding finish before stored rows are replaced. A read or
+//! provider failure therefore leaves the previous index data available.
+//!
 //! The algorithm:
 //! 1. Discover current files on disk
 //! 2. Load stored content hashes from the metadata DB
@@ -87,6 +90,17 @@ pub enum UpdateProgress {
     EmbeddingDone { count: usize },
     /// Updated index artifacts have been written to disk.
     StorageDone,
+}
+
+/// Parsed update data held in memory until embedding has succeeded.
+struct PreparedFile {
+    path: String,
+    hash: String,
+    modified: bool,
+    chunks: Vec<crate::types::Chunk>,
+    references: Vec<parsing::references::RawReference>,
+    type_relations: Vec<parsing::type_relations::RawTypeRelation>,
+    state: FileIndexState,
 }
 
 /// Compute a SHA-256 content hash for a file's contents.
@@ -297,7 +311,11 @@ where
         }
     }
 
-    let current_paths: HashSet<&str> = current_files.keys().map(|s| s.as_str()).collect();
+    let current_paths: HashSet<&str> = disc
+        .files
+        .iter()
+        .map(|file| file.relative_path.as_str())
+        .collect();
 
     // Classify files.
     let mut modified = Vec::new();
@@ -368,36 +386,24 @@ where
         deferred: files_deferred,
     });
 
-    // ── 4. Process deletions ─────────────────────────────────────
-    if !deleted.is_empty() {
-        let vector_path = idx_dir.join("vectors.db");
-        let vector_store = VectorStore::open(&vector_path, stored_dim)
-            .context("failed to open vector store for deletion")?;
-        let bm25_dir = idx_dir.join("bm25");
-        let bm25_index =
-            Bm25Index::open(&bm25_dir).context("failed to open BM25 index for deletion")?;
-
-        for file_path in &deleted {
-            remove_file_from_index(&metadata_store, &vector_store, &bm25_index, file_path)?;
-        }
-    }
-
-    // ── 5. Process modifications and additions ───────────────────
-    let files_to_index: Vec<(String, String, String)> =
-        modified.iter().chain(added.iter()).cloned().collect();
-    let mut file_states = Vec::new();
+    // ── 4. Prepare modifications and additions ───────────────────
+    let files_to_index: Vec<(String, String, String, bool)> = modified
+        .iter()
+        .cloned()
+        .map(|(path, content, hash)| (path, content, hash, true))
+        .chain(
+            added
+                .iter()
+                .cloned()
+                .map(|(path, content, hash)| (path, content, hash, false)),
+        )
+        .collect();
+    let mut prepared_files = Vec::new();
     let mut parse_errors = Vec::new();
 
     if !files_to_index.is_empty() {
-        // References and type relations are re-inserted during parsing, so
-        // clear the previous rows for modified files first.
-        for (file_path, _, _) in &modified {
-            remove_file_parse_data(&metadata_store, file_path)?;
-        }
-
         // Parse and chunk new/modified files.
-        let mut all_chunks = Vec::new();
-        for (rel_path, content, _hash) in &files_to_index {
+        for (rel_path, content, hash, is_modified) in &files_to_index {
             let language = detect_language_for_path(rel_path);
 
             // For RST, refs come from raw source; chunks from preprocessed.
@@ -430,20 +436,7 @@ where
                 chunk_file_for_update(content, rel_path, language, config, None, &mut parse_errors)
             };
 
-            file_states.push(file_state);
-
-            if !refs.is_empty() {
-                metadata_store
-                    .insert_references(rel_path, &refs)
-                    .context("failed to store references")?;
-            }
-
             let type_relations = parsing::type_relations::extract_type_relations(&chunks);
-            if !type_relations.is_empty() {
-                metadata_store
-                    .insert_type_relations(rel_path, &type_relations)
-                    .context("failed to store type relations")?;
-            }
 
             debug!(
                 file = %rel_path,
@@ -452,99 +445,35 @@ where
                 type_relations = type_relations.len(),
                 "parsed file"
             );
-            all_chunks.extend(chunks);
+
+            if file_state.status == FileIndexStatus::Indexed {
+                prepared_files.push(PreparedFile {
+                    path: rel_path.clone(),
+                    hash: hash.clone(),
+                    modified: *is_modified,
+                    chunks,
+                    references: refs,
+                    type_relations,
+                    state: file_state,
+                });
+            }
         }
+    }
+
+    let all_chunks: Vec<_> = prepared_files
+        .iter()
+        .flat_map(|file| file.chunks.iter().cloned())
+        .collect();
+    let file_states: Vec<_> = prepared_files
+        .iter()
+        .map(|file| file.state.clone())
+        .collect();
+
+    if !files_to_index.is_empty() {
         on_progress(UpdateProgress::ParsingDone {
             file_count: files_to_index.len(),
             chunk_count: all_chunks.len(),
         });
-
-        if !all_chunks.is_empty() {
-            // Generate embeddings.
-            let (batch_size, max_concurrent_requests) = config.embedding.bounded_parallelism();
-            if batch_size != config.embedding.batch_size
-                || max_concurrent_requests != config.embedding.max_concurrent_requests
-            {
-                info!(
-                    configured_batch_size = config.embedding.batch_size,
-                    configured_concurrency = config.embedding.max_concurrent_requests,
-                    max_in_flight_inputs = config.embedding.max_in_flight_inputs,
-                    batch_size,
-                    max_concurrent_requests,
-                    "clamped update embedding parallelism to the in-flight input bound"
-                );
-            }
-            let progress_cb = |done: usize, total: usize| {
-                on_progress(UpdateProgress::EmbeddingProgress { done, total });
-            };
-            let mut embeddings = embed_chunks_concurrent_with_progress(
-                provider,
-                &all_chunks,
-                batch_size,
-                max_concurrent_requests,
-                config.indexing.max_chunk_bytes,
-                progress_cb,
-            )
-            .await
-            .context("embedding generation failed")?;
-            on_progress(UpdateProgress::EmbeddingDone {
-                count: embeddings.len(),
-            });
-
-            // Truncate if needed.
-            let final_stored_dim = super::truncate_embeddings(&mut embeddings, stored_dim);
-
-            // Replace old chunk data for modified files only after embedding
-            // succeeded, so a failure leaves the previous index entries intact.
-            if !modified.is_empty() {
-                remove_modified_chunk_data(&metadata_store, &idx_dir, stored_dim, &modified)?;
-            }
-
-            // Store metadata.
-            metadata_store
-                .insert_chunks(&all_chunks)
-                .context("failed to insert updated chunk metadata")?;
-
-            // Store vectors.
-            let vector_path = idx_dir.join("vectors.db");
-            let vector_store = VectorStore::open(&vector_path, final_stored_dim)
-                .context("failed to open vector store for insertion")?;
-
-            let batch: Vec<(&str, &[f32])> = embeddings
-                .iter()
-                .map(|(id, vec)| (id.as_str(), vec.as_slice()))
-                .collect();
-            vector_store
-                .insert_batch(&batch)
-                .context("failed to insert updated vectors")?;
-
-            // Store BM25 documents.
-            let bm25_dir = idx_dir.join("bm25");
-            let bm25_index =
-                Bm25Index::open(&bm25_dir).context("failed to open BM25 index for insertion")?;
-
-            bm25_index
-                .insert_chunks(&all_chunks)
-                .context("failed to insert updated BM25 documents")?;
-        } else {
-            if !modified.is_empty() {
-                remove_modified_chunk_data(&metadata_store, &idx_dir, stored_dim, &modified)?;
-            }
-            on_progress(UpdateProgress::EmbeddingDone { count: 0 });
-        }
-
-        if !file_states.is_empty() {
-            metadata_store
-                .insert_file_states(&file_states)
-                .context("failed to update file index states")?;
-        }
-
-        // Update file hashes for all indexed files.
-        for (rel_path, _content, hash) in &files_to_index {
-            metadata_store
-                .set_file_hash(rel_path, hash)
-                .context("failed to update file hash")?;
-        }
     } else {
         on_progress(UpdateProgress::ParsingDone {
             file_count: 0,
@@ -553,7 +482,112 @@ where
         on_progress(UpdateProgress::EmbeddingDone { count: 0 });
     }
 
-    // ── 6. Get final counts ──────────────────────────────────────
+    let mut embeddings = if all_chunks.is_empty() {
+        if !files_to_index.is_empty() {
+            on_progress(UpdateProgress::EmbeddingDone { count: 0 });
+        }
+        Vec::new()
+    } else {
+        let (batch_size, max_concurrent_requests) = config.embedding.bounded_parallelism();
+        if batch_size != config.embedding.batch_size
+            || max_concurrent_requests != config.embedding.max_concurrent_requests
+        {
+            info!(
+                configured_batch_size = config.embedding.batch_size,
+                configured_concurrency = config.embedding.max_concurrent_requests,
+                max_in_flight_inputs = config.embedding.max_in_flight_inputs,
+                batch_size,
+                max_concurrent_requests,
+                "clamped update embedding parallelism to the in-flight input bound"
+            );
+        }
+        let progress_cb = |done: usize, total: usize| {
+            on_progress(UpdateProgress::EmbeddingProgress { done, total });
+        };
+        let embeddings = embed_chunks_concurrent_with_progress(
+            provider,
+            &all_chunks,
+            batch_size,
+            max_concurrent_requests,
+            config.indexing.max_chunk_bytes,
+            progress_cb,
+        )
+        .await
+        .context("embedding generation failed")?;
+        on_progress(UpdateProgress::EmbeddingDone {
+            count: embeddings.len(),
+        });
+        embeddings
+    };
+
+    let final_stored_dim = if embeddings.is_empty() {
+        stored_dim
+    } else {
+        super::truncate_embeddings(&mut embeddings, stored_dim)
+    };
+    let successful_modified = prepared_files.iter().filter(|file| file.modified).count();
+    let successful_added = prepared_files.len() - successful_modified;
+
+    if !deleted.is_empty() || !prepared_files.is_empty() {
+        let vector_path = idx_dir.join("vectors.db");
+        let vector_store = VectorStore::open(&vector_path, final_stored_dim)
+            .context("failed to open vector store for update")?;
+        let bm25_dir = idx_dir.join("bm25");
+        let bm25_index =
+            Bm25Index::open(&bm25_dir).context("failed to open BM25 index for update")?;
+
+        // All parsing and embedding work is complete. Writes below publish the prepared update.
+        for file_path in &deleted {
+            remove_file_from_index(&metadata_store, &vector_store, &bm25_index, file_path)?;
+        }
+
+        for file in prepared_files.iter().filter(|file| file.modified) {
+            remove_file_parse_data(&metadata_store, &file.path)?;
+            remove_file_chunk_data(&metadata_store, &vector_store, &bm25_index, &file.path)?;
+        }
+
+        for file in &prepared_files {
+            if !file.references.is_empty() {
+                metadata_store
+                    .insert_references(&file.path, &file.references)
+                    .context("failed to store references")?;
+            }
+            if !file.type_relations.is_empty() {
+                metadata_store
+                    .insert_type_relations(&file.path, &file.type_relations)
+                    .context("failed to store type relations")?;
+            }
+        }
+
+        if !all_chunks.is_empty() {
+            metadata_store
+                .insert_chunks(&all_chunks)
+                .context("failed to insert updated chunk metadata")?;
+            let batch: Vec<(&str, &[f32])> = embeddings
+                .iter()
+                .map(|(id, vector)| (id.as_str(), vector.as_slice()))
+                .collect();
+            vector_store
+                .insert_batch(&batch)
+                .context("failed to insert updated vectors")?;
+            bm25_index
+                .insert_chunks(&all_chunks)
+                .context("failed to insert updated BM25 documents")?;
+        }
+
+        if !file_states.is_empty() {
+            metadata_store
+                .insert_file_states(&file_states)
+                .context("failed to update file index states")?;
+        }
+        for file in &prepared_files {
+            metadata_store
+                .set_file_hash(&file.path, &file.hash)
+                .context("failed to update file hash")?;
+        }
+    }
+
+    // ── 5. Get final counts ──────────────────────────────────────
     let total_chunks = metadata_store
         .chunk_count()
         .context("failed to count chunks")?;
@@ -562,8 +596,8 @@ where
     on_progress(UpdateProgress::StorageDone);
 
     let summary = UpdateSummary {
-        files_modified: modified.len(),
-        files_added: added.len(),
+        files_modified: successful_modified,
+        files_added: successful_added,
         files_deleted: deleted.len(),
         files_unchanged: unchanged,
         files_with_tree_sitter_errors: file_states
@@ -702,26 +736,6 @@ fn remove_file_chunk_data(
         chunks = chunks.len(),
         "removed file chunk data from index"
     );
-
-    Ok(())
-}
-
-fn remove_modified_chunk_data(
-    metadata_store: &MetadataStore,
-    idx_dir: &Path,
-    stored_dim: usize,
-    modified: &[(String, String, String)],
-) -> Result<()> {
-    let vector_path = idx_dir.join("vectors.db");
-    let vector_store = VectorStore::open(&vector_path, stored_dim)
-        .context("failed to open vector store for modification")?;
-    let bm25_dir = idx_dir.join("bm25");
-    let bm25_index =
-        Bm25Index::open(&bm25_dir).context("failed to open BM25 index for modification")?;
-
-    for (file_path, _, _) in modified {
-        remove_file_chunk_data(metadata_store, &vector_store, &bm25_index, file_path)?;
-    }
 
     Ok(())
 }

--- a/crates/vera-core/src/indexing/update_tests.rs
+++ b/crates/vera-core/src/indexing/update_tests.rs
@@ -2,6 +2,7 @@
 
 use std::fs;
 use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Duration;
 
 use tempfile::TempDir;
 
@@ -50,21 +51,37 @@ async fn indexed_repo(
 
 struct BatchBoundProvider {
     max_batch_size: usize,
-    largest_batch: AtomicUsize,
+    active_inputs: AtomicUsize,
+    peak_inputs: AtomicUsize,
+}
+
+struct FailingProvider;
+
+impl EmbeddingProvider for FailingProvider {
+    async fn embed_batch(&self, _texts: &[String]) -> Result<Vec<Vec<f32>>, EmbeddingError> {
+        Err(EmbeddingError::ApiError {
+            status: 503,
+            message: "provider unavailable".to_string(),
+        })
+    }
+
+    fn expected_dim(&self) -> Option<usize> {
+        Some(8)
+    }
 }
 
 impl BatchBoundProvider {
     fn new(max_batch_size: usize) -> Self {
         Self {
             max_batch_size,
-            largest_batch: AtomicUsize::new(0),
+            active_inputs: AtomicUsize::new(0),
+            peak_inputs: AtomicUsize::new(0),
         }
     }
 }
 
 impl EmbeddingProvider for BatchBoundProvider {
     async fn embed_batch(&self, texts: &[String]) -> Result<Vec<Vec<f32>>, EmbeddingError> {
-        self.largest_batch.fetch_max(texts.len(), Ordering::SeqCst);
         if texts.len() > self.max_batch_size {
             return Err(EmbeddingError::ApiError {
                 status: 400,
@@ -76,11 +93,20 @@ impl EmbeddingProvider for BatchBoundProvider {
             });
         }
 
+        let active = self.active_inputs.fetch_add(texts.len(), Ordering::SeqCst) + texts.len();
+        self.peak_inputs.fetch_max(active, Ordering::SeqCst);
+        tokio::time::sleep(Duration::from_millis(25)).await;
+        self.active_inputs.fetch_sub(texts.len(), Ordering::SeqCst);
+
         Ok(vec![vec![0.0; 8]; texts.len()])
     }
 
     fn expected_dim(&self) -> Option<usize> {
         Some(8)
+    }
+
+    fn max_batch_size(&self) -> Option<usize> {
+        Some(self.max_batch_size)
     }
 }
 
@@ -143,15 +169,17 @@ async fn update_reports_progress_and_respects_max_in_flight_input_bound() {
         .await
         .unwrap();
 
-    for name in ["one.rs", "two.rs", "three.rs"] {
+    for name in [
+        "one.rs", "two.rs", "three.rs", "four.rs", "five.rs", "six.rs",
+    ] {
         fs::write(dir.path().join(name), format!("fn {}() {{}}\n", &name[..3])).unwrap();
     }
 
     let provider = BatchBoundProvider::new(2);
     let mut config = default_config();
-    config.embedding.batch_size = 128;
+    config.embedding.batch_size = 2;
     config.embedding.max_concurrent_requests = 8;
-    config.embedding.max_in_flight_inputs = 2;
+    config.embedding.max_in_flight_inputs = 4;
 
     let events = std::sync::Mutex::new(Vec::new());
     let summary =
@@ -161,9 +189,11 @@ async fn update_reports_progress_and_respects_max_in_flight_input_bound() {
         .await
         .unwrap();
 
-    assert_eq!(summary.files_added, 3);
+    assert_eq!(summary.files_added, 6);
     assert_eq!(summary.files_deferred, 0);
-    assert_eq!(provider.largest_batch.load(Ordering::SeqCst), 2);
+    let peak_inputs = provider.peak_inputs.load(Ordering::SeqCst);
+    assert!(peak_inputs > 2);
+    assert!(peak_inputs <= 4);
 
     let events = events.into_inner().unwrap();
     assert!(matches!(
@@ -173,20 +203,96 @@ async fn update_reports_progress_and_respects_max_in_flight_input_bound() {
     assert!(
         events
             .iter()
-            .any(|event| matches!(event, UpdateProgress::ClassificationDone { added: 3, .. }))
+            .any(|event| matches!(event, UpdateProgress::ClassificationDone { added: 6, .. }))
     );
     assert!(events.iter().any(|event| matches!(
         event,
         UpdateProgress::ParsingDone {
-            file_count: 3,
+            file_count: 6,
             chunk_count
-        } if *chunk_count >= 3
+        } if *chunk_count >= 6
     )));
     assert!(events.iter().any(|event| matches!(
         event,
-        UpdateProgress::EmbeddingProgress { done, total } if done == total && *total >= 3
+        UpdateProgress::EmbeddingProgress { done, total } if done == total && *total >= 6
     )));
     assert!(matches!(events.last(), Some(UpdateProgress::StorageDone)));
+}
+
+#[tokio::test]
+async fn update_keeps_indexed_data_when_a_discovered_file_cannot_be_read() {
+    let (dir, provider, config, _) =
+        indexed_repo(&[("main.rs", "fn preserved_symbol() -> u32 { 42 }\n")]).await;
+    let idx = index_dir(&dir.path().canonicalize().unwrap());
+    let metadata = MetadataStore::open(&idx.join("metadata.db")).unwrap();
+    let hash_before = metadata.get_file_hash("main.rs").unwrap();
+    let chunks_before: Vec<_> = metadata
+        .get_chunks_by_file("main.rs")
+        .unwrap()
+        .into_iter()
+        .map(|chunk| (chunk.id, chunk.content))
+        .collect();
+    let vectors_before = VectorStore::open(&idx.join("vectors.db"), 8)
+        .unwrap()
+        .count()
+        .unwrap();
+    let bm25 = Bm25Index::open(&idx.join("bm25")).unwrap();
+    assert!(!bm25.search("preserved_symbol", 10).unwrap().is_empty());
+
+    let source = dir.path().join("main.rs");
+    let replaced = std::sync::atomic::AtomicBool::new(false);
+    update_repository_with_progress(dir.path(), &provider, &config, "mock-model", |event| {
+        if matches!(event, UpdateProgress::DiscoveryDone { .. })
+            && !replaced.swap(true, Ordering::SeqCst)
+        {
+            fs::remove_file(&source).unwrap();
+            fs::create_dir(&source).unwrap();
+        }
+    })
+    .await
+    .unwrap();
+
+    assert_eq!(metadata.get_file_hash("main.rs").unwrap(), hash_before);
+    let chunks_after: Vec<_> = metadata
+        .get_chunks_by_file("main.rs")
+        .unwrap()
+        .into_iter()
+        .map(|chunk| (chunk.id, chunk.content))
+        .collect();
+    assert_eq!(chunks_after, chunks_before);
+    assert_eq!(
+        VectorStore::open(&idx.join("vectors.db"), 8)
+            .unwrap()
+            .count()
+            .unwrap(),
+        vectors_before
+    );
+    assert!(!bm25.search("preserved_symbol", 10).unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn update_embedding_failure_preserves_existing_parse_data() {
+    let (dir, _provider, config, _) = indexed_repo(&[(
+        "types.ts",
+        "class Loader {}\nclass CachedLoader extends Loader {}\n",
+    )])
+    .await;
+    let idx = index_dir(&dir.path().canonicalize().unwrap());
+    let metadata = MetadataStore::open(&idx.join("metadata.db")).unwrap();
+    assert_eq!(metadata.find_type_relations("Loader").unwrap().len(), 1);
+
+    fs::write(
+        dir.path().join("types.ts"),
+        "class Saver {}\nclass CachedSaver extends Saver {}\n",
+    )
+    .unwrap();
+
+    let error = update_repository(dir.path(), &FailingProvider, &config, "mock-model")
+        .await
+        .unwrap_err();
+    assert!(error.to_string().contains("embedding generation failed"));
+    assert_eq!(metadata.find_type_relations("Loader").unwrap().len(), 1);
+    assert!(metadata.find_type_relations("Saver").unwrap().is_empty());
 }
 
 #[tokio::test]

--- a/crates/vera-core/src/retrieval/hybrid.rs
+++ b/crates/vera-core/src/retrieval/hybrid.rs
@@ -344,7 +344,16 @@ pub(crate) async fn search_hybrid_reranked_with_augmentation(
                 reranked = reranked.len(),
                 "reranking complete"
             );
-            reranked.extend(hybrid_results.into_iter().skip(rerank_limit));
+            let mut score_ceiling = reranked.last().map(|result| result.score);
+            for mut result in hybrid_results.into_iter().skip(rerank_limit) {
+                // RRF and reranker scores have different scales. Keep the untouched tail below
+                // the reranked prefix so the public score order still matches the result order.
+                if let Some(ceiling) = score_ceiling {
+                    result.score = result.score.min(ceiling);
+                }
+                score_ceiling = Some(result.score);
+                reranked.push(result);
+            }
             reranked.truncate(fetch_limit);
             Ok((reranked, timings))
         }

--- a/crates/vera-core/src/retrieval/hybrid_tests.rs
+++ b/crates/vera-core/src/retrieval/hybrid_tests.rs
@@ -1,5 +1,25 @@
 use super::*;
+use crate::retrieval::reranker::{RerankScore, Reranker, RerankerError};
 use crate::types::{Language, SymbolType};
+
+struct NegativeReranker;
+
+impl Reranker for NegativeReranker {
+    async fn rerank(
+        &self,
+        _query: &str,
+        documents: &[String],
+    ) -> Result<Vec<RerankScore>, RerankerError> {
+        Ok(documents
+            .iter()
+            .enumerate()
+            .map(|(index, _)| RerankScore {
+                index,
+                relevance_score: -1.0 - index as f64,
+            })
+            .collect())
+    }
+}
 
 /// Helper to create a SearchResult with given parameters.
 fn make_result(
@@ -474,6 +494,39 @@ async fn search_hybrid_reranked_returns_reranked_results() {
             results[i].score,
         );
     }
+}
+
+#[tokio::test]
+async fn reranked_tail_scores_remain_descending_across_score_domains() {
+    use crate::embedding::test_helpers::MockProvider;
+
+    let tmp = tempfile::tempdir().unwrap();
+    let (index_dir, dim) = setup_test_index(tmp.path()).await;
+    let provider = MockProvider::new(dim);
+
+    let (results, _) = search_hybrid_reranked(
+        &index_dir,
+        &provider,
+        &NegativeReranker,
+        "function",
+        "function",
+        &SearchFilters::default(),
+        10,
+        1,
+        60.0,
+        dim,
+        1,
+        50,
+    )
+    .await
+    .unwrap();
+
+    assert!(results.len() > 1);
+    assert!(
+        results
+            .windows(2)
+            .all(|pair| pair[0].score >= pair[1].score)
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION

---

This follow-up fixes the review findings from #29 that still reproduce on current `master`.

Review the cancellation boundary closely. The public token keeps its clone-shared, permanent signal but now wraps Tokio's cancellation token instead of an atomic flag. One token covers the full indexing run. Cancelling it drops active provider futures, stops batch splitting and retries, and blocks artifact publication after the final progress callback. Embedding capacity still comes from `bounded_parallelism`; the configured batch size, request concurrency, and maximum in-flight inputs do not change.

The incremental update publication boundary also changed. Reads, parsing, and embedding now finish before stored data changes. A file found during discovery is not treated as deleted if a later read fails. Failed preparation keeps the prior hash, chunks, vectors, BM25 entries, references, and type relations. The write phase stays synchronous and uses the existing per-store replacement operations. This PR does not add a cross-store transaction.

The remaining fixes are independent:

- Authentication, rate-limit, and other HTTP error classes survive truncated response bodies. A body timeout remains a timeout because retrying it could duplicate upstream work.
- Hybrid results keep descending scores when an unreranked RRF tail follows a reranked prefix.
- CLI cancellation gives an already-ready operation result priority over an already-ready signal.

Current `master` does not contain the reported detached signal task. `cancel_on_signal` polls both futures inline and does not spawn a listener.

Validation:

- `cargo test -q -p vera-core -p vera-cli`
- `cargo fmt --all -- --check`
- `cargo clippy -p vera-core -p vera-cli --all-targets -- -D warnings`
- `git diff --check`

Clippy needed allowances for two unrelated warnings already present before this branch.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/VeraTools/codesmith/Vera/pr/60"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789743688&installation_model_id=432833&pr_number=60&repository=VeraTools%2FVera&return_to=https%3A%2F%2Fgithub.com%2FVeraTools%2FVera%2Fpull%2F60&signature=c9f3869936ff8bc7f427544fe2c22d34f9904d04c34373036a584a9fdb80987b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes indexing regressions by making cancellation cooperative across the pipeline and publishing updates only after parsing and embedding succeed. Provider errors now take precedence over simultaneous cancellation, and progress events stop once cancelled.

- Cancellation: replace the atomic flag with a Tokio cancellation token shared across the run. Cancelling drops in-flight provider futures, stops batch splitting/retries, and blocks publication after embedding. A completed provider error wins over a simultaneous cancel signal (CLI select is biased the same way). Progress callbacks are suppressed after cancellation. Embedding parallelism still derives from bounded_parallelism; configured batch size and concurrency are unchanged.
- Incremental publication: parse/chunk/extract relations, then embed; only on success replace chunks, vectors, BM25 docs, references, type relations, and file hashes/states. A discovered file that later fails to read is no longer treated as deleted. On provider/read failure the prior index data remains. Summary counts report only successfully published files.
- HTTP errors: truncated bodies still classify as auth (401/403) or rate limit (429); body timeouts remain timeouts to avoid duplicating upstream work.
- Hybrid retrieval: keep descending scores when appending the unreranked RRF tail after a reranked prefix.

**Review notes**
- Validate cancellation through embedding (error precedence and no post-cancel progress) and that no artifacts publish after cancellation or failed embedding. No config or public API changes expected. Tests cover in-flight cancellation, boundary after embedding, preservation on read/embedding failures, error classification with truncated bodies, and score monotonicity.

<sup>Written for commit 47afeaae3af61db04eb96b0a9c831b460d4575f9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/VeraTools/Vera/pull/60?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Cancelling an indexing operation now reliably stops in-progress embedding and prevents incomplete index artifacts from being published.
  - Failed or unreadable file updates now preserve existing indexed data.
  - Authentication, rate-limit, and timeout errors are reported more accurately when provider responses are incomplete.
  - Hybrid search results now maintain consistent descending score order when reranking only part of the results.
- **Reliability**
  - Incremental indexing counts and stored file state now reflect only successfully processed files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->