### PR TITLE
fix(retrieval): bound the KNN candidate pool instead of clamping silently

### DIFF
--- a/crates/vera-core/src/retrieval/vector.rs
+++ b/crates/vera-core/src/retrieval/vector.rs
@@ -62,8 +62,10 @@ pub async fn search_vector_with_stores(
     // 2. Search the vector store for nearest neighbors.
     let (requested, candidates) = candidate_pool(limit);
     if requested > candidates {
+        // Deliberately without the query text: the surrounding `debug!` calls
+        // carry it, but this one is on by default, and a search query is user
+        // content that should not be raised into default-visible logs.
         warn!(
-            query = query,
             requested,
             fetched = candidates,
             "candidate pool exceeds the sqlite-vec KNN cap; the filter and \

--- a/crates/vera-core/src/retrieval/vector.rs
+++ b/crates/vera-core/src/retrieval/vector.rs
@@ -7,11 +7,11 @@
 //! don't appear literally in results (e.g., "memory allocation" finds `alloc`).
 
 use anyhow::Result;
-use tracing::debug;
+use tracing::{debug, warn};
 
 use crate::embedding::{EmbeddingError, EmbeddingProvider};
 use crate::storage::metadata::MetadataStore;
-use crate::storage::vector::VectorStore;
+use crate::storage::vector::{MAX_KNN_K, VectorStore};
 use crate::types::SearchResult;
 
 /// Errors specific to vector search.
@@ -60,9 +60,16 @@ pub async fn search_vector_with_stores(
     );
 
     // 2. Search the vector store for nearest neighbors.
-    // Fetch extra candidates to account for missing metadata without doubling
-    // large caller-selected candidate pools.
-    let candidates = limit.saturating_add(limit / 2).max(limit + 10);
+    let (requested, candidates) = candidate_pool(limit);
+    if requested > candidates {
+        warn!(
+            query = query,
+            requested,
+            fetched = candidates,
+            "candidate pool exceeds the sqlite-vec KNN cap; the filter and \
+             metadata over-fetch are inert above it"
+        );
+    }
 
     let vector_results = vector_store
         .search(&query_embedding, candidates)
@@ -110,6 +117,25 @@ pub async fn search_vector_with_stores(
     );
 
     Ok(results)
+}
+
+/// Size the KNN request for a caller-selected pool, bounded by the backend cap.
+///
+/// Returns `(requested, fetched)`. Extra candidates are fetched to absorb chunks
+/// whose metadata has gone missing, without doubling an already-large pool.
+///
+/// The two values differ once the compounded over-fetch runs past
+/// [`MAX_KNN_K`]. Callers stack several multipliers before reaching here (query
+/// type, then a filter over-fetch, then this one), so a natural-language query
+/// with an active filter can ask for more than sqlite-vec will serve. Bounding
+/// it here rather than letting the storage layer clamp keeps the ceiling
+/// visible to the one place that can report it; the same `k` reaches sqlite-vec
+/// either way, so ranking is unchanged.
+fn candidate_pool(limit: usize) -> (usize, usize) {
+    let requested = limit
+        .saturating_add(limit / 2)
+        .max(limit.saturating_add(10));
+    (requested, requested.min(MAX_KNN_K))
 }
 
 /// Generate a query embedding, truncating to match stored dimensionality.
@@ -172,6 +198,26 @@ mod tests {
     use crate::embedding::test_helpers::MockProvider;
     use crate::types::{Chunk, Language, SymbolType};
     use anyhow::Context;
+
+    /// The pool must never ask sqlite-vec for more than it will serve, and must
+    /// report the shortfall so a degraded pool is diagnosable rather than silent.
+    #[test]
+    fn candidate_pool_is_bounded_by_the_knn_cap() {
+        // Below the cap the metadata over-fetch is untouched.
+        assert_eq!(candidate_pool(10), (20, 20));
+        assert_eq!(candidate_pool(100), (150, 150));
+
+        // At and above it, the request is reported but not made.
+        let (requested, fetched) = candidate_pool(MAX_KNN_K);
+        assert!(
+            requested > MAX_KNN_K,
+            "over-fetch should exceed the cap here"
+        );
+        assert_eq!(fetched, MAX_KNN_K);
+
+        // No caller can push the fetch past the cap, and none can overflow it.
+        assert_eq!(candidate_pool(usize::MAX).1, MAX_KNN_K);
+    }
 
     /// Create sample chunks with semantic variety for testing.
     fn sample_chunks() -> Vec<Chunk> {

--- a/crates/vera-core/src/storage/vector.rs
+++ b/crates/vera-core/src/storage/vector.rs
@@ -16,7 +16,10 @@ pub struct VectorStore {
 
 /// Maximum `k` sqlite-vec accepts in a KNN query. Requesting more is a hard
 /// error from the extension, not a soft limit.
-const MAX_KNN_K: usize = 4096;
+///
+/// Public so callers can size their candidate pools against the real ceiling
+/// instead of scaling past it and relying on [`VectorStore::search`] to clamp.
+pub const MAX_KNN_K: usize = 4096;
 
 /// A single vector search result: chunk ID and distance score.
 #[derive(Debug, Clone)]
@@ -207,11 +210,17 @@ impl VectorStore {
         // it on natural-language queries, and the whole vector arm would then be
         // dropped in favour of BM25-only results. Ask for as many as the backend
         // allows instead.
+        // Warn rather than debug: this is a silent quality reduction, and the
+        // reason #38 was hard to diagnose was a swallowed signal. Vera's own
+        // retrieval path now bounds the pool before it gets here, so reaching
+        // this branch means an external caller asked for more than the backend
+        // can give.
         if limit > MAX_KNN_K {
-            tracing::debug!(
+            tracing::warn!(
                 requested = limit,
                 clamped = MAX_KNN_K,
-                "clamping vector search limit to sqlite-vec KNN cap"
+                "clamping vector search limit to the sqlite-vec KNN cap; \
+                 the extra candidates are not fetched"
             );
         }
         let limit = limit.min(MAX_KNN_K);


### PR DESCRIPTION
Fixes #64.

Follow-up to review feedback left on #42 by @cubic-dev-ai that was never actioned before that PR
merged. The observation was correct.

## What was wrong

The clamp in `VectorStore::search` is what keeps vector search working at all — before #42, exceeding
the cap was a hard error that dropped the entire vector arm and fell back to BM25-only (#38). That
part is right and stays.

The problem is that nothing upstream knew the cap existed. Three multipliers compound before the
request arrives:

| step | effect |
|---|---|
| `compute_vector_candidates` | `limit * multiplier`, min 50 |
| filter over-fetch in `run_hybrid_search` | `* 4`, min 200, when filters are active |
| metadata over-fetch in `search_vector_with_stores` | `* 1.5`, min `limit + 10` |
| `VectorStore::search` | `min(4096)`, logged at `debug` |

So the pool was computed as if unbounded and the shortfall was invisible: `debug` is off by default
and nothing in the return value signals it. Two consequences:

1. **The over-fetch goes inert exactly when it is needed.** Both over-fetches exist so that
   post-fetch filtering and missing metadata cannot empty the window. Above the cap they do nothing,
   so a selective filter over a 4096-row window can still under-fill the vector arm feeding RRF and
   the reranker.
2. **Silent behaviour change in a public API.** `VectorStore::search` is `pub`; a caller asking for
   more than 4096 gets fewer results with no error.

## What changed

- `MAX_KNN_K` is now `pub`, so callers can size against the real ceiling.
- `candidate_pool` sizes the request against that ceiling and returns `(requested, fetched)`, and the
  caller warns when they differ, naming the query.
- The storage clamp stays as a backstop, with its log raised from `debug` to `warn` — reaching it now
  means an external caller, not Vera's own path.
- `limit + 10` became `saturating_add(10)`; it could overflow on a caller-supplied limit near
  `usize::MAX`.

## On the retrieval path instruction

**No ranking change, and no benchmark run.** The same `k` reaches sqlite-vec before and after, so the
same candidates come back in the same order; only the reporting differs. The pool arithmetic is
moved, not altered:

- below the cap, `candidate_pool` returns exactly what the old expression did — pinned by
  `assert_eq!(candidate_pool(10), (20, 20))` and `assert_eq!(candidate_pool(100), (150, 150))`
- above it, the value passed to `search` is `MAX_KNN_K`, which is what the storage clamp produced
  anyway

Happy to run the suite if you would rather have it on record, but I did not want to present a run
whose result is determined by construction.

## Verification

`cargo test --workspace` 916 passed / 0 failed. `cargo fmt --check` clean.
`cargo clippy -p vera-core --lib` reports only the five warnings already present on `master`.

`candidate_pool_is_bounded_by_the_knn_cap` is a pure test with no assets, covering the below-cap,
at-cap and `usize::MAX` cases.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bounds the KNN candidate pool to the sqlite-vec cap and surfaces shortfalls without logging user queries. Previously, `VectorStore::search` silently clamped k>4096 at `debug`; now retrieval sizes against the cap, warns on short pools, and ranking is unchanged.

- Exposes `MAX_KNN_K` and adds `candidate_pool(limit) -> (requested, fetched)`; emits `warn` when `requested > fetched` (warning omits the query text).
- Keeps the storage-level clamp as a backstop and raises its log to `warn`.
- Switches `limit + 10` to `saturating_add(10)` to avoid overflow.
- Migration: external callers must size candidate pools to `MAX_KNN_K` to avoid warnings and inert over-fetch.

<sup>Written for commit ef9bd4c5337579be03a6aa41a81ed863d89c7a0f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/VeraTools/Vera/pull/65?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

