### PR TITLE
fix(indexing): treat unreadable tracked files as stale in the freshness scan

### DIFF
--- a/crates/vera-core/src/indexing/freshness.rs
+++ b/crates/vera-core/src/indexing/freshness.rs
@@ -109,6 +109,22 @@ pub fn detect_staleness(
         .filter(|path| !current_files.contains_key(path.as_str()))
         .count();
 
+    let files_modified =
+        count_modified_files(&current_files, &tracked_files, &metadata_store, &repo_root)?;
+
+    Ok(IndexFreshness {
+        files_added,
+        files_modified,
+        files_deleted,
+    })
+}
+
+fn count_modified_files(
+    current_files: &HashMap<String, PathBuf>,
+    tracked_files: &HashSet<String>,
+    metadata_store: &MetadataStore,
+    repo_root: &Path,
+) -> Result<usize> {
     let mut files_modified = 0usize;
     for (rel_path, absolute_path) in current_files
         .iter()
@@ -122,11 +138,12 @@ pub fn detect_staleness(
                     error = %err,
                     "failed to read file during freshness scan"
                 );
+                files_modified += 1;
                 continue;
             }
         };
         let language = detect_language_for_path(rel_path);
-        let current_hash = hash_for_indexing_source(&content, rel_path, language, &repo_root);
+        let current_hash = hash_for_indexing_source(&content, rel_path, language, repo_root);
         let stored_hash = metadata_store
             .get_file_hash(rel_path)
             .with_context(|| format!("failed to read stored hash for {rel_path}"))?;
@@ -135,11 +152,7 @@ pub fn detect_staleness(
         }
     }
 
-    Ok(IndexFreshness {
-        files_added,
-        files_modified,
-        files_deleted,
-    })
+    Ok(files_modified)
 }
 
 fn load_indexing_config(
@@ -228,6 +241,28 @@ mod tests {
 
         let freshness = detect_staleness(dir.path(), &IndexingConfig::default()).unwrap();
         assert_eq!(freshness.files_modified, 1);
+    }
+
+    #[test]
+    fn freshness_scan_marks_tracked_read_failures_as_modified() {
+        let dir = tempdir().unwrap();
+        let read_failure_path = dir.path().join("src/unreadable.rs");
+        // Model a tracked file being replaced by a directory after discovery.
+        std::fs::create_dir_all(&read_failure_path).unwrap();
+
+        let index_dir = dir.path().join(".vera");
+        std::fs::create_dir_all(&index_dir).unwrap();
+        let metadata = MetadataStore::open(&index_dir.join("metadata.db")).unwrap();
+        metadata
+            .set_file_hash("src/unreadable.rs", &content_hash("fn indexed() {}\n"))
+            .unwrap();
+
+        let current_files = HashMap::from([("src/unreadable.rs".to_string(), read_failure_path)]);
+        let tracked_files = HashSet::from(["src/unreadable.rs".to_string()]);
+        let files_modified =
+            count_modified_files(&current_files, &tracked_files, &metadata, dir.path()).unwrap();
+
+        assert_eq!(files_modified, 1);
     }
 
     #[test]


### PR DESCRIPTION
## Problem

`detect_staleness` skipped tracked files when the freshness scan could not read them. If all tracked reads failed, the scan returned zero changes and callers treated the index as current.

## Fix

Count a tracked-file read failure as a modified file after logging the existing warning. This keeps the existing `IndexFreshness` contract and fails safe without aborting the scan.

## Tests

- Added a regression test for a tracked path replaced by a directory.
- `CARGO_TARGET_DIR=$HOME/.cache/vera-targets/i74 cargo test --workspace` (935 tests passed)
- `CARGO_TARGET_DIR=$HOME/.cache/vera-targets/i74 cargo fmt --all -- --check`
- `CARGO_TARGET_DIR=$HOME/.cache/vera-targets/i74 cargo clippy -p vera-core --lib -- -D warnings`
- The requested `--all-targets` clippy gate is blocked by the pre-existing unused `anyhow::Context` import in `crates/vera-core/src/retrieval/vector.rs`.

Fixes #74


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Treat unreadable tracked files as modified during the freshness scan to fail safe. Previously, the scan skipped unreadable tracked files; if all tracked reads failed, it reported zero changes and callers treated the index as current.

**Review notes**
- Count a tracked-file read failure as one modified file; keep the existing warning log and continue the scan.
- Extract `count_modified_files` from `detect_staleness` to compute `files_modified`.
- Adjust `hash_for_indexing_source` call to pass `repo_root` by value.
- Add a regression test for a tracked path replaced by a directory.
- No config or migration changes.

<sup>Written for commit f0ce4739c03a380ef538122c3f72cce9a461c06c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/VeraTools/Vera/pull/77?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of stale repository files.
  * Files that cannot be read, including files replaced by unreadable directories, are now correctly recognized as modified.
  * Repository file checks now use consistent paths for more reliable freshness results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->