### PR TITLE
fix(upgrade): verify the version changed, not that it equals the release tag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4028,6 +4028,7 @@ dependencies = [
  "console 0.16.4",
  "dirs",
  "reqwest",
+ "semver",
  "serde",
  "serde_json",
  "tempfile",

--- a/crates/vera-cli/Cargo.toml
+++ b/crates/vera-cli/Cargo.toml
@@ -17,6 +17,7 @@ vera-serve = { workspace = true }
 clap = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+semver = "1"
 tokio = { workspace = true }
 anyhow = { workspace = true }
 reqwest = { workspace = true }

--- a/crates/vera-cli/src/commands/upgrade.rs
+++ b/crates/vera-cli/src/commands/upgrade.rs
@@ -56,12 +56,22 @@ pub fn run(apply: bool, json_output: bool) -> Result<()> {
         .install_method
         .as_deref()
         .expect("apply requires a resolved install method");
+
+    // Read what the installer recorded *before* running it. The no-op is
+    // "the installer resolved the same version again", so the comparison has to
+    // be against the installer's own previous record. Comparing against the
+    // running binary's version instead would misread a stale or foreign
+    // provenance record as a successful upgrade.
+    let baseline_version = state::load_install_provenance()
+        .ok()
+        .and_then(|provenance| provenance.version);
+
     update_check::apply_update(method)?;
 
     // The installer command exiting 0 does not mean the new version landed. A
     // package registry can lag behind a GitHub release, in which case the
     // installer resolves the version already installed and the upgrade
-    // silently no-ops. Check whether the installed version actually changed
+    // silently no-ops. Check whether the recorded version actually changed
     // rather than reporting success on the exit code alone.
     report.installed_version = state::load_install_provenance()
         .ok()
@@ -69,7 +79,7 @@ pub fn run(apply: bool, json_output: bool) -> Result<()> {
 
     match verification_outcome(
         method,
-        &report.current_version,
+        baseline_version.as_deref(),
         report.latest_version.as_deref(),
         report.installed_version.as_deref(),
     ) {
@@ -97,22 +107,30 @@ pub fn run(apply: bool, json_output: bool) -> Result<()> {
 /// installer keeps resolving the version already installed, every installer
 /// command exits 0, and the upgrade silently no-ops.
 ///
-/// The test is whether the installed version *changed*, not whether it equals
-/// the advertised one. The installer resolves from the package registry while
-/// `latest` comes from the GitHub release, and the two can legitimately differ:
-/// a registry that is ahead of the release, or one that resolves an
-/// intermediate version, still performed a real upgrade. Comparing against
-/// `latest` reports those as failures and points the user at an older build.
+/// The test is whether the installer's own record *changed*, comparing the
+/// provenance written before the install against the one written after.
+///
+/// Not against `latest`: that comes from the GitHub release while the installer
+/// resolves from a package registry, and the two can legitimately differ. A
+/// registry ahead of the release, or one resolving an intermediate version,
+/// still performed a real upgrade, and comparing against `latest` would report
+/// those as failures and point the user at an older build.
+///
+/// Not against the running binary's version either: provenance can be stale or
+/// belong to another installation, so a no-op could leave it differing from the
+/// running version and read as success.
+///
+/// `latest` is used only to word the hint.
 fn applied_version_mismatch(
     method: &str,
-    current: &str,
+    baseline: &str,
     latest: Option<&str>,
     installed: &str,
 ) -> Option<String> {
-    if installed != current {
+    if installed != baseline {
         return None;
     }
-    let target = latest.unwrap_or("the new version");
+    let target = latest.unwrap_or("new version");
     Some(format!(
         "upgrade did not take effect: still on {installed}.\n\
          This usually means the {method} package for {target} has not been published yet, so the \
@@ -129,95 +147,21 @@ enum VerificationOutcome {
     Unknown,
 }
 
+/// Without a provenance record from either side of the install there is nothing
+/// to compare, so the outcome is [`VerificationOutcome::Unknown`] rather than an
+/// assumed success.
 fn verification_outcome(
     method: &str,
-    current: &str,
+    baseline: Option<&str>,
     latest: Option<&str>,
     installed: Option<&str>,
 ) -> VerificationOutcome {
-    let Some(installed) = installed else {
+    let (Some(baseline), Some(installed)) = (baseline, installed) else {
         return VerificationOutcome::Unknown;
     };
-    match applied_version_mismatch(method, current, latest, installed) {
+    match applied_version_mismatch(method, baseline, latest, installed) {
         Some(message) => VerificationOutcome::Mismatch(message),
         None => VerificationOutcome::Confirmed,
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::{VerificationOutcome, applied_version_mismatch, verification_outcome};
-
-    #[test]
-    fn reports_nothing_when_the_version_changed() {
-        assert!(applied_version_mismatch("bun", "0.12.13", Some("1.0.0"), "1.0.0").is_none());
-    }
-
-    #[test]
-    fn reports_the_no_op_with_the_version_and_the_install_method() {
-        let message = applied_version_mismatch("bun", "0.12.13", Some("1.0.0"), "0.12.13")
-            .expect("a stale registry must be reported, not treated as success");
-        assert!(message.contains("0.12.13"), "{message}");
-        assert!(message.contains("1.0.0"), "{message}");
-        assert!(message.contains("bun"), "{message}");
-    }
-
-    /// The installer resolves from the package registry, `latest` comes from
-    /// the GitHub release, and the two can legitimately disagree. A registry
-    /// that is ahead of the release still performed a real upgrade, so it must
-    /// not be reported as a failure telling the user to install the older
-    /// GitHub build.
-    #[test]
-    fn accepts_a_version_the_registry_resolved_ahead_of_the_release() {
-        assert!(
-            applied_version_mismatch("bun", "1.0.0", Some("1.0.1"), "1.0.2").is_none(),
-            "a registry ahead of the GitHub release is still a real upgrade"
-        );
-        assert_eq!(
-            verification_outcome("bun", "1.0.0", Some("1.0.1"), Some("1.0.2")),
-            VerificationOutcome::Confirmed
-        );
-    }
-
-    /// An intermediate version is also a real upgrade.
-    #[test]
-    fn accepts_an_intermediate_version_between_current_and_latest() {
-        assert_eq!(
-            verification_outcome("pip", "1.0.0", Some("1.2.0"), Some("1.1.0")),
-            VerificationOutcome::Confirmed
-        );
-    }
-
-    #[test]
-    fn detects_the_no_op_even_when_the_release_version_is_unknown() {
-        assert!(
-            applied_version_mismatch("bun", "0.12.13", None, "0.12.13").is_some(),
-            "the no-op is detectable without knowing the advertised version"
-        );
-    }
-
-    #[test]
-    fn confirms_when_the_installed_version_moved_off_the_current_one() {
-        assert_eq!(
-            verification_outcome("bun", "0.12.13", Some("1.0.0"), Some("1.0.0")),
-            VerificationOutcome::Confirmed
-        );
-    }
-
-    #[test]
-    fn keeps_a_no_op_upgrade_unapplied() {
-        assert!(matches!(
-            verification_outcome("bun", "0.12.13", Some("1.0.0"), Some("0.12.13")),
-            VerificationOutcome::Mismatch(_)
-        ));
-    }
-
-    #[test]
-    fn keeps_unknown_versions_unapplied() {
-        assert_eq!(
-            verification_outcome("bun", "0.12.13", Some("1.0.0"), None),
-            VerificationOutcome::Unknown
-        );
     }
 }
 
@@ -312,5 +256,95 @@ fn install_method_source_name(source: InstallMethodSource) -> &'static str {
         InstallMethodSource::Heuristic => "heuristic",
         InstallMethodSource::Ambiguous => "ambiguous",
         InstallMethodSource::Unknown => "unknown",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{VerificationOutcome, applied_version_mismatch, verification_outcome};
+
+    #[test]
+    fn reports_nothing_when_the_recorded_version_changed() {
+        assert!(applied_version_mismatch("bun", "0.12.13", Some("1.0.0"), "1.0.0").is_none());
+    }
+
+    #[test]
+    fn reports_the_no_op_with_the_version_and_the_install_method() {
+        let message = applied_version_mismatch("bun", "0.12.13", Some("1.0.0"), "0.12.13")
+            .expect("a stale registry must be reported, not treated as success");
+        assert!(message.contains("0.12.13"), "{message}");
+        assert!(message.contains("1.0.0"), "{message}");
+        assert!(message.contains("bun"), "{message}");
+    }
+
+    /// The installer resolves from the package registry, `latest` comes from
+    /// the GitHub release, and the two can legitimately disagree. A registry
+    /// ahead of the release still performed a real upgrade, so it must not be
+    /// reported as a failure telling the user to install the older build.
+    #[test]
+    fn accepts_a_version_the_registry_resolved_ahead_of_the_release() {
+        assert!(
+            applied_version_mismatch("bun", "1.0.0", Some("1.0.1"), "1.0.2").is_none(),
+            "a registry ahead of the GitHub release is still a real upgrade"
+        );
+        assert_eq!(
+            verification_outcome("bun", Some("1.0.0"), Some("1.0.1"), Some("1.0.2")),
+            VerificationOutcome::Confirmed
+        );
+    }
+
+    /// An intermediate version is also a real upgrade.
+    #[test]
+    fn accepts_an_intermediate_version_between_baseline_and_latest() {
+        assert_eq!(
+            verification_outcome("pip", Some("1.0.0"), Some("1.2.0"), Some("1.1.0")),
+            VerificationOutcome::Confirmed
+        );
+    }
+
+    /// The baseline is the installer's own previous record, not the running
+    /// binary. A stale or foreign provenance record that happens to differ from
+    /// the running version must not be read as a successful upgrade.
+    #[test]
+    fn detects_the_no_op_when_provenance_disagrees_with_the_running_binary() {
+        assert!(matches!(
+            verification_outcome("bun", Some("0.11.0"), Some("1.0.0"), Some("0.11.0")),
+            VerificationOutcome::Mismatch(_)
+        ));
+    }
+
+    /// `latest` only words the hint, so an unknown release must still produce
+    /// readable prose rather than "the the new version".
+    #[test]
+    fn renders_a_readable_hint_when_the_release_version_is_unknown() {
+        let message = applied_version_mismatch("bun", "0.12.13", None, "0.12.13")
+            .expect("the no-op is detectable without knowing the advertised version");
+        assert!(!message.contains("the the"), "{message}");
+        assert!(
+            message.contains("install the new version binary"),
+            "{message}"
+        );
+    }
+
+    #[test]
+    fn keeps_a_no_op_upgrade_unapplied() {
+        assert!(matches!(
+            verification_outcome("bun", Some("0.12.13"), Some("1.0.0"), Some("0.12.13")),
+            VerificationOutcome::Mismatch(_)
+        ));
+    }
+
+    /// Without a record from either side of the install there is nothing to
+    /// compare, so neither success nor failure may be assumed.
+    #[test]
+    fn keeps_unverifiable_upgrades_unapplied() {
+        assert_eq!(
+            verification_outcome("bun", Some("0.12.13"), Some("1.0.0"), None),
+            VerificationOutcome::Unknown
+        );
+        assert_eq!(
+            verification_outcome("bun", None, Some("1.0.0"), Some("1.0.0")),
+            VerificationOutcome::Unknown
+        );
     }
 }

--- a/crates/vera-cli/src/commands/upgrade.rs
+++ b/crates/vera-cli/src/commands/upgrade.rs
@@ -1,6 +1,10 @@
 //! `vera upgrade` — inspect or apply the binary update plan.
 
+use std::cmp::Ordering;
+use std::path::Path;
+
 use anyhow::{Result, bail};
+use semver::Version;
 use serde::Serialize;
 
 use crate::state;
@@ -59,12 +63,17 @@ pub fn run(apply: bool, json_output: bool) -> Result<()> {
 
     // Read what the installer recorded *before* running it. The no-op is
     // "the installer resolved the same version again", so the comparison has to
-    // be against the installer's own previous record. Comparing against the
-    // running binary's version instead would misread a stale or foreign
-    // provenance record as a successful upgrade.
-    let baseline_version = state::load_install_provenance()
-        .ok()
-        .and_then(|provenance| provenance.version);
+    // be against the installer's own previous record. Only trust that record as
+    // a baseline when it identifies the binary that is currently running;
+    // otherwise a stale or foreign record could make an unchanged binary look
+    // upgraded when the wrapper rewrites install.json.
+    let baseline_provenance = state::load_install_provenance().ok();
+    let current_executable = std::env::current_exe().ok();
+    let baseline_version = verified_baseline_version(
+        baseline_provenance.as_ref(),
+        &report.current_version,
+        current_executable.as_deref(),
+    );
 
     update_check::apply_update(method)?;
 
@@ -79,7 +88,7 @@ pub fn run(apply: bool, json_output: bool) -> Result<()> {
 
     match verification_outcome(
         method,
-        baseline_version.as_deref(),
+        baseline_version,
         report.latest_version.as_deref(),
         report.installed_version.as_deref(),
     ) {
@@ -89,7 +98,7 @@ pub fn run(apply: bool, json_output: bool) -> Result<()> {
             bail!(message);
         }
         VerificationOutcome::Unknown => {
-            let message = "could not confirm the upgrade applied because the installed version is unavailable";
+            let message = "could not confirm the upgrade because install provenance is missing or does not identify the running binary";
             if !json_output {
                 eprintln!("Warning: {message}.");
             }
@@ -99,6 +108,38 @@ pub fn run(apply: bool, json_output: bool) -> Result<()> {
     }
 
     print_report(&report, json_output)
+}
+
+fn verified_baseline_version<'a>(
+    provenance: Option<&'a state::InstallProvenance>,
+    current_version: &str,
+    current_executable: Option<&Path>,
+) -> Option<&'a str> {
+    let provenance = provenance?;
+    let version = provenance.version.as_deref()?;
+    if !same_version(version, current_version) {
+        return None;
+    }
+
+    let current_executable = current_executable?.canonicalize().ok()?;
+    let recorded_executable = Path::new(provenance.binary_path.as_deref()?)
+        .canonicalize()
+        .ok()?;
+    (recorded_executable == current_executable).then_some(version)
+}
+
+fn normalize_version(version: &str) -> &str {
+    version.strip_prefix('v').unwrap_or(version)
+}
+
+fn same_version(left: &str, right: &str) -> bool {
+    normalize_version(left) == normalize_version(right)
+}
+
+fn version_order(baseline: &str, installed: &str) -> Option<Ordering> {
+    let baseline = Version::parse(normalize_version(baseline)).ok()?;
+    let installed = Version::parse(normalize_version(installed)).ok()?;
+    Some(installed.cmp(&baseline))
 }
 
 /// Describe why an applied upgrade did not take effect, or `None` when it did.
@@ -127,7 +168,7 @@ fn applied_version_mismatch(
     latest: Option<&str>,
     installed: &str,
 ) -> Option<String> {
-    if installed != baseline {
+    if !same_version(installed, baseline) {
         return None;
     }
     let target = latest.unwrap_or("new version");
@@ -138,6 +179,21 @@ fn applied_version_mismatch(
          Hint: retry later, or install the {target} binary from \
          https://github.com/VeraTools/Vera/releases"
     ))
+}
+
+fn applied_version_downgrade(
+    method: &str,
+    baseline: &str,
+    latest: Option<&str>,
+    installed: &str,
+) -> String {
+    let target = latest.unwrap_or("new version");
+    format!(
+        "upgrade resolved older version {installed} than the current {baseline}.\n\
+         This usually means the {method} package for {target} resolved to an older release.\n\
+         Hint: retry later, or install the {target} binary from \
+         https://github.com/VeraTools/Vera/releases"
+    )
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -159,9 +215,15 @@ fn verification_outcome(
     let (Some(baseline), Some(installed)) = (baseline, installed) else {
         return VerificationOutcome::Unknown;
     };
-    match applied_version_mismatch(method, baseline, latest, installed) {
-        Some(message) => VerificationOutcome::Mismatch(message),
-        None => VerificationOutcome::Confirmed,
+    if let Some(message) = applied_version_mismatch(method, baseline, latest, installed) {
+        return VerificationOutcome::Mismatch(message);
+    }
+    match version_order(baseline, installed) {
+        Some(Ordering::Less) => VerificationOutcome::Mismatch(applied_version_downgrade(
+            method, baseline, latest, installed,
+        )),
+        Some(Ordering::Equal | Ordering::Greater) => VerificationOutcome::Confirmed,
+        None => VerificationOutcome::Unknown,
     }
 }
 
@@ -261,7 +323,11 @@ fn install_method_source_name(source: InstallMethodSource) -> &'static str {
 
 #[cfg(test)]
 mod tests {
-    use super::{VerificationOutcome, applied_version_mismatch, verification_outcome};
+    use super::{
+        VerificationOutcome, applied_version_mismatch, same_version, verification_outcome,
+        verified_baseline_version,
+    };
+    use crate::state::InstallProvenance;
 
     #[test]
     fn reports_nothing_when_the_recorded_version_changed() {
@@ -302,15 +368,88 @@ mod tests {
         );
     }
 
-    /// The baseline is the installer's own previous record, not the running
-    /// binary. A stale or foreign provenance record that happens to differ from
-    /// the running version must not be read as a successful upgrade.
+    /// A provenance record only qualifies as the baseline when it identifies
+    /// the running binary: same version (v-prefix tolerant) and same binary
+    /// path. Stale, foreign, or missing records make the upgrade unverifiable
+    /// instead of letting a rewritten record pose as a successful upgrade.
     #[test]
-    fn detects_the_no_op_when_provenance_disagrees_with_the_running_binary() {
-        assert!(matches!(
-            verification_outcome("bun", Some("0.11.0"), Some("1.0.0"), Some("0.11.0")),
-            VerificationOutcome::Mismatch(_)
-        ));
+    fn baseline_requires_provenance_identifying_the_running_binary() {
+        let exe = std::env::current_exe().unwrap();
+        let matching = InstallProvenance {
+            version: Some("1.0.0".to_string()),
+            binary_path: Some(exe.to_string_lossy().to_string()),
+            ..Default::default()
+        };
+        assert_eq!(
+            verified_baseline_version(Some(&matching), "1.0.0", Some(exe.as_path())),
+            Some("1.0.0")
+        );
+
+        // Stale record: the recorded version is not the running version.
+        assert_eq!(
+            verified_baseline_version(Some(&matching), "1.0.1", Some(exe.as_path())),
+            None
+        );
+
+        // Foreign record: same version, but recorded for another binary.
+        let foreign = InstallProvenance {
+            binary_path: Some("/dev/null".to_string()),
+            ..matching.clone()
+        };
+        assert_eq!(
+            verified_baseline_version(Some(&foreign), "1.0.0", Some(exe.as_path())),
+            None
+        );
+
+        // No record, or a record without the fields needed to verify.
+        assert_eq!(
+            verified_baseline_version(None, "1.0.0", Some(exe.as_path())),
+            None
+        );
+        let incomplete = InstallProvenance {
+            version: Some("1.0.0".to_string()),
+            ..Default::default()
+        };
+        assert_eq!(
+            verified_baseline_version(Some(&incomplete), "1.0.0", Some(exe.as_path())),
+            None
+        );
+    }
+
+    #[test]
+    fn version_comparison_ignores_a_v_prefix() {
+        assert!(same_version("v1.0.0", "1.0.0"));
+        assert!(!same_version("v1.0.0", "1.0.1"));
+    }
+
+    /// A registry resolving an older version than the baseline (yank,
+    /// rollback, channel mismatch) is a failed upgrade, not a success.
+    #[test]
+    fn flags_a_downgrade_as_a_failed_upgrade() {
+        let outcome = verification_outcome("bun", Some("1.2.0"), Some("1.3.0"), Some("1.1.0"));
+        match outcome {
+            VerificationOutcome::Mismatch(message) => {
+                assert!(message.contains("older version"), "{message}");
+                assert!(message.contains("1.1.0"), "{message}");
+                assert!(message.contains("bun"), "{message}");
+            }
+            other => panic!("a downgrade must not be reported as success: {other:?}"),
+        }
+    }
+
+    /// Versions that cannot be parsed change the record but cannot be ordered,
+    /// so the outcome is unverifiable rather than assumed success.
+    #[test]
+    fn unparseable_version_change_is_unverifiable() {
+        assert_eq!(
+            verification_outcome(
+                "bun",
+                Some("nightly-abc"),
+                Some("1.0.0"),
+                Some("nightly-def")
+            ),
+            VerificationOutcome::Unknown
+        );
     }
 
     /// `latest` only words the hint, so an unknown release must still produce

--- a/crates/vera-cli/src/commands/upgrade.rs
+++ b/crates/vera-cli/src/commands/upgrade.rs
@@ -61,14 +61,15 @@ pub fn run(apply: bool, json_output: bool) -> Result<()> {
     // The installer command exiting 0 does not mean the new version landed. A
     // package registry can lag behind a GitHub release, in which case the
     // installer resolves the version already installed and the upgrade
-    // silently no-ops. Compare what the installer recorded against what was
-    // advertised rather than reporting success on the exit code alone.
+    // silently no-ops. Check whether the installed version actually changed
+    // rather than reporting success on the exit code alone.
     report.installed_version = state::load_install_provenance()
         .ok()
         .and_then(|provenance| provenance.version);
 
     match verification_outcome(
         method,
+        &report.current_version,
         report.latest_version.as_deref(),
         report.installed_version.as_deref(),
     ) {
@@ -90,26 +91,33 @@ pub fn run(apply: bool, json_output: bool) -> Result<()> {
     print_report(&report, json_output)
 }
 
-/// Describe the mismatch when an applied upgrade did not produce the advertised
-/// version, or `None` when it did or when there is nothing to compare.
+/// Describe why an applied upgrade did not take effect, or `None` when it did.
 ///
 /// A package registry can lag behind a GitHub release, in which case the
 /// installer keeps resolving the version already installed, every installer
 /// command exits 0, and the upgrade silently no-ops.
+///
+/// The test is whether the installed version *changed*, not whether it equals
+/// the advertised one. The installer resolves from the package registry while
+/// `latest` comes from the GitHub release, and the two can legitimately differ:
+/// a registry that is ahead of the release, or one that resolves an
+/// intermediate version, still performed a real upgrade. Comparing against
+/// `latest` reports those as failures and points the user at an older build.
 fn applied_version_mismatch(
     method: &str,
+    current: &str,
     latest: Option<&str>,
-    installed: Option<&str>,
+    installed: &str,
 ) -> Option<String> {
-    let (latest, installed) = (latest?, installed?);
-    if installed == latest {
+    if installed != current {
         return None;
     }
+    let target = latest.unwrap_or("the new version");
     Some(format!(
-        "upgrade did not take effect: expected {latest}, but the installer recorded {installed}.\n\
-         This usually means the {method} package for {latest} has not been published yet, so the \
+        "upgrade did not take effect: still on {installed}.\n\
+         This usually means the {method} package for {target} has not been published yet, so the \
          installer resolved {installed} again.\n\
-         Hint: retry later, or install the {latest} binary from \
+         Hint: retry later, or install the {target} binary from \
          https://github.com/VeraTools/Vera/releases"
     ))
 }
@@ -123,13 +131,14 @@ enum VerificationOutcome {
 
 fn verification_outcome(
     method: &str,
+    current: &str,
     latest: Option<&str>,
     installed: Option<&str>,
 ) -> VerificationOutcome {
-    if latest.is_none() || installed.is_none() {
+    let Some(installed) = installed else {
         return VerificationOutcome::Unknown;
-    }
-    match applied_version_mismatch(method, latest, installed) {
+    };
+    match applied_version_mismatch(method, current, latest, installed) {
         Some(message) => VerificationOutcome::Mismatch(message),
         None => VerificationOutcome::Confirmed,
     }
@@ -140,37 +149,65 @@ mod tests {
     use super::{VerificationOutcome, applied_version_mismatch, verification_outcome};
 
     #[test]
-    fn reports_nothing_when_the_installed_version_matches() {
-        assert!(applied_version_mismatch("bun", Some("1.0.0"), Some("1.0.0")).is_none());
+    fn reports_nothing_when_the_version_changed() {
+        assert!(applied_version_mismatch("bun", "0.12.13", Some("1.0.0"), "1.0.0").is_none());
     }
 
     #[test]
-    fn reports_mismatch_with_both_versions_and_the_install_method() {
-        let message = applied_version_mismatch("bun", Some("1.0.0"), Some("0.12.13"))
+    fn reports_the_no_op_with_the_version_and_the_install_method() {
+        let message = applied_version_mismatch("bun", "0.12.13", Some("1.0.0"), "0.12.13")
             .expect("a stale registry must be reported, not treated as success");
-        assert!(message.contains("1.0.0"), "{message}");
         assert!(message.contains("0.12.13"), "{message}");
+        assert!(message.contains("1.0.0"), "{message}");
         assert!(message.contains("bun"), "{message}");
     }
 
+    /// The installer resolves from the package registry, `latest` comes from
+    /// the GitHub release, and the two can legitimately disagree. A registry
+    /// that is ahead of the release still performed a real upgrade, so it must
+    /// not be reported as a failure telling the user to install the older
+    /// GitHub build.
     #[test]
-    fn reports_nothing_when_either_version_is_unknown() {
-        assert!(applied_version_mismatch("bun", None, Some("0.12.13")).is_none());
-        assert!(applied_version_mismatch("bun", Some("1.0.0"), None).is_none());
+    fn accepts_a_version_the_registry_resolved_ahead_of_the_release() {
+        assert!(
+            applied_version_mismatch("bun", "1.0.0", Some("1.0.1"), "1.0.2").is_none(),
+            "a registry ahead of the GitHub release is still a real upgrade"
+        );
+        assert_eq!(
+            verification_outcome("bun", "1.0.0", Some("1.0.1"), Some("1.0.2")),
+            VerificationOutcome::Confirmed
+        );
     }
 
+    /// An intermediate version is also a real upgrade.
     #[test]
-    fn confirms_only_when_both_versions_match() {
+    fn accepts_an_intermediate_version_between_current_and_latest() {
         assert_eq!(
-            verification_outcome("bun", Some("1.0.0"), Some("1.0.0")),
+            verification_outcome("pip", "1.0.0", Some("1.2.0"), Some("1.1.0")),
             VerificationOutcome::Confirmed
         );
     }
 
     #[test]
-    fn keeps_mismatched_versions_unapplied() {
+    fn detects_the_no_op_even_when_the_release_version_is_unknown() {
+        assert!(
+            applied_version_mismatch("bun", "0.12.13", None, "0.12.13").is_some(),
+            "the no-op is detectable without knowing the advertised version"
+        );
+    }
+
+    #[test]
+    fn confirms_when_the_installed_version_moved_off_the_current_one() {
+        assert_eq!(
+            verification_outcome("bun", "0.12.13", Some("1.0.0"), Some("1.0.0")),
+            VerificationOutcome::Confirmed
+        );
+    }
+
+    #[test]
+    fn keeps_a_no_op_upgrade_unapplied() {
         assert!(matches!(
-            verification_outcome("bun", Some("1.0.0"), Some("0.12.13")),
+            verification_outcome("bun", "0.12.13", Some("1.0.0"), Some("0.12.13")),
             VerificationOutcome::Mismatch(_)
         ));
     }
@@ -178,7 +215,7 @@ mod tests {
     #[test]
     fn keeps_unknown_versions_unapplied() {
         assert_eq!(
-            verification_outcome("bun", Some("1.0.0"), None),
+            verification_outcome("bun", "0.12.13", Some("1.0.0"), None),
             VerificationOutcome::Unknown
         );
     }


### PR DESCRIPTION
Fixes #62.

Follow-up to review feedback left on #43 by @cubic-dev-ai that was never actioned before that PR
merged. The observation was correct.

## What was wrong

`applied_version_mismatch` treated an upgrade as applied only when the installer-recorded version
equalled the GitHub release tag:

```rust
if installed == latest { return None; }   // success
```

`latest` comes from the GitHub release; `installed` is whatever the package manager resolved. They
are independent sources, so they can disagree without anything being broken. When they did, a
successful upgrade was reported as a failure, `vera upgrade --apply` exited non-zero, and the hint
told the user to install the GitHub-tag build — a downgrade whenever the registry was ahead.

| current | GitHub `latest` | resolved | before | after |
|---|---|---|---|---|
| 1.0.0 | 1.0.1 | 1.0.1 | pass | pass |
| 1.0.0 | 1.0.1 | 1.0.2 | **fail, hints downgrade** | pass |
| 1.0.0 | 1.2.0 | 1.1.0 | **fail** | pass |
| 1.0.0 | 1.0.1 | 1.0.0 | fail | fail (correct: the real no-op) |

Only the last row is what the guard exists to catch, and this repo has already seen npm and PyPI
drift from the GitHub release (#35), so the middle rows are reachable in normal operation.

## What changed

The check now asks whether the installed version *changed*, comparing against `current_version`.
That detects the no-op exactly, accepts a genuine upgrade whichever source resolved it, and no
longer requires `latest` to be known in order to verify at all — the message falls back to "the new
version" when it is absent.

The failure message changed from `expected {latest}, but the installer recorded {installed}` to
`still on {installed}`, which is what actually happened in the no-op case.

## Verification

`cargo test --workspace` 917 passed / 0 failed. `cargo fmt --check` clean.
`cargo clippy -p vera-cli` reports only the five warnings already present on `master`.

Four new tests cover the rows above, including the two that previously failed:

- `accepts_a_version_the_registry_resolved_ahead_of_the_release`
- `accepts_an_intermediate_version_between_current_and_latest`
- `detects_the_no_op_even_when_the_release_version_is_unknown`
- `keeps_a_no_op_upgrade_unapplied`

The existing no-op coverage from #43 is kept and still passes, so the behaviour that PR added is
preserved; only the false failures are removed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Verifies upgrades by checking that the installer’s recorded version changes across the install instead of matching the GitHub release tag. Only trusts a baseline provenance that identifies the running binary and flags downgrades.

- Compares the post‑install recorded version to pre‑install provenance tied to the current binary; change = success, unchanged = failure with “still on {installed}”.
- Uses `semver` (v‑prefix tolerant) to order versions; downgrades (installed < baseline) are failures; unparseable versions yield Unknown.
- Returns Unknown when baseline or post‑install provenance is missing or the baseline does not identify the running binary; `latest` only words the hint (fallback: “new version”); cleans hint text and keeps the Releases fallback.
- Adds tests for registry‑ahead, intermediate versions, downgrades, baseline validation vs running binary, unknown‑`latest` hint wording, and the no‑op; moves the test module to the file bottom.

<sup>Written for commit 92d5a97042d499abc20fc7061637260ff3e28536. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/VeraTools/Vera/pull/63?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved upgrade verification by comparing the installed version with a validated pre-upgrade baseline.
  - Recognizes successful upgrades when the installed version changes without being a downgrade.
  - Correctly handles no-op upgrades, unavailable release information, and versions with a leading “v”.
  - Reports missing or unparseable version information as unknown instead of incorrectly indicating success or failure.
  - Rejects downgrade results and improves release-version guidance.

- **Tests**
  - Expanded coverage for version validation, ordering, no-ops, downgrades, and unknown versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->