### PR TITLE
perf(storage): index the lower() lookups instead of scanning

### DIFF
--- a/crates/vera-core/src/storage/metadata.rs
+++ b/crates/vera-core/src/storage/metadata.rs
@@ -103,6 +103,44 @@ pub struct LanguageHealthStat {
     pub files_with_parse_failures: u64,
 }
 
+/// Case-insensitive lookup queries, held as constants so the query-plan tests
+/// assert against the exact text the production methods run.
+///
+/// An expression index only applies when the index expression matches the
+/// query text. A test that asserted on its own copy of the SQL would keep
+/// passing after the original drifted, and the planner would silently fall
+/// back to a full scan with nothing failing.
+const SQL_CHUNKS_BY_SYMBOL_NAME: &str =
+    "SELECT id, file_path, line_start, line_end, content, language,
+                        symbol_type, symbol_name
+                 FROM chunks
+                 WHERE lower(symbol_name) = lower(?1)
+                 ORDER BY file_path, line_start";
+
+const SQL_FIND_CALLERS: &str = "SELECT file_path, line, caller FROM [references]
+                 WHERE lower(callee) = lower(?1)
+                 ORDER BY file_path, line";
+
+const SQL_FIND_CALLEES: &str = "SELECT file_path, line, callee FROM [references]
+                 WHERE lower(caller) = lower(?1)
+                 ORDER BY file_path, line";
+
+const SQL_FIND_TYPE_RELATIONS: &str = "SELECT file_path, line, owner, target, kind
+                 FROM type_relations
+                 WHERE lower(target) = lower(?1)
+                 ORDER BY file_path, line, owner";
+
+const SQL_FIND_DEAD_SYMBOLS: &str = "SELECT c.symbol_name, c.file_path, c.line_start, c.symbol_type
+                 FROM chunks c
+                 WHERE c.symbol_name IS NOT NULL
+                   AND c.symbol_type IN ('function', 'method')
+                   AND lower(c.symbol_name) NOT IN ('main', 'new', 'default', 'drop', 'clone', 'fmt', 'from', 'into', 'deref', 'init', 'setup', 'teardown')
+                   AND NOT EXISTS (
+                       SELECT 1 FROM [references] r
+                       WHERE lower(r.callee) = lower(c.symbol_name)
+                   )
+                 ORDER BY c.file_path, c.line_start";
+
 /// SQLite-backed metadata store for chunk attributes.
 pub struct MetadataStore {
     conn: Connection,
@@ -329,13 +367,7 @@ impl MetadataStore {
     pub fn get_chunks_by_symbol_name(&self, symbol_name: &str) -> Result<Vec<Chunk>> {
         let mut stmt = self
             .conn
-            .prepare_cached(
-                "SELECT id, file_path, line_start, line_end, content, language,
-                        symbol_type, symbol_name
-                 FROM chunks
-                 WHERE lower(symbol_name) = lower(?1)
-                 ORDER BY file_path, line_start",
-            )
+            .prepare_cached(SQL_CHUNKS_BY_SYMBOL_NAME)
             .context("failed to prepare symbol chunks query")?;
 
         let rows = stmt
@@ -671,11 +703,7 @@ impl MetadataStore {
     pub fn find_callers(&self, symbol_name: &str) -> Result<Vec<CallerRef>> {
         let mut stmt = self
             .conn
-            .prepare_cached(
-                "SELECT file_path, line, caller FROM [references]
-                 WHERE lower(callee) = lower(?1)
-                 ORDER BY file_path, line",
-            )
+            .prepare_cached(SQL_FIND_CALLERS)
             .context("failed to prepare callers query")?;
         let rows = stmt
             .query_map(params![symbol_name], |row| {
@@ -693,12 +721,7 @@ impl MetadataStore {
     pub fn find_type_relations(&self, symbol_name: &str) -> Result<Vec<TypeRelationRef>> {
         let mut stmt = self
             .conn
-            .prepare_cached(
-                "SELECT file_path, line, owner, target, kind
-                 FROM type_relations
-                 WHERE lower(target) = lower(?1)
-                 ORDER BY file_path, line, owner",
-            )
+            .prepare_cached(SQL_FIND_TYPE_RELATIONS)
             .context("failed to prepare type relation query")?;
         let rows = stmt
             .query_map(params![symbol_name], |row| {
@@ -724,11 +747,7 @@ impl MetadataStore {
     pub fn find_callees(&self, symbol_name: &str) -> Result<Vec<CalleeRef>> {
         let mut stmt = self
             .conn
-            .prepare_cached(
-                "SELECT file_path, line, callee FROM [references]
-                 WHERE lower(caller) = lower(?1)
-                 ORDER BY file_path, line",
-            )
+            .prepare_cached(SQL_FIND_CALLEES)
             .context("failed to prepare callees query")?;
         let rows = stmt
             .query_map(params![symbol_name], |row| {
@@ -749,18 +768,7 @@ impl MetadataStore {
     pub fn find_dead_symbols(&self) -> Result<Vec<DeadSymbol>> {
         let mut stmt = self
             .conn
-            .prepare(
-                "SELECT c.symbol_name, c.file_path, c.line_start, c.symbol_type
-                 FROM chunks c
-                 WHERE c.symbol_name IS NOT NULL
-                   AND c.symbol_type IN ('function', 'method')
-                   AND lower(c.symbol_name) NOT IN ('main', 'new', 'default', 'drop', 'clone', 'fmt', 'from', 'into', 'deref', 'init', 'setup', 'teardown')
-                   AND NOT EXISTS (
-                       SELECT 1 FROM [references] r
-                       WHERE lower(r.callee) = lower(c.symbol_name)
-                   )
-                 ORDER BY c.file_path, c.line_start",
-            )
+            .prepare(SQL_FIND_DEAD_SYMBOLS)
             .context("failed to prepare dead symbols query")?;
         let rows = stmt
             .query_map([], |row| {
@@ -1147,42 +1155,21 @@ mod tests {
         };
 
         for (label, sql) in [
-            (
-                "find_callers",
-                "SELECT file_path, line, caller FROM [references]
-                 WHERE lower(callee) = lower(?1)
-                 ORDER BY file_path, line",
-            ),
-            (
-                "find_callees",
-                "SELECT file_path, line, callee FROM [references]
-                 WHERE lower(caller) = lower(?1)
-                 ORDER BY file_path, line",
-            ),
-            (
-                "find_type_relations",
-                "SELECT file_path, line, owner, target, kind FROM type_relations
-                 WHERE lower(target) = lower(?1)
-                 ORDER BY file_path, line",
-            ),
-            (
-                "get_chunks_by_symbol_name",
-                "SELECT id, file_path, line_start, line_end, content, language,
-                        symbol_type, symbol_name
-                 FROM chunks WHERE lower(symbol_name) = lower(?1)",
-            ),
+            ("find_callers", SQL_FIND_CALLERS),
+            ("find_callees", SQL_FIND_CALLEES),
+            ("find_type_relations", SQL_FIND_TYPE_RELATIONS),
+            ("get_chunks_by_symbol_name", SQL_CHUNKS_BY_SYMBOL_NAME),
         ] {
             let plan = plan_for(sql);
+            // Assert on SEARCH vs SCAN, not on the presence of an index name.
+            // A full scan can still read *through* an index and report
+            // "SCAN t USING COVERING INDEX ...", so looking for "USING INDEX"
+            // passes on exactly the plan this test exists to reject.
             assert!(
-                plan.contains("USING INDEX") || plan.contains("USING COVERING INDEX"),
-                "{label} should seek an index, but the plan was: {plan}"
+                plan.starts_with("SEARCH"),
+                "{label} must seek its table, but the plan was: {plan}"
             );
-            assert!(
-                !plan.contains("SCAN [references]")
-                    && !plan.contains("SCAN chunks")
-                    && !plan.contains("SCAN type_relations"),
-                "{label} still scans its table: {plan}"
-            );
+            assert!(!plan.contains("SCAN"), "{label} still scans: {plan}");
         }
     }
 
@@ -1193,14 +1180,7 @@ mod tests {
         let store = MetadataStore::open_in_memory().unwrap();
         let mut stmt = store
             .conn
-            .prepare(
-                "EXPLAIN QUERY PLAN
-                 SELECT c.symbol_name FROM chunks c
-                 WHERE NOT EXISTS (
-                     SELECT 1 FROM [references] r
-                     WHERE lower(r.callee) = lower(c.symbol_name)
-                 )",
-            )
+            .prepare(&format!("EXPLAIN QUERY PLAN {SQL_FIND_DEAD_SYMBOLS}"))
             .unwrap();
         let plan: Vec<String> = stmt
             .query_map([], |row| row.get::<_, String>(3))

--- a/crates/vera-core/src/storage/metadata.rs
+++ b/crates/vera-core/src/storage/metadata.rs
@@ -1154,22 +1154,34 @@ mod tests {
             rows.join(" | ")
         };
 
-        for (label, sql) in [
-            ("find_callers", SQL_FIND_CALLERS),
-            ("find_callees", SQL_FIND_CALLEES),
-            ("find_type_relations", SQL_FIND_TYPE_RELATIONS),
-            ("get_chunks_by_symbol_name", SQL_CHUNKS_BY_SYMBOL_NAME),
+        for (label, sql, expected_index) in [
+            ("find_callers", SQL_FIND_CALLERS, "idx_refs_callee_lower"),
+            ("find_callees", SQL_FIND_CALLEES, "idx_refs_caller_lower"),
+            (
+                "find_type_relations",
+                SQL_FIND_TYPE_RELATIONS,
+                "idx_type_relations_target_lower",
+            ),
+            (
+                "get_chunks_by_symbol_name",
+                SQL_CHUNKS_BY_SYMBOL_NAME,
+                "idx_chunks_symbol_name_lower",
+            ),
         ] {
             let plan = plan_for(sql);
-            // Assert on SEARCH vs SCAN, not on the presence of an index name.
-            // A full scan can still read *through* an index and report
-            // "SCAN t USING COVERING INDEX ...", so looking for "USING INDEX"
-            // passes on exactly the plan this test exists to reject.
             assert!(
-                plan.starts_with("SEARCH"),
-                "{label} must seek its table, but the plan was: {plan}"
+                plan.contains(&format!("USING INDEX {expected_index}")),
+                "{label} must use {expected_index}, but the plan was: {plan}"
             );
-            assert!(!plan.contains("SCAN"), "{label} still scans: {plan}");
+            assert!(
+                plan.split(" | ").all(|detail| {
+                    detail
+                        .split_whitespace()
+                        .next()
+                        .is_none_or(|operation| operation != "SCAN")
+                }),
+                "{label} still scans: {plan}"
+            );
         }
     }
 

--- a/crates/vera-core/src/storage/metadata.rs
+++ b/crates/vera-core/src/storage/metadata.rs
@@ -153,7 +153,12 @@ impl MetadataStore {
                 CREATE INDEX IF NOT EXISTS idx_chunks_language
                     ON chunks(language);
                 CREATE INDEX IF NOT EXISTS idx_chunks_symbol_name
-                    ON chunks(symbol_name);",
+                    ON chunks(symbol_name);
+                -- `get_chunks_by_symbol_name` matches on `lower(symbol_name)`.
+                -- An index on the bare column cannot serve a predicate over an
+                -- expression, so without this the lookup scans the table.
+                CREATE INDEX IF NOT EXISTS idx_chunks_symbol_name_lower
+                    ON chunks(lower(symbol_name));",
             )
             .context("failed to create chunks table")?;
 
@@ -208,7 +213,14 @@ impl MetadataStore {
                 CREATE INDEX IF NOT EXISTS idx_refs_caller
                     ON [references](caller);
                 CREATE INDEX IF NOT EXISTS idx_refs_file_path
-                    ON [references](file_path);",
+                    ON [references](file_path);
+                -- `find_callers`, `find_callees` and the `NOT EXISTS` subquery
+                -- in `find_dead_symbols` all match on `lower(...)`, which an
+                -- index on the bare column cannot serve.
+                CREATE INDEX IF NOT EXISTS idx_refs_callee_lower
+                    ON [references](lower(callee));
+                CREATE INDEX IF NOT EXISTS idx_refs_caller_lower
+                    ON [references](lower(caller));",
             )
             .context("failed to create references table")?;
 
@@ -226,7 +238,11 @@ impl MetadataStore {
                 CREATE INDEX IF NOT EXISTS idx_type_relations_owner
                     ON type_relations(owner);
                 CREATE INDEX IF NOT EXISTS idx_type_relations_file_path
-                    ON type_relations(file_path);",
+                    ON type_relations(file_path);
+                -- `find_type_relations` matches on `lower(target)`, which an
+                -- index on the bare column cannot serve.
+                CREATE INDEX IF NOT EXISTS idx_type_relations_target_lower
+                    ON type_relations(lower(target));",
             )
             .context("failed to create type_relations table")?;
 
@@ -1108,6 +1124,94 @@ mod tests {
         let chunks = sample_chunks();
         store.insert_chunks(&chunks).unwrap();
         assert_eq!(store.chunk_count().unwrap(), 3);
+    }
+
+    /// The index expression has to match the query text exactly. If either
+    /// side is edited without the other, SQLite silently falls back to a full
+    /// scan and nothing fails — so assert on the plan, not just the results.
+    #[test]
+    fn case_insensitive_lookups_use_an_index_rather_than_scanning() {
+        let store = MetadataStore::open_in_memory().unwrap();
+
+        let plan_for = |sql: &str| -> String {
+            let mut stmt = store
+                .conn
+                .prepare(&format!("EXPLAIN QUERY PLAN {sql}"))
+                .unwrap();
+            let rows: Vec<String> = stmt
+                .query_map(params!["needle"], |row| row.get::<_, String>(3))
+                .unwrap()
+                .map(|r| r.unwrap())
+                .collect();
+            rows.join(" | ")
+        };
+
+        for (label, sql) in [
+            (
+                "find_callers",
+                "SELECT file_path, line, caller FROM [references]
+                 WHERE lower(callee) = lower(?1)
+                 ORDER BY file_path, line",
+            ),
+            (
+                "find_callees",
+                "SELECT file_path, line, callee FROM [references]
+                 WHERE lower(caller) = lower(?1)
+                 ORDER BY file_path, line",
+            ),
+            (
+                "find_type_relations",
+                "SELECT file_path, line, owner, target, kind FROM type_relations
+                 WHERE lower(target) = lower(?1)
+                 ORDER BY file_path, line",
+            ),
+            (
+                "get_chunks_by_symbol_name",
+                "SELECT id, file_path, line_start, line_end, content, language,
+                        symbol_type, symbol_name
+                 FROM chunks WHERE lower(symbol_name) = lower(?1)",
+            ),
+        ] {
+            let plan = plan_for(sql);
+            assert!(
+                plan.contains("USING INDEX") || plan.contains("USING COVERING INDEX"),
+                "{label} should seek an index, but the plan was: {plan}"
+            );
+            assert!(
+                !plan.contains("SCAN [references]")
+                    && !plan.contains("SCAN chunks")
+                    && !plan.contains("SCAN type_relations"),
+                "{label} still scans its table: {plan}"
+            );
+        }
+    }
+
+    #[test]
+    fn dead_symbol_lookup_seeks_the_reference_index() {
+        // The correlated NOT EXISTS re-runs per candidate chunk, so a scan
+        // here is O(chunks x references) rather than a constant overhead.
+        let store = MetadataStore::open_in_memory().unwrap();
+        let mut stmt = store
+            .conn
+            .prepare(
+                "EXPLAIN QUERY PLAN
+                 SELECT c.symbol_name FROM chunks c
+                 WHERE NOT EXISTS (
+                     SELECT 1 FROM [references] r
+                     WHERE lower(r.callee) = lower(c.symbol_name)
+                 )",
+            )
+            .unwrap();
+        let plan: Vec<String> = stmt
+            .query_map([], |row| row.get::<_, String>(3))
+            .unwrap()
+            .map(|r| r.unwrap())
+            .collect();
+        let plan = plan.join(" | ");
+        assert!(
+            plan.contains("SEARCH r"),
+            "the reference subquery must seek, not scan: {plan}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Problem

Five queries in `metadata.rs` match on `lower(column)`. SQLite cannot use an index on a bare column to satisfy a predicate over an expression, so every one of them full-scans its table — and the four indexes created to serve them (`idx_refs_callee`, `idx_refs_caller`, `idx_type_relations_target`, `idx_chunks_symbol_name`) are never used for seeks. They are maintained on every write and serve no read.

`find_dead_symbols` is the worst case. Its correlated `NOT EXISTS` re-scans `[references]` once per candidate chunk, so the cost is O(chunks × references).

## Change

Four expression indexes in `init_schema`, matching the query text:

- `[references](lower(callee))`
- `[references](lower(caller))`
- `type_relations(lower(target))`
- `chunks(lower(symbol_name))`

`lower()` is deterministic, so it is legal in an index. `CREATE INDEX IF NOT EXISTS` means existing databases pick them up on the next open without a migration step.

No query text changed, so there is no behaviour change to reason about — only which plan SQLite picks.

## Verification

Reproduced against this repository's own index (4790 chunks, 28118 references, 1033 type relations), with the current released binary as the control on the same index and the same query.

Plans, before and after:

```
find_callers               SCAN references     ->  SEARCH references USING INDEX idx_refs_callee_lower (<expr>=?)
get_chunks_by_symbol_name  SCAN chunks         ->  SEARCH chunks USING INDEX idx_chunks_symbol_name_lower (<expr>=?)
find_type_relations        SCAN type_relations ->  SEARCH type_relations USING INDEX idx_type_relations_target_lower (<expr>=?)
find_dead_symbols          SCAN r USING COVERING INDEX idx_refs_callee
                                               ->  SEARCH r USING COVERING INDEX idx_refs_callee_lower (<expr>=?)
```

End to end, same index, same command:

| Command | Control (master) | This branch | Output |
|---|---|---|---|
| `vera dead-code` | 3.622 s | **0.010 s** | 443 lines, byte-identical |
| `vera references build_session` | 0.020 s | **0.008 s** | identical |

The first `dead-code` run against a pre-existing index takes 1.714 s while SQLite builds the four indexes, which is still below the control; every run after that is the 0.010 s figure.

Raw SQL timings on the same database, 200 iterations each: `find_callers` 0.390 s → 0.00018 s, `get_chunks_by_symbol_name` 0.063 s → 0.00006 s. `find_dead_symbols` returns the same 440 rows in both cases, confirming this is a plan change rather than a semantic one.

## Tests

Two tests that assert on `EXPLAIN QUERY PLAN` rather than on results. That is deliberate: the index expression has to match the query text character for character, and if either side is edited without the other, SQLite silently falls back to a full scan and no result-based test would notice.

Confirmed they catch it — with the four indexes removed:

```
find_type_relations still scans its table: SCAN type_relations USING INDEX idx_type_relations_file_path | ...
the reference subquery must seek, not scan: ... | SCAN r USING COVERING INDEX idx_refs_callee
```

772 `vera-core` tests pass, `cargo fmt --check` clean, clippy unchanged at the pre-existing warnings.

## Deliberately not included

Two follow-ups that belong to maintainers rather than this PR:

1. Once these land, the four bare-column indexes are provably unused for seeks and are pure write amplification on the two largest tables. Dropping them is a schema migration against existing user databases and deserves its own decision.
2. The alternative design is `COLLATE NOCASE` on the column, or storing a normalised column. Both are schema changes with migrations, and both alter behaviour for non-ASCII identifiers. Expression indexes get the win without touching semantics, so they seemed the right first step.

Fixes #78

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Indexes the lower()-based metadata lookups so SQLite seeks instead of scanning, and strengthens plan tests to prevent silent regressions. Before, predicates on lower(column) full-scanned `references`, `chunks`, and `type_relations`; now four expression indexes match the query text, yielding seeks with no semantic changes.

- Adds indexes: `[references](lower(callee))`, `[references](lower(caller))`, `type_relations(lower(target))`, `chunks(lower(symbol_name))`.
- Extracts the lookup SQL into shared constants; plan tests assert the exact expression index is used and reject any SCAN.
- Query text is unchanged; schema init adds indexes via `CREATE INDEX IF NOT EXISTS`. Bare-column indexes remain and are currently unused for these seeks.

**Rollout**
- No migration required; existing databases build the new indexes on next open.
- First run may take ~1–2s to build indexes; subsequent runs use seeks.

<sup>Written for commit ca83719cbed04029f6e9d7e6b8b352932c3769dc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/VeraTools/Vera/pull/80?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Improved case-insensitive searches for symbols, callers, callees, type relations, and dead-symbol references.
  * Added indexes to accelerate matching and reduce unnecessary database scans.
  * Optimized query execution for faster search results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->