### PR TITLE
feat(local-models): make CodeRankEmbed the default embedding model

### DIFF
--- a/crates/vera-cli/src/commands/doctor.rs
+++ b/crates/vera-cli/src/commands/doctor.rs
@@ -21,6 +21,46 @@ struct DoctorCheck {
     detail: String,
 }
 
+/// Execution providers the local ONNX sessions actually run on.
+///
+/// A single requested backend does not decide this: the embedding session and
+/// the reranker session each resolve it independently, and either can land on
+/// CPU while the request was a GPU provider. Preflighting the request instead
+/// of the resolution makes doctor report failures for a configuration
+/// production runs fine, and vice versa.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct EffectiveProviders {
+    embedding: vera_core::config::OnnxExecutionProvider,
+    reranker: vera_core::config::OnnxExecutionProvider,
+}
+
+impl EffectiveProviders {
+    fn resolve(
+        ep: vera_core::config::OnnxExecutionProvider,
+        embedding_model: &vera_core::local_models::LocalEmbeddingModelConfig,
+    ) -> Self {
+        Self {
+            embedding: vera_core::local_models::embedding_execution_provider(ep, embedding_model),
+            reranker: vera_core::local_models::reranker_execution_provider(ep),
+        }
+    }
+
+    /// Distinct non-CPU providers needing a shared-library dependency check,
+    /// in embedding-then-reranker order. Empty when both sessions run on CPU,
+    /// where provider-specific checks are not needed.
+    fn dependency_check_providers(self) -> Vec<vera_core::config::OnnxExecutionProvider> {
+        let mut providers = Vec::new();
+        for candidate in [self.embedding, self.reranker] {
+            if candidate != vera_core::config::OnnxExecutionProvider::Cpu
+                && !providers.contains(&candidate)
+            {
+                providers.push(candidate);
+            }
+        }
+        providers
+    }
+}
+
 #[derive(Debug, Clone, Serialize)]
 struct DoctorReport {
     version: String,
@@ -74,7 +114,13 @@ pub fn run(json_output: bool, probe: bool) -> anyhow::Result<()> {
                 status: CheckStatus::Ok,
                 detail: embedding_model.display_name(),
             });
-            let runtime_path = vera_core::local_models::ort_library_path_for_ep(ep)?;
+            // The embedding and reranker sessions each resolve the requested
+            // backend to their own provider, so preflight the resolved pair
+            // rather than the request: otherwise doctor checks a library
+            // production never loads and skips every probe when it is absent.
+            let providers = EffectiveProviders::resolve(ep, &embedding_model);
+            let runtime_path =
+                vera_core::local_models::ort_library_path_for_ep(providers.embedding)?;
             let runtime_check = vera_core::local_models::ensure_ort_runtime(Some(&runtime_path));
             let runtime_detail = match &runtime_check {
                 Ok(()) => runtime_path.display().to_string(),
@@ -90,16 +136,20 @@ pub fn run(json_output: bool, probe: bool) -> anyhow::Result<()> {
                 detail: runtime_detail,
             });
 
-            let model_assets =
-                vera_core::local_models::inspect_local_model_files_for_ep(ep, &embedding_model)?;
+            let model_assets = vera_core::local_models::inspect_local_model_files_for_ep(
+                providers.embedding,
+                &embedding_model,
+            )?;
+            // The hint stays on the requested backend: `vera repair
+            // --onnx-jina-<ep>` is what installs that backend's files.
             let repair_hint = format!("run `vera repair --onnx-jina-{ep}`");
             checks.push(local_model_assets_check(&model_assets, &repair_hint));
             if probe {
                 checks.extend(probe_local_backend(
                     ep,
+                    providers,
                     &runtime_path,
                     &model_assets,
-                    &embedding_model,
                 )?);
             }
         }
@@ -302,12 +352,22 @@ fn probe_potion_backend(
 
 fn probe_local_backend(
     ep: vera_core::config::OnnxExecutionProvider,
+    providers: EffectiveProviders,
     runtime_path: &std::path::Path,
     model_assets: &[vera_core::local_models::LocalModelAssetStatus],
-    embedding_model: &vera_core::local_models::LocalEmbeddingModelConfig,
 ) -> anyhow::Result<Vec<DoctorCheck>> {
+    let embedding_ep = providers.embedding;
+    let reranker_ep = providers.reranker;
     let mut checks = Vec::new();
 
+    // `ensure_ort_runtime` is a process-wide `OnceLock`: only the FIRST path
+    // handed to it is dlopened, and every later call replays that first result
+    // whatever path it is given. `runtime_path` is the embedding provider's
+    // library, so when the two components resolve to different providers the
+    // reranker's library can only be existence-checked (which is what
+    // `dependency_probe_status` does), never load-checked. Calling
+    // `ensure_ort_runtime` a second time would report the first library's
+    // outcome under the second library's name.
     let ort_stage = result_check(
         "probe-ort-library",
         runtime_path.display().to_string(),
@@ -316,40 +376,108 @@ fn probe_local_backend(
     let ort_ok = matches!(ort_stage.status, CheckStatus::Ok);
     checks.push(ort_stage);
 
+    let mut embedding_provider_ok = false;
+    let mut reranker_provider_ok = false;
     let provider_stage = if ort_ok {
-        result_check(
-            "probe-provider-registration",
-            format!("registered {}", ep),
+        let embedding_result =
             vera_core::embedding::local_provider::LocalEmbeddingProvider::probe_provider_registration(
-                ep,
-            ),
-        )
+                embedding_ep,
+            );
+        embedding_provider_ok = embedding_result.is_ok();
+        if reranker_ep == embedding_ep {
+            reranker_provider_ok = embedding_provider_ok;
+            result_check(
+                "probe-provider-registration",
+                format!("registered {embedding_ep} for embedding and reranking"),
+                embedding_result,
+            )
+        } else {
+            let reranker_result =
+                vera_core::embedding::local_provider::LocalEmbeddingProvider::probe_provider_registration(
+                    reranker_ep,
+                );
+            reranker_provider_ok = reranker_result.is_ok();
+            let failures = [
+                embedding_result
+                    .err()
+                    .map(|err| format!("embedding {embedding_ep}: {}", one_line_error(&err))),
+                reranker_result
+                    .err()
+                    .map(|err| format!("reranker {reranker_ep}: {}", one_line_error(&err))),
+            ]
+            .into_iter()
+            .flatten()
+            .collect::<Vec<_>>();
+            if failures.is_empty() {
+                DoctorCheck {
+                    name: "probe-provider-registration",
+                    status: CheckStatus::Ok,
+                    detail: format!(
+                        "registered {embedding_ep} for embedding and {reranker_ep} for reranking"
+                    ),
+                }
+            } else {
+                DoctorCheck {
+                    name: "probe-provider-registration",
+                    status: CheckStatus::Fail,
+                    detail: failures.join("; "),
+                }
+            }
+        }
     } else {
         skipped_check(
             "probe-provider-registration",
             "skipped because ONNX Runtime could not be initialized",
         )
     };
-    let provider_ok = matches!(provider_stage.status, CheckStatus::Ok);
     checks.push(provider_stage);
 
-    let dependencies_stage = if ep == vera_core::config::OnnxExecutionProvider::Cpu {
+    let dependency_providers = providers.dependency_check_providers();
+    let mut failed_dependency_providers = Vec::new();
+    let dependencies_stage = if dependency_providers.is_empty() {
         skipped_check(
             "probe-dependencies",
-            "skipped for the CPU backend because provider-specific shared-library checks are not needed",
+            "skipped because the embedding and reranker sessions both run on CPU, where provider-specific shared-library checks are not needed",
         )
     } else if ort_ok {
-        dependency_probe_check(ep, runtime_path)
+        let mut status = CheckStatus::Ok;
+        let mut details = Vec::new();
+        for provider in &dependency_providers {
+            let library_path = if *provider == embedding_ep {
+                runtime_path.to_path_buf()
+            } else {
+                vera_core::local_models::ort_library_path_for_ep(*provider)?
+            };
+            let (provider_status, detail) = dependency_probe_status(*provider, &library_path);
+            if matches!(provider_status, CheckStatus::Fail) {
+                failed_dependency_providers.push(*provider);
+            }
+            status = worse_status(status, provider_status);
+            details.push(if dependency_providers.len() > 1 {
+                format!("{provider}: {detail}")
+            } else {
+                detail
+            });
+        }
+        DoctorCheck {
+            name: "probe-dependencies",
+            status,
+            detail: details.join("; "),
+        }
     } else {
         skipped_check(
             "probe-dependencies",
             "skipped because ONNX Runtime could not be initialized",
         )
     };
-    let dependencies_ok = !matches!(dependencies_stage.status, CheckStatus::Fail);
+    let embedding_dependencies_ok = !failed_dependency_providers.contains(&embedding_ep);
+    let reranker_dependencies_ok = !failed_dependency_providers.contains(&reranker_ep);
     checks.push(dependencies_stage);
 
-    let embedding_session_stage = if ort_ok && provider_ok && dependencies_ok {
+    let embedding_ok = ort_ok && embedding_provider_ok && embedding_dependencies_ok;
+    let reranker_ok = ort_ok && reranker_provider_ok && reranker_dependencies_ok;
+
+    let embedding_session_stage = if embedding_ok {
         let missing = missing_assets(model_assets, &["embedding-onnx", "embedding-onnx-data"]);
         if missing.is_empty() {
             result_check(
@@ -373,7 +501,7 @@ fn probe_local_backend(
     };
     checks.push(embedding_session_stage);
 
-    let reranker_session_stage = if ort_ok && provider_ok && dependencies_ok {
+    let reranker_session_stage = if reranker_ok {
         let missing = missing_assets(model_assets, &["reranker-onnx"]);
         if missing.is_empty() {
             result_check(
@@ -397,7 +525,7 @@ fn probe_local_backend(
     };
     checks.push(reranker_session_stage);
 
-    let tiny_inference_stage = if ort_ok && provider_ok && dependencies_ok {
+    let tiny_inference_stage = if embedding_ok && reranker_ok {
         let missing = missing_assets(
             model_assets,
             &[
@@ -436,7 +564,7 @@ fn probe_local_backend(
     let tiny_inference_ok = matches!(tiny_inference_stage.status, CheckStatus::Ok);
     checks.push(tiny_inference_stage);
 
-    if ep != vera_core::config::OnnxExecutionProvider::Cpu {
+    if !dependency_providers.is_empty() {
         checks.push(if tiny_inference_ok {
             DoctorCheck {
                 name: "probe-provider-confirmation",
@@ -461,13 +589,10 @@ fn probe_local_backend(
         // The embedding model is not unconditionally GPU-accelerated either:
         // some models are pinned to CPU under CoreML (see
         // `embedding_execution_provider`). Report what the configured model
-        // actually does rather than asserting embeddings run on the GPU.
-        // `run` resolves the embedding config before probing and propagates
-        // any failure, so this is the already-validated config rather than a
-        // second read that could disagree with it.
-        let embedding_on_cpu =
-            vera_core::local_models::embedding_execution_provider(ep, embedding_model)
-                == vera_core::config::OnnxExecutionProvider::Cpu;
+        // actually does rather than asserting embeddings run on the GPU. This
+        // is the same resolution the probes above ran on, so the two cannot
+        // disagree.
+        let embedding_on_cpu = embedding_ep == vera_core::config::OnnxExecutionProvider::Cpu;
         let detail = if embedding_on_cpu {
             "the reranker and the configured embedding model both run on CPU under CoreML (no CoreML-compatible reranker ONNX export exists, and this embedding model fails at inference on the CoreML provider), so this backend is not currently GPU-accelerated. If search latency is unacceptable, disable reranking with `vera config set retrieval.reranking_enabled false`"
         } else {
@@ -526,13 +651,13 @@ fn skipped_check(name: &'static str, detail: impl Into<String>) -> DoctorCheck {
     }
 }
 
-fn dependency_probe_check(
+fn dependency_probe_status(
     ep: vera_core::config::OnnxExecutionProvider,
     runtime_path: &std::path::Path,
-) -> DoctorCheck {
+) -> (CheckStatus, String) {
     if !runtime_path.exists() {
-        return skipped_check(
-            "probe-dependencies",
+        return (
+            CheckStatus::Skip,
             format!("skipped because {} is missing", runtime_path.display()),
         );
     }
@@ -540,31 +665,44 @@ fn dependency_probe_check(
     match vera_core::local_models::inspect_provider_dependencies(ep, runtime_path) {
         Ok(Some(status)) => {
             if status.missing_details.is_empty() {
-                DoctorCheck {
-                    name: "probe-dependencies",
-                    status: CheckStatus::Ok,
-                    detail: "found no unresolved ONNX Runtime dependencies".to_string(),
-                }
+                (
+                    CheckStatus::Ok,
+                    "found no unresolved ONNX Runtime dependencies".to_string(),
+                )
             } else {
-                DoctorCheck {
-                    name: "probe-dependencies",
-                    status: CheckStatus::Fail,
-                    detail: format!(
+                (
+                    CheckStatus::Fail,
+                    format!(
                         "missing shared libraries: {}",
                         status.missing_details.join("; ")
                     ),
-                }
+                )
             }
         }
-        Ok(None) => skipped_check(
-            "probe-dependencies",
-            "dependency inspection is currently available on Linux with `ldd` and macOS with `otool`",
+        Ok(None) => (
+            CheckStatus::Skip,
+            "dependency inspection is currently available on Linux with `ldd` and macOS with `otool`".to_string(),
         ),
-        Err(err) => DoctorCheck {
-            name: "probe-dependencies",
-            status: CheckStatus::Warn,
-            detail: one_line_error(&err),
-        },
+        Err(err) => (CheckStatus::Warn, one_line_error(&err)),
+    }
+}
+
+/// Keep the most severe of two statuses when one check covers several
+/// providers.
+fn worse_status(current: CheckStatus, next: CheckStatus) -> CheckStatus {
+    fn severity(status: &CheckStatus) -> u8 {
+        match status {
+            CheckStatus::Ok => 0,
+            CheckStatus::Skip => 1,
+            CheckStatus::Warn => 2,
+            CheckStatus::Fail => 3,
+        }
+    }
+
+    if severity(&next) > severity(&current) {
+        next
+    } else {
+        current
     }
 }
 
@@ -613,4 +751,67 @@ fn one_line_error(err: &anyhow::Error) -> String {
         .filter(|line| !line.is_empty())
         .collect::<Vec<_>>()
         .join("; ")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::EffectiveProviders;
+    use vera_core::config::OnnxExecutionProvider;
+    use vera_core::local_models::LocalEmbeddingModelConfig;
+
+    #[test]
+    fn coreml_pins_both_sessions_to_cpu_for_coderankembed() {
+        let providers = EffectiveProviders::resolve(
+            OnnxExecutionProvider::CoreMl,
+            &LocalEmbeddingModelConfig::coderankembed(),
+        );
+
+        assert_eq!(providers.embedding, OnnxExecutionProvider::Cpu);
+        assert_eq!(providers.reranker, OnnxExecutionProvider::Cpu);
+        assert!(providers.dependency_check_providers().is_empty());
+    }
+
+    #[test]
+    fn coreml_keeps_jina_embeddings_on_gpu_and_reranks_on_cpu() {
+        let providers = EffectiveProviders::resolve(
+            OnnxExecutionProvider::CoreMl,
+            &LocalEmbeddingModelConfig::jina(),
+        );
+
+        assert_eq!(providers.embedding, OnnxExecutionProvider::CoreMl);
+        assert_eq!(providers.reranker, OnnxExecutionProvider::Cpu);
+        assert_eq!(
+            providers.dependency_check_providers(),
+            vec![OnnxExecutionProvider::CoreMl]
+        );
+    }
+
+    #[test]
+    fn cpu_needs_no_dependency_check_for_any_model() {
+        for config in [
+            LocalEmbeddingModelConfig::jina(),
+            LocalEmbeddingModelConfig::coderankembed(),
+        ] {
+            let providers = EffectiveProviders::resolve(OnnxExecutionProvider::Cpu, &config);
+
+            assert_eq!(providers.embedding, OnnxExecutionProvider::Cpu);
+            assert_eq!(providers.reranker, OnnxExecutionProvider::Cpu);
+            assert!(providers.dependency_check_providers().is_empty());
+        }
+    }
+
+    #[test]
+    fn non_coreml_gpu_backends_keep_both_sessions_on_the_requested_provider() {
+        let providers = EffectiveProviders::resolve(
+            OnnxExecutionProvider::Cuda,
+            &LocalEmbeddingModelConfig::coderankembed(),
+        );
+
+        assert_eq!(providers.embedding, OnnxExecutionProvider::Cuda);
+        assert_eq!(providers.reranker, OnnxExecutionProvider::Cuda);
+        assert_eq!(
+            providers.dependency_check_providers(),
+            vec![OnnxExecutionProvider::Cuda]
+        );
+    }
 }

--- a/crates/vera-cli/src/commands/doctor.rs
+++ b/crates/vera-cli/src/commands/doctor.rs
@@ -95,7 +95,12 @@ pub fn run(json_output: bool, probe: bool) -> anyhow::Result<()> {
             let repair_hint = format!("run `vera repair --onnx-jina-{ep}`");
             checks.push(local_model_assets_check(&model_assets, &repair_hint));
             if probe {
-                checks.extend(probe_local_backend(ep, &runtime_path, &model_assets)?);
+                checks.extend(probe_local_backend(
+                    ep,
+                    &runtime_path,
+                    &model_assets,
+                    &embedding_model,
+                )?);
             }
         }
         vera_core::config::InferenceBackend::PotionCode => {
@@ -299,6 +304,7 @@ fn probe_local_backend(
     ep: vera_core::config::OnnxExecutionProvider,
     runtime_path: &std::path::Path,
     model_assets: &[vera_core::local_models::LocalModelAssetStatus],
+    embedding_model: &vera_core::local_models::LocalEmbeddingModelConfig,
 ) -> anyhow::Result<Vec<DoctorCheck>> {
     let mut checks = Vec::new();
 
@@ -456,24 +462,16 @@ fn probe_local_backend(
         // some models are pinned to CPU under CoreML (see
         // `embedding_execution_provider`). Report what the configured model
         // actually does rather than asserting embeddings run on the GPU.
-        // A config that cannot be read is a third state: it must not be
-        // reported as "configured for CoreML".
-        let embedding_on_cpu = vera_core::local_models::LocalEmbeddingModelConfig::from_env()
-            .ok()
-            .map(|config| {
-                vera_core::local_models::embedding_execution_provider(ep, &config)
-                    == vera_core::config::OnnxExecutionProvider::Cpu
-            });
-        let detail = match embedding_on_cpu {
-            Some(true) => {
-                "the reranker and the configured embedding model both run on CPU under CoreML (no CoreML-compatible reranker ONNX export exists, and this embedding model fails at inference on the CoreML provider), so this backend is not currently GPU-accelerated. If search latency is unacceptable, disable reranking with `vera config set retrieval.reranking_enabled false`"
-            }
-            Some(false) => {
-                "the reranker runs on CPU under CoreML (no CoreML-compatible reranker ONNX export exists). The embedding model is configured for CoreML, but ONNX Runtime can still place nodes on CPU, so active GPU execution cannot be confirmed here. If reranking latency is unacceptable, disable it with `vera config set retrieval.reranking_enabled false`"
-            }
-            None => {
-                "the reranker runs on CPU under CoreML (no CoreML-compatible reranker ONNX export exists). The embedding model's placement could not be determined because the local embedding configuration could not be read. If reranking latency is unacceptable, disable it with `vera config set retrieval.reranking_enabled false`"
-            }
+        // `run` resolves the embedding config before probing and propagates
+        // any failure, so this is the already-validated config rather than a
+        // second read that could disagree with it.
+        let embedding_on_cpu =
+            vera_core::local_models::embedding_execution_provider(ep, embedding_model)
+                == vera_core::config::OnnxExecutionProvider::Cpu;
+        let detail = if embedding_on_cpu {
+            "the reranker and the configured embedding model both run on CPU under CoreML (no CoreML-compatible reranker ONNX export exists, and this embedding model fails at inference on the CoreML provider), so this backend is not currently GPU-accelerated. If search latency is unacceptable, disable reranking with `vera config set retrieval.reranking_enabled false`"
+        } else {
+            "the reranker runs on CPU under CoreML (no CoreML-compatible reranker ONNX export exists). The embedding model is configured for CoreML, but ONNX Runtime can still place nodes on CPU, so active GPU execution cannot be confirmed here. If reranking latency is unacceptable, disable it with `vera config set retrieval.reranking_enabled false`"
         };
         checks.push(DoctorCheck {
             name: "probe-reranker-coreml-cpu",

--- a/crates/vera-cli/src/commands/doctor.rs
+++ b/crates/vera-cli/src/commands/doctor.rs
@@ -456,15 +456,24 @@ fn probe_local_backend(
         // some models are pinned to CPU under CoreML (see
         // `embedding_execution_provider`). Report what the configured model
         // actually does rather than asserting embeddings run on the GPU.
+        // A config that cannot be read is a third state: it must not be
+        // reported as "configured for CoreML".
         let embedding_on_cpu = vera_core::local_models::LocalEmbeddingModelConfig::from_env()
-            .is_ok_and(|config| {
+            .ok()
+            .map(|config| {
                 vera_core::local_models::embedding_execution_provider(ep, &config)
                     == vera_core::config::OnnxExecutionProvider::Cpu
             });
-        let detail = if embedding_on_cpu {
-            "the reranker and the configured embedding model both run on CPU under CoreML (no CoreML-compatible reranker ONNX export exists, and this embedding model fails at inference on the CoreML provider), so this backend is not currently GPU-accelerated. If search latency is unacceptable, disable reranking with `vera config set retrieval.reranking_enabled false`"
-        } else {
-            "the reranker runs on CPU under CoreML (no CoreML-compatible reranker ONNX export exists). The embedding model is configured for CoreML, but ONNX Runtime can still place nodes on CPU, so active GPU execution cannot be confirmed here. If reranking latency is unacceptable, disable it with `vera config set retrieval.reranking_enabled false`"
+        let detail = match embedding_on_cpu {
+            Some(true) => {
+                "the reranker and the configured embedding model both run on CPU under CoreML (no CoreML-compatible reranker ONNX export exists, and this embedding model fails at inference on the CoreML provider), so this backend is not currently GPU-accelerated. If search latency is unacceptable, disable reranking with `vera config set retrieval.reranking_enabled false`"
+            }
+            Some(false) => {
+                "the reranker runs on CPU under CoreML (no CoreML-compatible reranker ONNX export exists). The embedding model is configured for CoreML, but ONNX Runtime can still place nodes on CPU, so active GPU execution cannot be confirmed here. If reranking latency is unacceptable, disable it with `vera config set retrieval.reranking_enabled false`"
+            }
+            None => {
+                "the reranker runs on CPU under CoreML (no CoreML-compatible reranker ONNX export exists). The embedding model's placement could not be determined because the local embedding configuration could not be read. If reranking latency is unacceptable, disable it with `vera config set retrieval.reranking_enabled false`"
+            }
         };
         checks.push(DoctorCheck {
             name: "probe-reranker-coreml-cpu",

--- a/crates/vera-cli/src/commands/doctor.rs
+++ b/crates/vera-cli/src/commands/doctor.rs
@@ -452,10 +452,24 @@ fn probe_local_backend(
     // and then fail at inference. The probes above cannot detect this, so
     // surface it deterministically here.
     if ep == vera_core::config::OnnxExecutionProvider::CoreMl {
+        // The embedding model is not unconditionally GPU-accelerated either:
+        // some models are pinned to CPU under CoreML (see
+        // `embedding_execution_provider`). Report what the configured model
+        // actually does rather than asserting embeddings run on the GPU.
+        let embedding_on_cpu = vera_core::local_models::LocalEmbeddingModelConfig::from_env()
+            .is_ok_and(|config| {
+                vera_core::local_models::embedding_execution_provider(ep, &config)
+                    == vera_core::config::OnnxExecutionProvider::Cpu
+            });
+        let detail = if embedding_on_cpu {
+            "the reranker and the configured embedding model both run on CPU under CoreML (no CoreML-compatible reranker ONNX export exists, and this embedding model fails at inference on the CoreML provider), so this backend is not currently GPU-accelerated. If search latency is unacceptable, disable reranking with `vera config set retrieval.reranking_enabled false`"
+        } else {
+            "the reranker runs on CPU under CoreML (no CoreML-compatible reranker ONNX export exists); only the embedding model is GPU-accelerated. Reranking will be slower than embedding. If reranking latency is unacceptable, disable it with `vera config set retrieval.reranking_enabled false`"
+        };
         checks.push(DoctorCheck {
             name: "probe-reranker-coreml-cpu",
             status: CheckStatus::Warn,
-            detail: "the reranker runs on CPU under CoreML (no CoreML-compatible reranker ONNX export exists); only the embedding model is GPU-accelerated. Reranking will be slower than embedding. If reranking latency is unacceptable, disable it with `vera config set retrieval.reranking_enabled false`".to_string(),
+            detail: detail.to_string(),
         });
     }
 

--- a/crates/vera-cli/src/commands/doctor.rs
+++ b/crates/vera-cli/src/commands/doctor.rs
@@ -464,7 +464,7 @@ fn probe_local_backend(
         let detail = if embedding_on_cpu {
             "the reranker and the configured embedding model both run on CPU under CoreML (no CoreML-compatible reranker ONNX export exists, and this embedding model fails at inference on the CoreML provider), so this backend is not currently GPU-accelerated. If search latency is unacceptable, disable reranking with `vera config set retrieval.reranking_enabled false`"
         } else {
-            "the reranker runs on CPU under CoreML (no CoreML-compatible reranker ONNX export exists); only the embedding model is GPU-accelerated. Reranking will be slower than embedding. If reranking latency is unacceptable, disable it with `vera config set retrieval.reranking_enabled false`"
+            "the reranker runs on CPU under CoreML (no CoreML-compatible reranker ONNX export exists). The embedding model is configured for CoreML, but ONNX Runtime can still place nodes on CPU, so active GPU execution cannot be confirmed here. If reranking latency is unacceptable, disable it with `vera config set retrieval.reranking_enabled false`"
         };
         checks.push(DoctorCheck {
             name: "probe-reranker-coreml-cpu",

--- a/crates/vera-core/src/embedding/local_provider.rs
+++ b/crates/vera-core/src/embedding/local_provider.rs
@@ -355,7 +355,7 @@ impl LocalEmbeddingProvider {
         let ort_path = crate::local_models::ort_library_path_for_ep(ep)?;
         crate::local_models::ensure_ort_runtime(Some(&ort_path))?;
         let asset_paths = config.cached_asset_paths()?;
-        let _ = build_session(ep, asset_paths.onnx_path, 0)?;
+        let _ = build_session(ep, asset_paths.onnx_path, 0, &config)?;
         Ok(())
     }
 
@@ -365,7 +365,7 @@ impl LocalEmbeddingProvider {
         let ort_path = crate::local_models::ort_library_path_for_ep(ep)?;
         crate::local_models::ensure_ort_runtime(Some(&ort_path))?;
         let asset_paths = config.cached_asset_paths()?;
-        let mut session = build_session(ep, asset_paths.onnx_path, 0)?;
+        let mut session = build_session(ep, asset_paths.onnx_path, 0, &config)?;
         let tokenizer = load_tokenizer(asset_paths.tokenizer_path, config.max_length)?;
         run_probe_inference(&mut session, &tokenizer)
     }
@@ -605,8 +605,11 @@ async fn load_embedding_components(
     let tokenizer =
         task::spawn_blocking(move || load_tokenizer(tokenizer_path, tokenizer_max_length))
             .await??;
-    let session =
-        task::spawn_blocking(move || build_session(ep, onnx_path, gpu_mem_limit_mb)).await??;
+    let session_config = config.clone();
+    let session = task::spawn_blocking(move || {
+        build_session(ep, onnx_path, gpu_mem_limit_mb, &session_config)
+    })
+    .await??;
 
     Ok((session, tokenizer))
 }
@@ -812,7 +815,9 @@ fn build_session(
     ep: OnnxExecutionProvider,
     onnx_path: std::path::PathBuf,
     gpu_mem_limit_mb: u64,
+    config: &LocalEmbeddingModelConfig,
 ) -> Result<Session> {
+    let ep = crate::local_models::embedding_execution_provider(ep, config);
     let available = std::thread::available_parallelism()
         .map(|n| n.get())
         .unwrap_or(1);

--- a/crates/vera-core/src/embedding/local_provider.rs
+++ b/crates/vera-core/src/embedding/local_provider.rs
@@ -272,6 +272,12 @@ impl LocalEmbeddingProvider {
         gpu_mem_limit_mb: u64,
     ) -> Result<Self, EmbeddingError> {
         let base_config = LocalEmbeddingModelConfig::from_env().map_err(api_err)?;
+        // `build_session` pins some models to CPU regardless of the requested
+        // backend (see `embedding_execution_provider`). Resolve that here too:
+        // otherwise a session that actually runs on CPU still gets GPU batch
+        // scaling, GPU provider dependencies, and a CPU "fallback" retry of the
+        // CPU session it already built.
+        let ep = crate::local_models::embedding_execution_provider(ep, &base_config);
         let mut config = base_config.clone();
         config.adjust_for_gpu(ep);
         let mut batch_scaler = if ep == OnnxExecutionProvider::Cpu {

--- a/crates/vera-core/src/embedding/local_provider.rs
+++ b/crates/vera-core/src/embedding/local_provider.rs
@@ -272,14 +272,7 @@ impl LocalEmbeddingProvider {
         gpu_mem_limit_mb: u64,
     ) -> Result<Self, EmbeddingError> {
         let base_config = LocalEmbeddingModelConfig::from_env().map_err(api_err)?;
-        // `build_session` pins some models to CPU regardless of the requested
-        // backend (see `embedding_execution_provider`). Resolve that here too:
-        // otherwise a session that actually runs on CPU still gets GPU batch
-        // scaling, GPU provider dependencies, and a CPU "fallback" retry of the
-        // CPU session it already built.
-        let ep = crate::local_models::embedding_execution_provider(ep, &base_config);
-        let mut config = base_config.clone();
-        config.adjust_for_gpu(ep);
+        let (ep, mut config) = resolve_provider_and_config(ep, &base_config);
         let mut batch_scaler = if ep == OnnxExecutionProvider::Cpu {
             None
         } else {
@@ -356,8 +349,7 @@ impl LocalEmbeddingProvider {
     }
 
     pub fn probe_session(ep: OnnxExecutionProvider) -> Result<()> {
-        let mut config = LocalEmbeddingModelConfig::from_env()?;
-        config.adjust_for_gpu(ep);
+        let (ep, config) = resolve_provider_and_config(ep, &LocalEmbeddingModelConfig::from_env()?);
         let ort_path = crate::local_models::ort_library_path_for_ep(ep)?;
         crate::local_models::ensure_ort_runtime(Some(&ort_path))?;
         let asset_paths = config.cached_asset_paths()?;
@@ -366,8 +358,7 @@ impl LocalEmbeddingProvider {
     }
 
     pub fn probe_inference(ep: OnnxExecutionProvider) -> Result<()> {
-        let mut config = LocalEmbeddingModelConfig::from_env()?;
-        config.adjust_for_gpu(ep);
+        let (ep, config) = resolve_provider_and_config(ep, &LocalEmbeddingModelConfig::from_env()?);
         let ort_path = crate::local_models::ort_library_path_for_ep(ep)?;
         crate::local_models::ensure_ort_runtime(Some(&ort_path))?;
         let asset_paths = config.cached_asset_paths()?;
@@ -815,6 +806,27 @@ fn normalize_embedding(embedding: &mut [f32]) {
             *value /= norm;
         }
     }
+}
+
+/// Resolve the execution provider a session will actually run on, and adjust
+/// the model config to match it.
+///
+/// `build_session` pins some models to CPU regardless of the requested backend
+/// (see `embedding_execution_provider`), so everything derived from the
+/// provider has to follow the effective one rather than the requested one.
+/// Adjusting for the requested provider would select the GPU ONNX export for a
+/// session that then runs on CPU, and would give a CPU session GPU batch
+/// scaling, GPU provider dependencies, and a CPU "fallback" retry of the CPU
+/// session it already built. Probe paths must resolve identically or `vera
+/// doctor` reports on a configuration production never loads.
+fn resolve_provider_and_config(
+    ep: OnnxExecutionProvider,
+    config: &LocalEmbeddingModelConfig,
+) -> (OnnxExecutionProvider, LocalEmbeddingModelConfig) {
+    let ep = crate::local_models::embedding_execution_provider(ep, config);
+    let mut resolved = config.clone();
+    resolved.adjust_for_gpu(ep);
+    (ep, resolved)
 }
 
 fn build_session(

--- a/crates/vera-core/src/embedding/local_provider.rs
+++ b/crates/vera-core/src/embedding/local_provider.rs
@@ -808,9 +808,10 @@ fn normalize_embedding(embedding: &mut [f32]) {
 /// Resolve the execution provider a session will actually run on, and adjust
 /// the model config to match it.
 ///
-/// `build_session` pins some models to CPU regardless of the requested backend
-/// (see `embedding_execution_provider`), so everything derived from the
-/// provider has to follow the effective one rather than the requested one.
+/// Some models are pinned to CPU regardless of the requested backend (see
+/// `embedding_execution_provider`), so everything derived from the provider
+/// has to follow the effective one rather than the requested one. This is the
+/// only place that resolution happens; `build_session` trusts what it is given.
 /// Adjusting for the requested provider would select the GPU ONNX export for a
 /// session that then runs on CPU, and would give a CPU session GPU batch
 /// scaling, GPU provider dependencies, and a CPU "fallback" retry of the CPU

--- a/crates/vera-core/src/embedding/local_provider.rs
+++ b/crates/vera-core/src/embedding/local_provider.rs
@@ -353,7 +353,7 @@ impl LocalEmbeddingProvider {
         let ort_path = crate::local_models::ort_library_path_for_ep(ep)?;
         crate::local_models::ensure_ort_runtime(Some(&ort_path))?;
         let asset_paths = config.cached_asset_paths()?;
-        let _ = build_session(ep, asset_paths.onnx_path, 0, &config)?;
+        let _ = build_session(ep, asset_paths.onnx_path, 0)?;
         Ok(())
     }
 
@@ -362,7 +362,7 @@ impl LocalEmbeddingProvider {
         let ort_path = crate::local_models::ort_library_path_for_ep(ep)?;
         crate::local_models::ensure_ort_runtime(Some(&ort_path))?;
         let asset_paths = config.cached_asset_paths()?;
-        let mut session = build_session(ep, asset_paths.onnx_path, 0, &config)?;
+        let mut session = build_session(ep, asset_paths.onnx_path, 0)?;
         let tokenizer = load_tokenizer(asset_paths.tokenizer_path, config.max_length)?;
         run_probe_inference(&mut session, &tokenizer)
     }
@@ -602,11 +602,8 @@ async fn load_embedding_components(
     let tokenizer =
         task::spawn_blocking(move || load_tokenizer(tokenizer_path, tokenizer_max_length))
             .await??;
-    let session_config = config.clone();
-    let session = task::spawn_blocking(move || {
-        build_session(ep, onnx_path, gpu_mem_limit_mb, &session_config)
-    })
-    .await??;
+    let session =
+        task::spawn_blocking(move || build_session(ep, onnx_path, gpu_mem_limit_mb)).await??;
 
     Ok((session, tokenizer))
 }
@@ -829,13 +826,16 @@ fn resolve_provider_and_config(
     (ep, resolved)
 }
 
+/// Build an ONNX Runtime session on an already-resolved execution provider.
+///
+/// `ep` must come from [`resolve_provider_and_config`], and `onnx_path` from
+/// the config it returned. Resolving again here would duplicate the provider
+/// contract in two places that could drift apart.
 fn build_session(
     ep: OnnxExecutionProvider,
     onnx_path: std::path::PathBuf,
     gpu_mem_limit_mb: u64,
-    config: &LocalEmbeddingModelConfig,
 ) -> Result<Session> {
-    let ep = crate::local_models::embedding_execution_provider(ep, config);
     let available = std::thread::available_parallelism()
         .map(|n| n.get())
         .unwrap_or(1);
@@ -1007,6 +1007,63 @@ fn register_execution_provider(
 mod tests {
     use super::*;
     use tempfile::tempdir;
+
+    // Asset-free: these exercise the provider/config contract directly, so
+    // they still run when ONNX Runtime is absent (unlike the tests below,
+    // which return early and pass without asserting anything).
+
+    #[test]
+    fn coreml_pins_coderankembed_to_cpu_but_leaves_other_models_alone() {
+        let (ep, _) = resolve_provider_and_config(
+            OnnxExecutionProvider::CoreMl,
+            &LocalEmbeddingModelConfig::coderankembed(),
+        );
+        assert_eq!(ep, OnnxExecutionProvider::Cpu);
+
+        let (ep, _) = resolve_provider_and_config(
+            OnnxExecutionProvider::CoreMl,
+            &LocalEmbeddingModelConfig::jina(),
+        );
+        assert_eq!(ep, OnnxExecutionProvider::CoreMl);
+    }
+
+    #[test]
+    fn config_is_adjusted_for_the_effective_provider_not_the_requested_one() {
+        // A model pinned to CPU must not be handed the GPU ONNX export: the
+        // session would then load fp16 weights it cannot run on CPU.
+        let coderank = LocalEmbeddingModelConfig::coderankembed();
+        let (_, resolved) = resolve_provider_and_config(OnnxExecutionProvider::CoreMl, &coderank);
+        assert_eq!(resolved.onnx_file, coderank.onnx_file);
+
+        // An unpinned model keeps the GPU adjustment it would get anyway.
+        let jina = LocalEmbeddingModelConfig::jina();
+        let (_, resolved) = resolve_provider_and_config(OnnxExecutionProvider::CoreMl, &jina);
+        let mut expected = jina.clone();
+        expected.adjust_for_gpu(OnnxExecutionProvider::CoreMl);
+        assert_eq!(resolved.onnx_file, expected.onnx_file);
+    }
+
+    #[test]
+    fn resolution_is_idempotent_so_build_session_need_not_repeat_it() {
+        // `build_session` no longer re-resolves the provider; it trusts what
+        // the caller passes. Resolving an already-resolved pair must be a
+        // no-op, or a second pass anywhere would change the answer.
+        for config in [
+            LocalEmbeddingModelConfig::coderankembed(),
+            LocalEmbeddingModelConfig::jina(),
+        ] {
+            for requested in [
+                OnnxExecutionProvider::CoreMl,
+                OnnxExecutionProvider::Cpu,
+                OnnxExecutionProvider::Cuda,
+            ] {
+                let (ep, resolved) = resolve_provider_and_config(requested, &config);
+                let (twice_ep, twice_resolved) = resolve_provider_and_config(ep, &resolved);
+                assert_eq!(ep, twice_ep);
+                assert_eq!(resolved.onnx_file, twice_resolved.onnx_file);
+            }
+        }
+    }
 
     #[tokio::test]
     async fn test_local_embedding_provider() {

--- a/crates/vera-core/src/local_models/mod.rs
+++ b/crates/vera-core/src/local_models/mod.rs
@@ -223,18 +223,18 @@ impl LocalEmbeddingModelConfig {
         )
     }
 
-    pub fn from_huggingface_repo(repo: impl Into<String>) -> Self {
-        let source = LocalEmbeddingSource::HuggingFace { repo: repo.into() };
+    fn from_source(source: LocalEmbeddingSource) -> Self {
         let mut defaults = Self::defaults_for_source(&source);
         defaults.source = source;
         defaults
     }
 
+    pub fn from_huggingface_repo(repo: impl Into<String>) -> Self {
+        Self::from_source(LocalEmbeddingSource::HuggingFace { repo: repo.into() })
+    }
+
     pub fn from_directory(path: PathBuf) -> Self {
-        Self {
-            source: LocalEmbeddingSource::Directory { path },
-            ..Self::default()
-        }
+        Self::from_source(LocalEmbeddingSource::Directory { path })
     }
 
     /// Switch to the FP16 ONNX model when running on a GPU execution provider.

--- a/crates/vera-core/src/local_models/mod.rs
+++ b/crates/vera-core/src/local_models/mod.rs
@@ -71,6 +71,38 @@ pub fn reranker_execution_provider(
     }
 }
 
+/// Execution provider the embedding session must use for a given backend and
+/// configured model.
+///
+/// CoreML accelerates embeddings (~39ms) for models it can run, and that
+/// acceleration is worth keeping for the default's alternatives (jina keeps
+/// running on CoreML here). CodeRankEmbed is the exception: the CoreML EP
+/// accepts a fused subgraph for its ONNX graph and then fails at inference
+/// with a static output shape mismatch (observed: CoreML static output shape
+/// `{2,1,1,80}` vs. inferred shape `{1,1,1,-1}`), the same class of bug as the
+/// reranker's CoreML failure (see `reranker_execution_provider`). Session
+/// creation succeeds, so the failure only surfaces once inference runs, deep
+/// inside the indexing pipeline, rather than up front. Pinning CodeRankEmbed
+/// to CPU under CoreML costs indexing throughput on Apple Silicon relative to
+/// a model CoreML could accelerate, but the alternative is a hard indexing
+/// failure, so the CPU cost is strictly better. This does not blanket-pin all
+/// embeddings to CPU: any other model, including a custom override, keeps
+/// whatever provider was selected.
+pub fn embedding_execution_provider(
+    ep: crate::config::OnnxExecutionProvider,
+    config: &LocalEmbeddingModelConfig,
+) -> crate::config::OnnxExecutionProvider {
+    let is_coderankembed = matches!(
+        &config.source,
+        LocalEmbeddingSource::HuggingFace { repo } if repo == CODERANK_EMBEDDING_REPO
+    );
+    if ep == crate::config::OnnxExecutionProvider::CoreMl && is_coderankembed {
+        crate::config::OnnxExecutionProvider::Cpu
+    } else {
+        ep
+    }
+}
+
 /// ONNX Runtime version to auto-download. Using 1.24.4 for CUDA 13 support.
 /// The `ort` crate (rc.11) uses `load-dynamic` so any ABI-compatible ORT works.
 pub(super) const ORT_VERSION: &str = "1.24.4";
@@ -148,7 +180,7 @@ pub struct LocalEmbeddingAssetPaths {
 
 impl Default for LocalEmbeddingModelConfig {
     fn default() -> Self {
-        Self::jina()
+        Self::coderankembed()
     }
 }
 
@@ -323,12 +355,21 @@ impl LocalEmbeddingModelConfig {
         })
     }
 
+    /// Template used to fill in the non-source fields (onnx file, tokenizer,
+    /// pooling, query prefix) for a given source.
+    ///
+    /// This is deliberately not `Self::default()`: `default()` is the
+    /// no-override starting point (CodeRankEmbed), but an arbitrary custom
+    /// HuggingFace repo or directory has no reason to inherit CodeRankEmbed's
+    /// CLS pooling and required query prefix. It falls back to jina's
+    /// mean-pooling, no-prefix shape, same as before CodeRankEmbed became the
+    /// default.
     fn defaults_for_source(source: &LocalEmbeddingSource) -> Self {
         match source {
             LocalEmbeddingSource::HuggingFace { repo } if repo == CODERANK_EMBEDDING_REPO => {
                 Self::coderankembed()
             }
-            _ => Self::default(),
+            _ => Self::jina(),
         }
     }
 
@@ -577,6 +618,45 @@ mod finding_tests {
             jina.onnx_data_file.as_deref(),
             Some(EMBEDDING_ONNX_GPU_DATA_FILE)
         );
+    }
+
+    #[test]
+    fn default_embedding_model_is_coderankembed() {
+        assert_eq!(
+            LocalEmbeddingModelConfig::default(),
+            LocalEmbeddingModelConfig::coderankembed()
+        );
+    }
+
+    #[test]
+    fn embedding_runs_on_cpu_under_coreml_for_coderankembed_only() {
+        // CodeRankEmbed cannot run on the CoreML EP: registering it anyway
+        // lets ORT fuse a subgraph that fails at inference with a static
+        // output shape mismatch.
+        let coderank = LocalEmbeddingModelConfig::coderankembed();
+        assert_eq!(
+            embedding_execution_provider(OnnxExecutionProvider::CoreMl, &coderank),
+            OnnxExecutionProvider::Cpu
+        );
+
+        // jina keeps CoreML acceleration: only CodeRankEmbed is pinned to CPU.
+        let jina = LocalEmbeddingModelConfig::jina();
+        assert_eq!(
+            embedding_execution_provider(OnnxExecutionProvider::CoreMl, &jina),
+            OnnxExecutionProvider::CoreMl
+        );
+
+        // Every non-CoreML EP is unaffected, for either model.
+        for ep in [
+            OnnxExecutionProvider::Cpu,
+            OnnxExecutionProvider::Cuda,
+            OnnxExecutionProvider::Rocm,
+            OnnxExecutionProvider::DirectMl,
+            OnnxExecutionProvider::OpenVino,
+        ] {
+            assert_eq!(embedding_execution_provider(ep, &coderank), ep);
+            assert_eq!(embedding_execution_provider(ep, &jina), ep);
+        }
     }
 
     #[test]

--- a/crates/vera-core/src/local_models/tests.rs
+++ b/crates/vera-core/src/local_models/tests.rs
@@ -35,6 +35,21 @@ fn coderankembed_repo_uses_coderank_defaults() {
 }
 
 #[test]
+fn custom_sources_do_not_inherit_coderank_pooling_or_query_prefix() {
+    // `default()` is CodeRankEmbed, but an arbitrary repo or a user-supplied
+    // ONNX directory has no reason to inherit its CLS pooling and mandatory
+    // query prefix — that would silently change their embeddings.
+    for config in [
+        LocalEmbeddingModelConfig::from_huggingface_repo("acme/custom-embeddings"),
+        LocalEmbeddingModelConfig::from_directory(PathBuf::from("/models/custom")),
+    ] {
+        assert_eq!(config.pooling, LocalEmbeddingPooling::Mean);
+        assert_eq!(config.query_prefix, None);
+        assert_eq!(config.query_text("find router code"), "find router code");
+    }
+}
+
+#[test]
 fn parse_cuda_major_version_handles_paths_and_versions() {
     assert_eq!(
         parse_cuda_major_version(r#"C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.2"#),


### PR DESCRIPTION
## What

Makes CodeRankEmbed the default local embedding model (was jina-embeddings-v5-text-nano-retrieval), and pins its CoreML execution to CPU since the CoreML EP cannot run it at all.

## Why

Vera is a code-search tool but defaulted to a general-text embedding model. Published numbers from the model card ([huggingface.co/nomic-ai/CodeRankEmbed](https://huggingface.co/nomic-ai/CodeRankEmbed)):

| Model | CodeSearchNet MRR | CoIR NDCG@10 | Params |
|---|---|---|---|
| CodeRankEmbed | 77.9 | 60.1 | 137M |
| jina-embeddings-v2-base-code | 67.2 | 58.4 | 239M |
| Arctic-Embed-M-Long (CodeRankEmbed's own general-purpose base) | 53.4 | 43.0 | — |

The model actually shipped as Vera's current default publishes no code-retrieval number at all. CodeRankEmbed is also smaller.

**No A/B on Vera's own eval corpus was completed.** The run aborted on the CoreML bug described below, so this quality claim rests entirely on the model author's published benchmarks above, not on Vera-specific measurement. That comparison would be a good follow-up.

**This changes the default and requires existing users to reindex** — the embedding dimension and model identity change, so a stored index built against jina is not compatible with CodeRankEmbed at query time.

## The CoreML blocker

CodeRankEmbed cannot run on the CoreML execution provider. Verified twice on Apple Silicon before this fix:

```
CoreMLExecutionProvider_..._1 node ... GetStaticOutputShape
CoreML static output shape ({2,1,1,80}) and inferred shape ({1,1,1,-1}) have an inconsistent static dimensions (2 vs. 1)
Error: indexing failed: embedding generation failed
```

Session creation succeeds, so this only surfaces once inference actually runs — the same class of bug as #41, where the reranker's CoreML EP accepted a fused subgraph and then died at inference. That was fixed with `reranker_execution_provider`, which maps CoreML → CPU for the reranker specifically.

This PR adds the embedding-side equivalent, `embedding_execution_provider` in `crates/vera-core/src/local_models/mod.rs`, wired into `build_session` in `crates/vera-core/src/embedding/local_provider.rs`. It pins **only CodeRankEmbed** to CPU under CoreML — jina and any custom override keep CoreML acceleration.

**Cost:** CoreML accelerates embeddings only (~39ms), so pinning CodeRankEmbed to CPU under CoreML costs indexing throughput on Apple Silicon relative to a model CoreML could run. The alternative is a hard indexing failure, so paying that cost is strictly better than the status quo.

## Fallout from flipping the default

`defaults_for_source`'s fallback for an arbitrary custom HuggingFace repo or directory source used to reuse `Self::default()` as its field template. With `default()` now CodeRankEmbed, that silently gave custom models CodeRankEmbed's CLS pooling and required query prefix instead of jina's mean-pooling/no-prefix shape. Decoupled it to use `Self::jina()` explicitly as the generic template, restoring prior behavior for custom repos. Caught by the existing `gpu_adjustment_only_changes_the_default_jina_model` test.

## Verification

```
$ cargo build --release -p vera-cli   # clean
$ cargo fmt --check                    # clean
$ cargo clippy -p vera-core --lib      # 5 warnings, all pre-existing (unrelated to this change)
$ cargo test --workspace               # 917 passed, 0 failed
```

End-to-end against the built binary, default backend, no explicit `--onnx-*` flag (`VERA_NO_UPDATE_CHECK=1` set per contributor docs):

````
$ printf 'export function addNumbers(a: number, b: number): number { return a + b; }\n' > a.ts
$ vera index .
Indexing complete!

  Files parsed:        1
  Chunks created:      1
  Embeddings generated: 1
  Elapsed time:        0.37s

$ vera search "add two numbers"
```a.ts:1-1 function:addNumbers
export function addNumbers(a: number, b: number): number { return a + b; }
```
````

Indexing on the default backend, which previously died with the CoreML shape-mismatch error above, now succeeds, and a natural-language query returns the correct semantic match.

## Refs

References #70, #71.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sets `CodeRankEmbed` as the default local embedding model and pins it to CPU under CoreML to avoid an inference-time shape-mismatch crash. The old default was `jina-embeddings-v5-text-nano-retrieval`; existing indices are incompatible and must be rebuilt.

- CoreML behavior: only `CodeRankEmbed` is CPU-pinned via `embedding_execution_provider`; other embedding models keep CoreML acceleration.
- Provider resolution: single-sourced in `embedding_execution_provider` + `resolve_provider_and_config`; `build_session` trusts the resolved provider. Probes share this resolution. `vera doctor` now preflights the effective embedding/reranker providers (not just the requested backend), loads the correct ORT library, inspects assets for the effective EP, and runs dependency checks once per distinct non-CPU provider; the repair hint stays on the requested EP. It also respects the single-library load semantics of `ensure_ort_runtime`.
- Diagnostics: `vera doctor` consumes the already-resolved embedding config, removes the unreachable “unknown placement” branch, and for CoreML reports whether embeddings are CPU-pinned without claiming confirmed GPU execution.
- Custom sources: `from_huggingface_repo`/`from_directory` route through `defaults_for_source` using a Jina template so arbitrary repos/directories keep mean pooling and no query prefix (do not inherit `CodeRankEmbed`’s CLS pooling/query prefix).

**Migration**
- Rebuild any index created with the Jina default before upgrading.

<sup>Written for commit 6475510281c4b9e95fae6c69da8c1acc79cecd6a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/VeraTools/Vera/pull/72?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CodeRankEmbed is now the default local embedding model.
  * Source-specific configurations retain appropriate defaults, including Jina where applicable.
  * Custom repositories and local model directories now use their intended embedding behavior.

* **Bug Fixes**
  * Improved provider selection for CoreML compatibility, including CPU fallback where required.
  * Enhanced embedding provider initialization and inference reliability.
  * Diagnostics now separately report embedding and reranking provider readiness.
  * Updated guidance clearly identifies CPU usage for embedding and reranking.
  * Preserved correct configuration behavior for custom embedding models.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Fixes #70
Fixes #71

