### PR TITLE
perf(indexing): parallelize update path and batch metadata writes/reads (#69)

### DIFF
--- a/crates/vera-core/src/indexing/freshness.rs
+++ b/crates/vera-core/src/indexing/freshness.rs
@@ -5,6 +5,7 @@ use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use anyhow::{Context, Result};
+use rayon::prelude::*;
 use tracing::warn;
 
 use crate::config::IndexingConfig;
@@ -125,25 +126,45 @@ fn count_modified_files(
     metadata_store: &MetadataStore,
     repo_root: &Path,
 ) -> Result<usize> {
-    let mut files_modified = 0usize;
-    for (rel_path, absolute_path) in current_files
+    let tracked_current: Vec<(&String, &PathBuf)> = current_files
         .iter()
         .filter(|(path, _)| tracked_files.contains(path.as_str()))
-    {
-        let content = match crate::discovery::read_source_lossy(absolute_path) {
-            Ok(content) => content,
-            Err(err) => {
-                warn!(
-                    file = %rel_path,
-                    error = %err,
-                    "failed to read file during freshness scan"
-                );
-                files_modified += 1;
-                continue;
-            }
+        .collect();
+
+    // Reading and hashing is I/O and CPU bound, so it runs under rayon. The
+    // metadata lookup that follows stays sequential: `MetadataStore` wraps a
+    // single SQLite connection and is not `Sync`, so it cannot be called from
+    // several rayon threads at once.
+    //
+    // `None` means the file could not be read. It is counted as modified
+    // rather than skipped, so an unreadable tracked file cannot make a stale
+    // index look current (#74).
+    let hashed: Vec<(&String, Option<String>)> = tracked_current
+        .par_iter()
+        .map(|(rel_path, absolute_path)| {
+            let content = match crate::discovery::read_source_lossy(absolute_path) {
+                Ok(content) => content,
+                Err(err) => {
+                    warn!(
+                        file = %rel_path,
+                        error = %err,
+                        "failed to read file during freshness scan"
+                    );
+                    return (*rel_path, None);
+                }
+            };
+            let language = detect_language_for_path(rel_path);
+            let current_hash = hash_for_indexing_source(&content, rel_path, language, repo_root);
+            (*rel_path, Some(current_hash))
+        })
+        .collect();
+
+    let mut files_modified = 0usize;
+    for (rel_path, current_hash) in hashed {
+        let Some(current_hash) = current_hash else {
+            files_modified += 1;
+            continue;
         };
-        let language = detect_language_for_path(rel_path);
-        let current_hash = hash_for_indexing_source(&content, rel_path, language, repo_root);
         let stored_hash = metadata_store
             .get_file_hash(rel_path)
             .with_context(|| format!("failed to read stored hash for {rel_path}"))?;

--- a/crates/vera-core/src/indexing/pipeline.rs
+++ b/crates/vera-core/src/indexing/pipeline.rs
@@ -610,29 +610,21 @@ fn store_index(
         .insert_chunks(chunks)
         .context("failed to insert chunk metadata")?;
 
-    // Store file content hashes for incremental indexing.
-    for (file_path, hash) in file_hashes {
-        metadata_store
-            .set_file_hash(file_path, hash)
-            .context("failed to store file hash")?;
-    }
+    // Store file content hashes for incremental indexing, batched into a
+    // single transaction instead of one commit per file.
+    metadata_store
+        .set_file_hashes_batch(file_hashes)
+        .context("failed to store file hashes")?;
 
     metadata_store
         .insert_file_states(metadata.file_states)
         .context("failed to store file index states")?;
 
-    // Store call-site references for call graph analysis.
-    for (file_path, refs) in file_refs {
-        metadata_store
-            .insert_references(file_path, refs)
-            .context("failed to store references")?;
-    }
-
-    for (file_path, relations) in file_type_relations {
-        metadata_store
-            .insert_type_relations(file_path, relations)
-            .context("failed to store type relations")?;
-    }
+    // Store call-site references and type relations for call graph analysis,
+    // batched into a single transaction instead of up to two commits per file.
+    metadata_store
+        .insert_parse_artifacts_batch(file_refs, file_type_relations)
+        .context("failed to store references and type relations")?;
 
     metadata_store
         .set_index_meta("model_name", metadata.model_name)

--- a/crates/vera-core/src/indexing/update.rs
+++ b/crates/vera-core/src/indexing/update.rs
@@ -19,6 +19,7 @@ use std::path::Path;
 use std::time::Instant;
 
 use anyhow::{Context, Result, bail};
+use rayon::prelude::*;
 use sha2::{Digest, Sha256};
 use tracing::{debug, info, warn};
 
@@ -29,6 +30,8 @@ use crate::embedding::{
     EmbeddingError, EmbeddingProvider, embed_chunks_concurrent_with_progress_and_cancellation,
 };
 use crate::parsing;
+use crate::parsing::references::RawReference;
+use crate::parsing::type_relations::RawTypeRelation;
 use crate::storage::bm25::Bm25Index;
 use crate::storage::metadata::{FileIndexState, FileIndexStatus, MetadataStore};
 use crate::storage::vector::VectorStore;
@@ -451,18 +454,27 @@ where
     let mut parse_errors = Vec::new();
 
     if !files_to_index.is_empty() {
-        // Parse and chunk new/modified files.
-        for (rel_path, content, hash, is_modified) in &files_to_index {
-            cancellation.check()?;
-            let language = detect_language_for_path(rel_path);
+        // Parse and chunk new/modified files. Tree-sitter parsing is CPU-bound,
+        // so this is parallelized with rayon (mirrors pipeline.rs's full-index
+        // path). Results are still staged in `PreparedFile` and written only
+        // after embedding succeeds. Parallelism here must not move any write
+        // earlier.
+        let parsed: Vec<(PreparedFile, Option<FileError>)> = files_to_index
+            .par_iter()
+            .map(|(rel_path, content, hash, is_modified)| {
+                cancellation.check()?;
+                let language = detect_language_for_path(rel_path);
 
-            // For RST, refs come from raw source; chunks from preprocessed.
-            // For all other languages, parse once for both.
-            let (chunks, refs, file_state) = if language == Language::Rst {
-                let refs = parsing::parse_and_extract_references(content, language);
-                let absolute_path = repo_root.join(rel_path);
-                let normalized_source =
-                    match parsing::sphinx::preprocess_rst(content, &absolute_path, &repo_root) {
+                // For RST, refs come from raw source; chunks from preprocessed.
+                // For all other languages, parse once for both.
+                let (chunks, refs, file_state, parse_error) = if language == Language::Rst {
+                    let refs = parsing::parse_and_extract_references(content, language);
+                    let absolute_path = repo_root.join(rel_path);
+                    let normalized_source = match parsing::sphinx::preprocess_rst(
+                        content,
+                        &absolute_path,
+                        &repo_root,
+                    ) {
                         Ok(preprocessed) => Some(preprocessed),
                         Err(err) => {
                             warn!(
@@ -473,38 +485,45 @@ where
                             None
                         }
                     };
-                let src = normalized_source.as_deref().unwrap_or(content);
-                chunk_file_for_update(
-                    src,
-                    rel_path,
-                    language,
-                    config,
-                    Some(refs),
-                    &mut parse_errors,
-                )
-            } else {
-                chunk_file_for_update(content, rel_path, language, config, None, &mut parse_errors)
-            };
+                    let src = normalized_source.as_deref().unwrap_or(content);
+                    chunk_file_for_update(src, rel_path, language, config, Some(refs))
+                } else {
+                    chunk_file_for_update(content, rel_path, language, config, None)
+                };
 
-            let type_relations = parsing::type_relations::extract_type_relations(&chunks);
+                let type_relations = parsing::type_relations::extract_type_relations(&chunks);
 
-            debug!(
-                file = %rel_path,
-                chunks = chunks.len(),
-                refs = refs.len(),
-                type_relations = type_relations.len(),
-                "parsed file"
-            );
+                debug!(
+                    file = %rel_path,
+                    chunks = chunks.len(),
+                    refs = refs.len(),
+                    type_relations = type_relations.len(),
+                    "parsed file"
+                );
 
-            prepared_files.push(PreparedFile {
-                path: rel_path.clone(),
-                hash: hash.clone(),
-                modified: *is_modified,
-                chunks,
-                references: refs,
-                type_relations,
-                state: file_state,
-            });
+                Ok((
+                    PreparedFile {
+                        path: rel_path.clone(),
+                        hash: hash.clone(),
+                        modified: *is_modified,
+                        chunks,
+                        references: refs,
+                        type_relations,
+                        state: file_state,
+                    },
+                    parse_error,
+                ))
+            })
+            .collect::<Result<_>>()?;
+        cancellation.check()?;
+
+        // `files_to_index` order is preserved by `collect`, so the sequential
+        // and parallel paths produce identical `prepared_files` ordering.
+        for (prepared, parse_error) in parsed {
+            prepared_files.push(prepared);
+            if let Some(parse_error) = parse_error {
+                parse_errors.push(parse_error);
+            }
         }
     }
 
@@ -640,18 +659,23 @@ where
                 .delete_file_state(&file.path)
                 .with_context(|| format!("failed to delete file state for {}", file.path))?;
         }
-        for file in &prepared_files {
-            if !file.references.is_empty() {
-                metadata_store
-                    .insert_references(&file.path, &file.references)
-                    .context("failed to store references")?;
-            }
-            if !file.type_relations.is_empty() {
-                metadata_store
-                    .insert_type_relations(&file.path, &file.type_relations)
-                    .context("failed to store type relations")?;
-            }
-        }
+        // Batched into a single transaction instead of up to two commits per
+        // file. This stays at the same point in the sequence as the per-file
+        // writes it replaces, so the "nothing is replaced until embedding
+        // succeeds" guarantee is unchanged.
+        let file_refs: Vec<(String, Vec<RawReference>)> = prepared_files
+            .iter()
+            .filter(|file| !file.references.is_empty())
+            .map(|file| (file.path.clone(), file.references.clone()))
+            .collect();
+        let file_type_relations: Vec<(String, Vec<RawTypeRelation>)> = prepared_files
+            .iter()
+            .filter(|file| !file.type_relations.is_empty())
+            .map(|file| (file.path.clone(), file.type_relations.clone()))
+            .collect();
+        metadata_store
+            .insert_parse_artifacts_batch(&file_refs, &file_type_relations)
+            .context("failed to store references and type relations")?;
 
         if !all_chunks.is_empty() {
             metadata_store
@@ -674,11 +698,13 @@ where
                 .insert_file_states(&file_states)
                 .context("failed to update file index states")?;
         }
-        for file in &prepared_files {
-            metadata_store
-                .set_file_hash(&file.path, &file.hash)
-                .context("failed to update file hash")?;
-        }
+        let file_hashes: Vec<(String, String)> = prepared_files
+            .iter()
+            .map(|file| (file.path.clone(), file.hash.clone()))
+            .collect();
+        metadata_store
+            .set_file_hashes_batch(&file_hashes)
+            .context("failed to update file hashes")?;
     }
 
     // ── 5. Get final counts ──────────────────────────────────────
@@ -730,11 +756,11 @@ fn chunk_file_for_update(
     language: Language,
     config: &VeraConfig,
     refs_override: Option<Vec<parsing::references::RawReference>>,
-    parse_errors: &mut Vec<FileError>,
 ) -> (
     Vec<crate::types::Chunk>,
     Vec<parsing::references::RawReference>,
     FileIndexState,
+    Option<FileError>,
 ) {
     let state =
         |status: FileIndexStatus, tree_has_error: bool, tier0_fallback: bool, chunk_count: u64| {
@@ -760,6 +786,7 @@ fn chunk_file_for_update(
                     diagnostics.used_tier0_fallback,
                     chunk_count,
                 ),
+                None,
             )
         }
         Err(err) => {
@@ -774,14 +801,14 @@ fn chunk_file_for_update(
                     "failed to chunk rst during update; keeping extracted references"
                 );
             }
-            parse_errors.push(FileError {
-                file_path: rel_path.to_string(),
-                error: err.to_string(),
-            });
             (
                 Vec::new(),
                 refs,
                 state(FileIndexStatus::ParseError, false, false, 0),
+                Some(FileError {
+                    file_path: rel_path.to_string(),
+                    error: err.to_string(),
+                }),
             )
         }
     }

--- a/crates/vera-core/src/indexing/update.rs
+++ b/crates/vera-core/src/indexing/update.rs
@@ -30,8 +30,6 @@ use crate::embedding::{
     EmbeddingError, EmbeddingProvider, embed_chunks_concurrent_with_progress_and_cancellation,
 };
 use crate::parsing;
-use crate::parsing::references::RawReference;
-use crate::parsing::type_relations::RawTypeRelation;
 use crate::storage::bm25::Bm25Index;
 use crate::storage::metadata::{FileIndexState, FileIndexStatus, MetadataStore};
 use crate::storage::vector::VectorStore;
@@ -107,6 +105,20 @@ struct PreparedFile {
     references: Vec<parsing::references::RawReference>,
     type_relations: Vec<parsing::type_relations::RawTypeRelation>,
     state: FileIndexState,
+}
+
+fn collect_prepared_results(
+    results: Vec<(PreparedFile, Option<FileError>)>,
+) -> (Vec<PreparedFile>, Vec<FileError>) {
+    let mut prepared_files = Vec::with_capacity(results.len());
+    let mut parse_errors = Vec::new();
+    for (prepared, parse_error) in results {
+        prepared_files.push(prepared);
+        if let Some(parse_error) = parse_error {
+            parse_errors.push(parse_error);
+        }
+    }
+    (prepared_files, parse_errors)
 }
 
 fn processed_file_counts(files: impl IntoIterator<Item = bool>) -> (usize, usize) {
@@ -348,19 +360,30 @@ where
         .into_iter()
         .collect();
 
-    // Read file contents and compute hashes for current files.
-    let mut current_files: HashMap<String, String> = HashMap::new(); // rel_path → content
-    for file in &disc.files {
-        cancellation.check()?;
-        match discovery::read_source_lossy(&file.absolute_path) {
-            Ok(content) => {
-                current_files.insert(file.relative_path.clone(), content);
-            }
-            Err(err) => {
-                warn!(file = %file.relative_path, error = %err, "failed to read file");
-            }
-        }
-    }
+    // File reads are independent and I/O-bound, so run them under rayon.
+    // Unreadable files stay in `current_paths` below but not `current_files`,
+    // preserving their existing index data instead of treating them as deleted.
+    let read_results: Vec<(String, Option<String>)> = disc
+        .files
+        .par_iter()
+        .map(|file| {
+            cancellation.check()?;
+            let content = match discovery::read_source_lossy(&file.absolute_path) {
+                Ok(content) => Some(content),
+                Err(err) => {
+                    warn!(file = %file.relative_path, error = %err, "failed to read file");
+                    None
+                }
+            };
+            Ok((file.relative_path.clone(), content))
+        })
+        .collect::<Result<_>>()?;
+    cancellation.check()?;
+
+    let current_files: HashMap<String, String> = read_results
+        .into_iter()
+        .filter_map(|(path, content)| content.map(|content| (path, content)))
+        .collect();
 
     let current_paths: HashSet<&str> = disc
         .files
@@ -519,12 +542,7 @@ where
 
         // `files_to_index` order is preserved by `collect`, so the sequential
         // and parallel paths produce identical `prepared_files` ordering.
-        for (prepared, parse_error) in parsed {
-            prepared_files.push(prepared);
-            if let Some(parse_error) = parse_error {
-                parse_errors.push(parse_error);
-            }
-        }
+        (prepared_files, parse_errors) = collect_prepared_results(parsed);
     }
 
     let all_chunks: Vec<_> = prepared_files
@@ -663,18 +681,19 @@ where
         // file. This stays at the same point in the sequence as the per-file
         // writes it replaces, so the "nothing is replaced until embedding
         // succeeds" guarantee is unchanged.
-        let file_refs: Vec<(String, Vec<RawReference>)> = prepared_files
+        let file_refs: Vec<(&str, &[parsing::references::RawReference])> = prepared_files
             .iter()
             .filter(|file| !file.references.is_empty())
-            .map(|file| (file.path.clone(), file.references.clone()))
+            .map(|file| (file.path.as_str(), file.references.as_slice()))
             .collect();
-        let file_type_relations: Vec<(String, Vec<RawTypeRelation>)> = prepared_files
-            .iter()
-            .filter(|file| !file.type_relations.is_empty())
-            .map(|file| (file.path.clone(), file.type_relations.clone()))
-            .collect();
+        let file_type_relations: Vec<(&str, &[parsing::type_relations::RawTypeRelation])> =
+            prepared_files
+                .iter()
+                .filter(|file| !file.type_relations.is_empty())
+                .map(|file| (file.path.as_str(), file.type_relations.as_slice()))
+                .collect();
         metadata_store
-            .insert_parse_artifacts_batch(&file_refs, &file_type_relations)
+            .insert_parse_artifacts_batch_borrowed(&file_refs, &file_type_relations)
             .context("failed to store references and type relations")?;
 
         if !all_chunks.is_empty() {
@@ -698,12 +717,12 @@ where
                 .insert_file_states(&file_states)
                 .context("failed to update file index states")?;
         }
-        let file_hashes: Vec<(String, String)> = prepared_files
+        let file_hashes: Vec<(&str, &str)> = prepared_files
             .iter()
-            .map(|file| (file.path.clone(), file.hash.clone()))
+            .map(|file| (file.path.as_str(), file.hash.as_str()))
             .collect();
         metadata_store
-            .set_file_hashes_batch(&file_hashes)
+            .set_file_hashes_batch_borrowed(&file_hashes)
             .context("failed to update file hashes")?;
     }
 

--- a/crates/vera-core/src/indexing/update_tests.rs
+++ b/crates/vera-core/src/indexing/update_tests.rs
@@ -23,7 +23,7 @@ use crate::storage::metadata::{FileIndexState, FileIndexStatus, MetadataStore};
 use crate::storage::vector::VectorStore;
 use crate::types::Language;
 
-use super::{content_hash, processed_file_counts};
+use super::{PreparedFile, collect_prepared_results, content_hash, processed_file_counts};
 
 fn default_config() -> VeraConfig {
     VeraConfig::default()
@@ -158,6 +158,49 @@ fn content_hash_is_hex_sha256() {
 #[test]
 fn processed_file_counts_cover_modified_and_added_files() {
     assert_eq!(processed_file_counts([true, false]), (1, 1));
+}
+
+#[test]
+fn parallel_results_keep_parse_error_files_in_input_order() {
+    let prepared = |path: &str, status| PreparedFile {
+        path: path.to_string(),
+        hash: format!("hash-{path}"),
+        modified: true,
+        chunks: Vec::new(),
+        references: Vec::new(),
+        type_relations: Vec::new(),
+        state: FileIndexState {
+            file_path: path.to_string(),
+            language: "rust".to_string(),
+            status,
+            tree_has_error: false,
+            tier0_fallback: false,
+            chunk_count: 0,
+        },
+    };
+    let error = crate::indexing::pipeline::FileError {
+        file_path: "broken.rs".to_string(),
+        error: "parse failed".to_string(),
+    };
+
+    let (prepared_files, parse_errors) = collect_prepared_results(vec![
+        (prepared("ok.rs", FileIndexStatus::Indexed), None),
+        (
+            prepared("broken.rs", FileIndexStatus::ParseError),
+            Some(error),
+        ),
+    ]);
+
+    assert_eq!(
+        prepared_files
+            .iter()
+            .map(|file| file.path.as_str())
+            .collect::<Vec<_>>(),
+        ["ok.rs", "broken.rs"]
+    );
+    assert_eq!(prepared_files[1].state.status, FileIndexStatus::ParseError);
+    assert_eq!(parse_errors.len(), 1);
+    assert_eq!(parse_errors[0].file_path, "broken.rs");
 }
 
 // ── Update: no changes ──────────────────────────────────────────────

--- a/crates/vera-core/src/retrieval/vector.rs
+++ b/crates/vera-core/src/retrieval/vector.rs
@@ -717,20 +717,17 @@ mod tests {
             })
             .collect();
 
-        // Guard that the fixture actually discriminates: if the distance order
-        // happened to equal insertion order or the `IN (...)` primary-key
-        // order, the assertions below would pass without testing anything.
+        // Guard that the fixture actually discriminates. The chunks are
+        // inserted in id order, so insertion order and the `IN (...)`
+        // primary-key order are the same sequence here; one comparison covers
+        // both. Without this, a fixture whose distance order matched storage
+        // order would satisfy the assertions below without testing anything —
+        // which is exactly what the first version of this test did.
         let expected_paths: Vec<&str> = expected.iter().map(|(path, _, _)| *path).collect();
-        let insertion_paths: Vec<&str> = chunks.iter().map(|c| c.file_path.as_str()).collect();
-        let mut lexicographic_paths = insertion_paths.clone();
-        lexicographic_paths.sort_unstable();
+        let storage_order_paths: Vec<&str> = chunks.iter().map(|c| c.file_path.as_str()).collect();
         assert_ne!(
-            expected_paths, insertion_paths,
-            "fixture is not discriminating: distance order equals insertion order"
-        );
-        assert_ne!(
-            expected_paths, lexicographic_paths,
-            "fixture is not discriminating: distance order equals primary-key order"
+            expected_paths, storage_order_paths,
+            "fixture is not discriminating: distance order equals insertion and primary-key order"
         );
 
         let results =

--- a/crates/vera-core/src/retrieval/vector.rs
+++ b/crates/vera-core/src/retrieval/vector.rs
@@ -201,7 +201,6 @@ fn distance_to_similarity(distance: f64) -> f64 {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use anyhow::Context;
     use crate::embedding::test_helpers::MockProvider;
     use crate::types::{Chunk, Language, SymbolType};
     use std::collections::HashMap;

--- a/crates/vera-core/src/retrieval/vector.rs
+++ b/crates/vera-core/src/retrieval/vector.rs
@@ -84,17 +84,21 @@ pub async fn search_vector_with_stores(
     );
 
     // 3. Hydrate results from metadata store and convert distances to scores.
+    // Fetched in a single batch query instead of one query per candidate
+    // (N+1). SQLite does not preserve `IN (...)` row order, so results are
+    // re-projected back into the original vector-distance order below.
+    let ids: Vec<String> = vector_results
+        .iter()
+        .map(|vr| vr.chunk_id.clone())
+        .collect();
+    let mut chunk_by_id = metadata_store.get_chunks_by_ids(&ids).map_err(|e| {
+        VectorSearchError::StorageError(e.context("failed to batch-fetch chunk metadata"))
+    })?;
+
     let mut results = Vec::with_capacity(vector_results.len());
 
     for vr in &vector_results {
-        let chunk = metadata_store.get_chunk(&vr.chunk_id).map_err(|e| {
-            VectorSearchError::StorageError(e.context(format!(
-                "failed to fetch metadata for chunk: {}",
-                vr.chunk_id
-            )))
-        })?;
-
-        let Some(chunk) = chunk else {
+        let Some(chunk) = chunk_by_id.remove(&vr.chunk_id) else {
             debug!(
                 chunk_id = %vr.chunk_id,
                 "chunk metadata not found, skipping"
@@ -197,8 +201,10 @@ fn distance_to_similarity(distance: f64) -> f64 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use anyhow::Context;
     use crate::embedding::test_helpers::MockProvider;
     use crate::types::{Chunk, Language, SymbolType};
+    use std::collections::HashMap;
 
     /// The pool must never ask sqlite-vec for more than it will serve, and must
     /// report the shortfall so a degraded pool is diagnosable rather than silent.
@@ -633,6 +639,123 @@ mod tests {
                 .unwrap();
 
         assert!(results.is_empty(), "empty store should return no results");
+    }
+
+    #[tokio::test]
+    async fn batch_chunk_fetch_preserves_vector_distance_order() {
+        // Regression test for the N+1 -> batch fetch change: insert chunks
+        // in an order different from the requested id order, and assert the
+        // search results come back in vector-distance order (the order `vr`
+        // came in), not whatever order SQLite happens to return for
+        // `IN (...)` (unspecified) or insertion order.
+        let dim = 8;
+        let metadata_store = MetadataStore::open_in_memory().unwrap();
+
+        // Inserted in id order, which is also the order `WHERE id IN (...)`
+        // returns rows in (the chunks table keys on id). The mock provider
+        // ranks these contents c, a, b by distance, so the expected result
+        // order differs from both — which is what makes the assertions below
+        // able to fail.
+        let chunks = vec![
+            Chunk {
+                id: "a".to_string(),
+                file_path: "src/a.rs".to_string(),
+                line_start: 1,
+                line_end: 2,
+                content: "fn a() {}".to_string(),
+                language: Language::Rust,
+                symbol_type: Some(SymbolType::Function),
+                symbol_name: Some("a".to_string()),
+            },
+            Chunk {
+                id: "b".to_string(),
+                file_path: "src/b.rs".to_string(),
+                line_start: 1,
+                line_end: 2,
+                content: "fn b() {}".to_string(),
+                language: Language::Rust,
+                symbol_type: Some(SymbolType::Function),
+                symbol_name: Some("b".to_string()),
+            },
+            Chunk {
+                id: "c".to_string(),
+                file_path: "src/c.rs".to_string(),
+                line_start: 1,
+                line_end: 2,
+                content: "fn c() {}".to_string(),
+                language: Language::Rust,
+                symbol_type: Some(SymbolType::Function),
+                symbol_name: Some("c".to_string()),
+            },
+        ];
+        metadata_store.insert_chunks(&chunks).unwrap();
+
+        let vector_store = VectorStore::open_in_memory(dim).unwrap();
+        let provider = MockProvider::new(dim);
+        crate::embedding::test_helpers::embed_and_insert_vectors(&vector_store, &provider, &chunks)
+            .await;
+
+        // Ground truth: the distance order the vector store itself reports.
+        // Every candidate must come back paired with its own distance.
+        let query_embedding = generate_query_embedding(&provider, "fn", dim)
+            .await
+            .unwrap();
+        let vector_results = vector_store.search(&query_embedding, chunks.len()).unwrap();
+        assert_eq!(vector_results.len(), chunks.len());
+
+        let chunk_by_id: HashMap<&str, &Chunk> =
+            chunks.iter().map(|c| (c.id.as_str(), c)).collect();
+        let expected: Vec<(&str, &str, f64)> = vector_results
+            .iter()
+            .map(|vr| {
+                let chunk = chunk_by_id[vr.chunk_id.as_str()];
+                (
+                    chunk.file_path.as_str(),
+                    chunk.content.as_str(),
+                    distance_to_similarity(vr.distance),
+                )
+            })
+            .collect();
+
+        // Guard that the fixture actually discriminates: if the distance order
+        // happened to equal insertion order or the `IN (...)` primary-key
+        // order, the assertions below would pass without testing anything.
+        let expected_paths: Vec<&str> = expected.iter().map(|(path, _, _)| *path).collect();
+        let insertion_paths: Vec<&str> = chunks.iter().map(|c| c.file_path.as_str()).collect();
+        let mut lexicographic_paths = insertion_paths.clone();
+        lexicographic_paths.sort_unstable();
+        assert_ne!(
+            expected_paths, insertion_paths,
+            "fixture is not discriminating: distance order equals insertion order"
+        );
+        assert_ne!(
+            expected_paths, lexicographic_paths,
+            "fixture is not discriminating: distance order equals primary-key order"
+        );
+
+        let results =
+            search_vector_with_stores(&vector_store, &metadata_store, &provider, "fn", 10)
+                .await
+                .unwrap();
+
+        // Assert the pairing, not just that scores descend. Scores descend for
+        // any implementation that emits one result per candidate in candidate
+        // order, because the vector store already returns rows sorted by
+        // distance — so a monotonicity check cannot catch chunks being paired
+        // with the wrong neighbour's distance.
+        assert_eq!(
+            results.len(),
+            expected.len(),
+            "batch fetch dropped candidates"
+        );
+        let actual: Vec<(&str, &str, f64)> = results
+            .iter()
+            .map(|r| (r.file_path.as_str(), r.content.as_str(), r.score))
+            .collect();
+        assert_eq!(
+            actual, expected,
+            "each chunk must come back paired with its own distance, in vector-distance order"
+        );
     }
 
     #[tokio::test]

--- a/crates/vera-core/src/storage/metadata.rs
+++ b/crates/vera-core/src/storage/metadata.rs
@@ -1285,6 +1285,102 @@ mod tests {
     }
 
     #[test]
+    fn set_file_hashes_batch_persists_every_row_and_replaces_on_repeat() {
+        let store = MetadataStore::open_in_memory().unwrap();
+        store
+            .set_file_hashes_batch(&[
+                ("src/main.rs".to_string(), "hash-a".to_string()),
+                ("src/lib.py".to_string(), "hash-b".to_string()),
+            ])
+            .unwrap();
+        assert_eq!(
+            store.get_file_hash("src/main.rs").unwrap().as_deref(),
+            Some("hash-a")
+        );
+        assert_eq!(
+            store.get_file_hash("src/lib.py").unwrap().as_deref(),
+            Some("hash-b")
+        );
+
+        store
+            .set_file_hashes_batch(&[("src/main.rs".to_string(), "hash-c".to_string())])
+            .unwrap();
+        assert_eq!(
+            store.get_file_hash("src/main.rs").unwrap().as_deref(),
+            Some("hash-c")
+        );
+    }
+
+    #[test]
+    fn batch_writes_accept_empty_input() {
+        // The batch methods early-return before opening a transaction. An
+        // update run with nothing to write must not error.
+        let store = MetadataStore::open_in_memory().unwrap();
+        store.set_file_hashes_batch(&[]).unwrap();
+        store.insert_parse_artifacts_batch(&[], &[]).unwrap();
+        assert!(store.get_chunks_by_ids(&[]).unwrap().is_empty());
+    }
+
+    #[test]
+    fn insert_parse_artifacts_batch_persists_both_kinds_across_files() {
+        let store = MetadataStore::open_in_memory().unwrap();
+        let refs = vec![
+            (
+                "src/main.rs".to_string(),
+                vec![crate::parsing::references::RawReference {
+                    callee: "helper".to_string(),
+                    caller: Some("main".to_string()),
+                    line: 3,
+                }],
+            ),
+            (
+                "src/lib.py".to_string(),
+                vec![crate::parsing::references::RawReference {
+                    callee: "helper".to_string(),
+                    caller: None,
+                    line: 9,
+                }],
+            ),
+        ];
+        let relations = vec![(
+            "src/main.rs".to_string(),
+            vec![RawTypeRelation {
+                owner: "Config".to_string(),
+                target: "Display".to_string(),
+                line: 12,
+                kind: TypeRelationKind::Conforms,
+            }],
+        )];
+        store
+            .insert_parse_artifacts_batch(&refs, &relations)
+            .unwrap();
+
+        // Both files' references land, not just the first.
+        assert_eq!(store.find_callers("helper").unwrap().len(), 2);
+        assert_eq!(store.find_type_relations("Display").unwrap().len(), 1);
+    }
+
+    #[test]
+    fn get_chunks_by_ids_returns_only_requested_rows() {
+        let store = MetadataStore::open_in_memory().unwrap();
+        store.insert_chunks(&sample_chunks()).unwrap();
+
+        let found = store
+            .get_chunks_by_ids(&["src/main.rs:0".to_string(), "src/lib.py:0".to_string()])
+            .unwrap();
+        assert_eq!(found.len(), 2);
+        assert_eq!(found["src/main.rs:0"].symbol_name.as_deref(), Some("main"));
+        assert!(!found.contains_key("src/main.rs:1"));
+
+        // A missing id is skipped rather than erroring, which is what the
+        // caller's "chunk metadata not found" branch relies on.
+        let partial = store
+            .get_chunks_by_ids(&["src/main.rs:0".to_string(), "does/not/exist:9".to_string()])
+            .unwrap();
+        assert_eq!(partial.len(), 1);
+    }
+
+    #[test]
     fn get_chunk_by_id() {
         let store = MetadataStore::open_in_memory().unwrap();
         store.insert_chunks(&sample_chunks()).unwrap();

--- a/crates/vera-core/src/storage/metadata.rs
+++ b/crates/vera-core/src/storage/metadata.rs
@@ -1309,6 +1309,12 @@ mod tests {
             store.get_file_hash("src/main.rs").unwrap().as_deref(),
             Some("hash-c")
         );
+        // Guards against a partial write taking out rows the batch never
+        // mentioned: re-checking only src/main.rs would miss that.
+        assert_eq!(
+            store.get_file_hash("src/lib.py").unwrap().as_deref(),
+            Some("hash-b")
+        );
     }
 
     #[test]
@@ -1355,8 +1361,17 @@ mod tests {
             .insert_parse_artifacts_batch(&refs, &relations)
             .unwrap();
 
-        // Both files' references land, not just the first.
-        assert_eq!(store.find_callers("helper").unwrap().len(), 2);
+        // Both files' references land, not just the first. A count of 2 alone
+        // would also pass if both rows were stored under one file path, so
+        // assert the paths themselves.
+        let mut caller_paths: Vec<String> = store
+            .find_callers("helper")
+            .unwrap()
+            .into_iter()
+            .map(|caller_ref| caller_ref.file_path)
+            .collect();
+        caller_paths.sort();
+        assert_eq!(caller_paths, vec!["src/lib.py", "src/main.rs"]);
         assert_eq!(store.find_type_relations("Display").unwrap().len(), 1);
     }
 

--- a/crates/vera-core/src/storage/metadata.rs
+++ b/crates/vera-core/src/storage/metadata.rs
@@ -572,7 +572,7 @@ impl MetadataStore {
 
     /// Store a file content hash for incremental indexing.
     pub fn set_file_hash(&self, file_path: &str, hash: &str) -> Result<()> {
-        self.set_file_hashes_batch(&[(file_path.to_string(), hash.to_string())])
+        self.set_file_hashes_batch_borrowed(&[(file_path, hash)])
     }
 
     /// Get the stored content hash for a file.
@@ -653,7 +653,7 @@ impl MetadataStore {
         file_path: &str,
         refs: &[crate::parsing::references::RawReference],
     ) -> Result<()> {
-        self.insert_parse_artifacts_batch(&[(file_path.to_string(), refs.to_vec())], &[])
+        self.insert_parse_artifacts_batch_borrowed(&[(file_path, refs)], &[])
     }
 
     /// Insert a batch of explicit type relations for a single file.
@@ -662,7 +662,7 @@ impl MetadataStore {
         file_path: &str,
         relations: &[RawTypeRelation],
     ) -> Result<()> {
-        self.insert_parse_artifacts_batch(&[], &[(file_path.to_string(), relations.to_vec())])
+        self.insert_parse_artifacts_batch_borrowed(&[], &[(file_path, relations)])
     }
 
     /// Store content hashes for many files in a single transaction.
@@ -670,6 +670,18 @@ impl MetadataStore {
     /// Equivalent to calling [`Self::set_file_hash`] once per file, but
     /// issues one commit for the whole batch instead of one per file.
     pub fn set_file_hashes_batch(&self, hashes: &[(String, String)]) -> Result<()> {
+        if hashes.is_empty() {
+            return Ok(());
+        }
+
+        let borrowed: Vec<(&str, &str)> = hashes
+            .iter()
+            .map(|(file_path, hash)| (file_path.as_str(), hash.as_str()))
+            .collect();
+        self.set_file_hashes_batch_borrowed(&borrowed)
+    }
+
+    pub(crate) fn set_file_hashes_batch_borrowed(&self, hashes: &[(&str, &str)]) -> Result<()> {
         if hashes.is_empty() {
             return Ok(());
         }
@@ -709,6 +721,26 @@ impl MetadataStore {
             return Ok(());
         }
 
+        let borrowed_refs: Vec<(&str, &[crate::parsing::references::RawReference])> = file_refs
+            .iter()
+            .map(|(file_path, refs)| (file_path.as_str(), refs.as_slice()))
+            .collect();
+        let borrowed_relations: Vec<(&str, &[RawTypeRelation])> = file_type_relations
+            .iter()
+            .map(|(file_path, relations)| (file_path.as_str(), relations.as_slice()))
+            .collect();
+        self.insert_parse_artifacts_batch_borrowed(&borrowed_refs, &borrowed_relations)
+    }
+
+    pub(crate) fn insert_parse_artifacts_batch_borrowed(
+        &self,
+        file_refs: &[(&str, &[crate::parsing::references::RawReference])],
+        file_type_relations: &[(&str, &[RawTypeRelation])],
+    ) -> Result<()> {
+        if file_refs.is_empty() && file_type_relations.is_empty() {
+            return Ok(());
+        }
+
         let tx = self
             .conn
             .unchecked_transaction()
@@ -720,7 +752,7 @@ impl MetadataStore {
                      VALUES (?1, ?2, ?3, ?4)",
                 )
                 .context("failed to prepare batch reference insert")?;
-            for (file_path, refs) in file_refs {
+            for &(file_path, refs) in file_refs {
                 for r in refs {
                     ref_stmt
                         .execute(params![file_path, r.line, r.callee, r.caller])
@@ -734,7 +766,7 @@ impl MetadataStore {
                      VALUES (?1, ?2, ?3, ?4, ?5)",
                 )
                 .context("failed to prepare batch type relation insert")?;
-            for (file_path, relations) in file_type_relations {
+            for &(file_path, relations) in file_type_relations {
                 for relation in relations {
                     relation_stmt
                         .execute(params![

--- a/crates/vera-core/src/storage/metadata.rs
+++ b/crates/vera-core/src/storage/metadata.rs
@@ -3,6 +3,8 @@
 //! Stores chunk metadata (file path, line ranges, language, symbol info)
 //! in a SQLite database. Uses WAL mode for concurrent read performance.
 
+use std::collections::HashMap;
+
 use anyhow::{Context, Result};
 use rusqlite::{Connection, OptionalExtension, params};
 
@@ -344,6 +346,42 @@ impl MetadataStore {
         }
     }
 
+    /// Get multiple chunks by id in a single query.
+    ///
+    /// Returns a lookup map keyed by chunk id rather than a `Vec`, because
+    /// SQLite does not preserve any particular row order for `IN (...)`
+    /// queries. Callers that need results in a specific order (e.g.
+    /// vector-distance ranking) must re-project from the map themselves.
+    pub fn get_chunks_by_ids(&self, ids: &[String]) -> Result<HashMap<String, Chunk>> {
+        if ids.is_empty() {
+            return Ok(HashMap::new());
+        }
+
+        let placeholders = std::iter::repeat_n("?", ids.len())
+            .collect::<Vec<_>>()
+            .join(",");
+        let sql = format!(
+            "SELECT id, file_path, line_start, line_end, content, language,
+                    symbol_type, symbol_name
+             FROM chunks WHERE id IN ({placeholders})"
+        );
+        let mut stmt = self
+            .conn
+            .prepare(&sql)
+            .context("failed to prepare batch chunk query")?;
+
+        let rows = stmt
+            .query_map(rusqlite::params_from_iter(ids.iter()), |row| {
+                Ok(row_to_chunk(row))
+            })
+            .context("failed to query chunks by id batch")?;
+
+        let chunks: Vec<Chunk> = collect_rows(rows)?
+            .into_iter()
+            .collect::<Result<Vec<_>>>()?;
+        Ok(chunks.into_iter().map(|c| (c.id.clone(), c)).collect())
+    }
+
     /// Get all chunks for a given file path.
     pub fn get_chunks_by_file(&self, file_path: &str) -> Result<Vec<Chunk>> {
         let mut stmt = self
@@ -534,14 +572,7 @@ impl MetadataStore {
 
     /// Store a file content hash for incremental indexing.
     pub fn set_file_hash(&self, file_path: &str, hash: &str) -> Result<()> {
-        self.conn
-            .execute(
-                "INSERT OR REPLACE INTO file_hashes (file_path, content_hash)
-                 VALUES (?1, ?2)",
-                params![file_path, hash],
-            )
-            .context("failed to set file hash")?;
-        Ok(())
+        self.set_file_hashes_batch(&[(file_path.to_string(), hash.to_string())])
     }
 
     /// Get the stored content hash for a file.
@@ -622,25 +653,7 @@ impl MetadataStore {
         file_path: &str,
         refs: &[crate::parsing::references::RawReference],
     ) -> Result<()> {
-        let tx = self
-            .conn
-            .unchecked_transaction()
-            .context("failed to begin reference transaction")?;
-        {
-            let mut stmt = self
-                .conn
-                .prepare_cached(
-                    "INSERT INTO [references] (file_path, line, callee, caller)
-                     VALUES (?1, ?2, ?3, ?4)",
-                )
-                .context("failed to prepare reference insert")?;
-            for r in refs {
-                stmt.execute(params![file_path, r.line, r.callee, r.caller])
-                    .context("failed to insert reference")?;
-            }
-        }
-        tx.commit().context("failed to commit reference inserts")?;
-        Ok(())
+        self.insert_parse_artifacts_batch(&[(file_path.to_string(), refs.to_vec())], &[])
     }
 
     /// Insert a batch of explicit type relations for a single file.
@@ -649,31 +662,96 @@ impl MetadataStore {
         file_path: &str,
         relations: &[RawTypeRelation],
     ) -> Result<()> {
+        self.insert_parse_artifacts_batch(&[], &[(file_path.to_string(), relations.to_vec())])
+    }
+
+    /// Store content hashes for many files in a single transaction.
+    ///
+    /// Equivalent to calling [`Self::set_file_hash`] once per file, but
+    /// issues one commit for the whole batch instead of one per file.
+    pub fn set_file_hashes_batch(&self, hashes: &[(String, String)]) -> Result<()> {
+        if hashes.is_empty() {
+            return Ok(());
+        }
+
         let tx = self
             .conn
             .unchecked_transaction()
-            .context("failed to begin type relation transaction")?;
+            .context("failed to begin file hash batch transaction")?;
         {
-            let mut stmt = self
-                .conn
+            let mut stmt = tx
+                .prepare_cached(
+                    "INSERT OR REPLACE INTO file_hashes (file_path, content_hash)
+                     VALUES (?1, ?2)",
+                )
+                .context("failed to prepare batch file hash insert")?;
+            for (file_path, hash) in hashes {
+                stmt.execute(params![file_path, hash])
+                    .with_context(|| format!("failed to set file hash: {file_path}"))?;
+            }
+        }
+        tx.commit().context("failed to commit file hash batch")?;
+        Ok(())
+    }
+
+    /// Store call-site references and type relations for many files in a
+    /// single transaction.
+    ///
+    /// Equivalent to calling [`Self::insert_references`] and
+    /// [`Self::insert_type_relations`] once per file, but issues one commit
+    /// for the whole batch instead of up to two per file.
+    pub fn insert_parse_artifacts_batch(
+        &self,
+        file_refs: &[(String, Vec<crate::parsing::references::RawReference>)],
+        file_type_relations: &[(String, Vec<RawTypeRelation>)],
+    ) -> Result<()> {
+        if file_refs.is_empty() && file_type_relations.is_empty() {
+            return Ok(());
+        }
+
+        let tx = self
+            .conn
+            .unchecked_transaction()
+            .context("failed to begin parse artifacts batch transaction")?;
+        {
+            let mut ref_stmt = tx
+                .prepare_cached(
+                    "INSERT INTO [references] (file_path, line, callee, caller)
+                     VALUES (?1, ?2, ?3, ?4)",
+                )
+                .context("failed to prepare batch reference insert")?;
+            for (file_path, refs) in file_refs {
+                for r in refs {
+                    ref_stmt
+                        .execute(params![file_path, r.line, r.callee, r.caller])
+                        .with_context(|| format!("failed to insert reference for {file_path}"))?;
+                }
+            }
+
+            let mut relation_stmt = tx
                 .prepare_cached(
                     "INSERT INTO type_relations (file_path, line, owner, target, kind)
                      VALUES (?1, ?2, ?3, ?4, ?5)",
                 )
-                .context("failed to prepare type relation insert")?;
-            for relation in relations {
-                stmt.execute(params![
-                    file_path,
-                    relation.line,
-                    relation.owner,
-                    relation.target,
-                    relation.kind.as_str(),
-                ])
-                .context("failed to insert type relation")?;
+                .context("failed to prepare batch type relation insert")?;
+            for (file_path, relations) in file_type_relations {
+                for relation in relations {
+                    relation_stmt
+                        .execute(params![
+                            file_path,
+                            relation.line,
+                            relation.owner,
+                            relation.target,
+                            relation.kind.as_str(),
+                        ])
+                        .with_context(|| {
+                            format!("failed to insert type relation for {file_path}")
+                        })?;
+                }
             }
         }
         tx.commit()
-            .context("failed to commit type relation inserts")?;
+            .context("failed to commit parse artifacts batch")?;
         Ok(())
     }
 


### PR DESCRIPTION
## Summary

Implements all four performance fixes from #69:

1. **Parallelize serial file parsing in the update path** (`indexing/update.rs`) — tree-sitter parsing of modified/added files was a serial `for` loop; now uses rayon `par_iter`, mirroring the shape already used by the full-index path in `pipeline.rs`.
2. **Parallelize sequential file reads for freshness/update classification** (`indexing/update.rs`, `indexing/freshness.rs`) — file reads (and, in freshness.rs, the content hashing) are now done with rayon `par_iter` instead of a serial loop over every current file.
3. **Batch per-file transactions into one transaction** (`storage/metadata.rs`, `indexing/pipeline.rs`, `indexing/update.rs`) — added `MetadataStore::set_file_hashes_batch` and `MetadataStore::insert_parse_artifacts_batch`, each wrapping the previous per-file `set_file_hash` / `insert_references` / `insert_type_relations` calls in a single transaction. Used from both the full-index and incremental-update paths. The existing single-file methods are left in place (still used by tests and elsewhere).
4. **Batch chunk fetch to eliminate N+1 query** (`retrieval/vector.rs`, `storage/metadata.rs`) — added `MetadataStore::get_chunks_by_ids` (single `SELECT ... WHERE id IN (...)`), used in `search_vector_with_stores` instead of one `get_chunk` call per candidate.

Nothing was skipped — all four items from the issue landed.

## Correctness

These are correctness-preserving refactors; no ranking/retrieval-result change, so no Semble benchmark evidence is included (relevance ordering is unchanged).

For fix 4 specifically: the same chunks are returned in the same order as before. SQLite does not guarantee row order for `IN (...)`, so the batch result is collected into a lookup map and re-projected back into the original vector-distance order (the order candidates arrived in from the vector store), preserving the existing early-break-at-`limit` behavior. Only the number of SQL round-trips changes (N queries → 1 batch query). A regression test (`batch_chunk_fetch_preserves_vector_distance_order` in `retrieval/vector.rs`) inserts chunks out of request order and asserts results come back in the requested order, not storage/insertion order.

For fixes 1 and 2, metadata-store writes that happened inside the original per-file loops are collected from the parallel parsing results and applied sequentially afterward — `MetadataStore` wraps a single non-`Sync` SQLite `Connection`, so it can't be called concurrently from multiple rayon worker threads.

## Verification

Run from a git worktree on `perf/parallel-update-path`, cut from `origin/master`.

- `cargo build -p vera-core --lib` — clean build after each fix.
- `cargo fmt --check` — clean, zero diffs.
- `cargo clippy -p vera-core --lib` — exactly the 5 pre-existing warnings (`pip_package_for_ep`, `CUDA_RUNTIME_LIBRARY_PREFIXES`, `parse_cuda_major_from_runtime_library_entry`, one unused import, one unused variable, all in `local_models/`), no new ones introduced.
- `cargo test --workspace` — **921 passed, 0 failed, 0 ignored** across the workspace (`vera` 92, `vera_core` 756, `vera_eval` 35, `vera_mcp` 37, `vera_serve` 1; doc-tests 0/0/0).

## Test plan

- [x] `cargo build -p vera-core --lib`
- [x] `cargo fmt --check`
- [x] `cargo clippy -p vera-core --lib` (no new warnings vs. baseline)
- [x] `cargo test --workspace` (921/921 passing)
- [x] New regression test added for batch chunk fetch order preservation

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Parallelizes incremental update and freshness scans and batches metadata I/O, while preserving write-after-embedding atomicity; retrieval now batch-fetches chunk metadata and preserves ranking. Old behavior: serial per-file parse/commits and an N+1 chunk fetch; new behavior: `rayon`-parallel reads/parsing and single-transaction batch writes/reads with identical results, order, and cancellation semantics.

- Update path: file reads and hashing run under `rayon`; parsing/chunking uses `par_iter` and preserves input order; `chunk_file_for_update` returns a per-file parse error for collection; unreadable files keep existing index data; writes move to `insert_parse_artifacts_batch` and `set_file_hashes_batch` (borrowed variants avoid copies) and still occur only after embeddings succeed.
- Freshness: parallelizes file reads and content hashing; counts unreadable tracked files as modified; keeps `MetadataStore` lookups sequential due to a single SQLite connection.
- Retrieval: replaces per-candidate `get_chunk` with `get_chunks_by_ids`; re-projects to vector-distance order; regression test asserts each chunk remains paired with its own distance.
- Storage: adds `get_chunks_by_ids`, `set_file_hashes_batch`, and `insert_parse_artifacts_batch` (single-file methods delegate); early-returns on empty input; tests cover multi-row persistence, replace-on-repeat, partial-result behavior, and cross-file reference persistence.
- Migration: none.

<sup>Written for commit 03eaeed51b6af7ae8baa45b2d0ffc59a43551160. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/VeraTools/Vera/pull/73?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

Fixes #69


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Faster indexing and incremental updates through parallel file processing.
  * More efficient persistence of file metadata and parsed results through batched operations.
  * Faster vector search by retrieving matching chunk details in batches.

* **Reliability**
  * Preserved search ranking and result ordering.
  * Unreadable files continue to be skipped with warnings.
  * Parsing errors are reported per file without interrupting other updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
