### PR TITLE
perf(storage): seek the index when deleting a file's vectors

### DIFF
--- a/crates/vera-core/src/storage/vector.rs
+++ b/crates/vera-core/src/storage/vector.rs
@@ -8,6 +8,10 @@ use rusqlite::{Connection, OptionalExtension, ffi::sqlite3_auto_extension, param
 use sqlite_vec::sqlite3_vec_init;
 use zerocopy::IntoBytes;
 
+const PREFIX_RANGE_SQL: &str =
+    "SELECT rowid FROM chunk_id_map WHERE chunk_id >= ?1 AND chunk_id < ?2";
+const PREFIX_LOWER_BOUND_SQL: &str = "SELECT rowid FROM chunk_id_map WHERE chunk_id >= ?1";
+
 /// sqlite-vec backed vector store for embedding search.
 pub struct VectorStore {
     conn: Connection,
@@ -377,14 +381,8 @@ fn rowids_with_prefix(conn: &Connection, prefix: &str) -> Result<Vec<i64>> {
     // SQL would cost the index range plan, which is the point of all this.
     let upper = prefix_upper_bound(prefix);
     let (sql, args): (&str, Vec<&dyn rusqlite::ToSql>) = match &upper {
-        Some(upper) => (
-            "SELECT rowid FROM chunk_id_map WHERE chunk_id >= ?1 AND chunk_id < ?2",
-            vec![&prefix, upper],
-        ),
-        None => (
-            "SELECT rowid FROM chunk_id_map WHERE chunk_id >= ?1",
-            vec![&prefix],
-        ),
+        Some(upper) => (PREFIX_RANGE_SQL, vec![&prefix, upper]),
+        None => (PREFIX_LOWER_BOUND_SQL, vec![&prefix]),
     };
 
     let mut stmt = conn
@@ -756,11 +754,9 @@ mod tests {
     }
 
     #[test]
-    fn prefix_delete_scans_and_deletes_in_one_transaction() {
-        // The scan runs inside the transaction, so a second connection cannot
-        // insert a matching row between finding the rowids and deleting them.
-        // An IMMEDIATE transaction takes the write lock up front, which is
-        // what makes the competing writer wait rather than slip in.
+    fn prefix_delete_releases_transaction_for_subsequent_writes() {
+        // A second connection can write after the prefix delete commits, which
+        // confirms that the transaction was committed and released.
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("vectors.db");
         let store = VectorStore::open(&path, 4).unwrap();
@@ -789,10 +785,9 @@ mod tests {
         let store = VectorStore::open_in_memory(4).unwrap();
         let mut stmt = store
             .conn
-            .prepare(
-                "EXPLAIN QUERY PLAN
-                 SELECT rowid FROM chunk_id_map WHERE chunk_id >= ?1 AND chunk_id < ?2",
-            )
+            .prepare(&format!(
+                "EXPLAIN QUERY PLAN\n                 {PREFIX_RANGE_SQL}"
+            ))
             .unwrap();
         let plan: Vec<String> = stmt
             .query_map(params!["a", "b"], |row| row.get::<_, String>(3))
@@ -801,8 +796,9 @@ mod tests {
             .collect();
         let plan = plan.join(" | ");
         assert!(
-            plan.contains("USING COVERING INDEX") || plan.contains("USING INDEX"),
-            "prefix range must seek the index: {plan}"
+            plan.contains("SEARCH")
+                && (plan.contains("USING COVERING INDEX") || plan.contains("USING INDEX")),
+            "prefix range must search using an index: {plan}"
         );
     }
 }

--- a/crates/vera-core/src/storage/vector.rs
+++ b/crates/vera-core/src/storage/vector.rs
@@ -310,18 +310,27 @@ impl VectorStore {
         // form scans `chunk_id_map` in full where a range seeks the index. It
         // also removes the need to escape `%` and `_`, since a range has no
         // wildcards to confuse.
-        let rows = self.rowids_with_prefix(prefix)?;
+        // One transaction for the whole file instead of two commits per row,
+        // opened *before* the scan so a concurrent writer on the same database
+        // cannot insert a matching row between finding the rowids and deleting
+        // them — that row would survive while this reported success.
+        //
+        // IMMEDIATE rather than the default DEFERRED because this transaction
+        // reads and then writes: a deferred transaction starts as a reader and
+        // can fail the upgrade with SQLITE_BUSY_SNAPSHOT, which `busy_timeout`
+        // does not retry.
+        let tx = rusqlite::Transaction::new_unchecked(
+            &self.conn,
+            rusqlite::TransactionBehavior::Immediate,
+        )
+        .context("failed to begin prefix delete transaction")?;
 
+        let rows = rowids_with_prefix(&tx, prefix)?;
         let count = rows.len() as u64;
         if count == 0 {
             return Ok(count);
         }
 
-        // One transaction for the whole file instead of two commits per row.
-        let tx = self
-            .conn
-            .unchecked_transaction()
-            .context("failed to begin prefix delete transaction")?;
         {
             let mut delete_vector = tx
                 .prepare_cached("DELETE FROM vec_chunks WHERE rowid = ?1")
@@ -343,39 +352,6 @@ impl VectorStore {
         Ok(count)
     }
 
-    fn rowids_with_prefix(&self, prefix: &str) -> Result<Vec<i64>> {
-        // `prefix_upper_bound` returns None only when nothing can sort above
-        // the prefix, in which case `>= prefix` is already exact.
-        match prefix_upper_bound(prefix) {
-            Some(upper) => {
-                let mut stmt = self
-                    .conn
-                    .prepare_cached(
-                        "SELECT rowid FROM chunk_id_map WHERE chunk_id >= ?1 AND chunk_id < ?2",
-                    )
-                    .context("failed to prepare prefix delete query")?;
-                let rows = stmt
-                    .query_map(params![prefix, upper], |row| row.get::<_, i64>(0))
-                    .context("failed to query chunks by prefix")?
-                    .collect::<std::result::Result<Vec<_>, _>>()
-                    .context("failed to collect prefix results")?;
-                Ok(rows)
-            }
-            None => {
-                let mut stmt = self
-                    .conn
-                    .prepare_cached("SELECT rowid FROM chunk_id_map WHERE chunk_id >= ?1")
-                    .context("failed to prepare prefix delete query")?;
-                let rows = stmt
-                    .query_map(params![prefix], |row| row.get::<_, i64>(0))
-                    .context("failed to query chunks by prefix")?
-                    .collect::<std::result::Result<Vec<_>, _>>()
-                    .context("failed to collect prefix results")?;
-                Ok(rows)
-            }
-        }
-    }
-
     /// Clear all vectors from the store.
     pub fn clear(&self) -> Result<()> {
         self.conn
@@ -388,6 +364,38 @@ impl VectorStore {
     pub fn dim(&self) -> usize {
         self.dim
     }
+}
+
+/// Rowids of every `chunk_id` starting with `prefix`, via a range scan.
+///
+/// Takes the connection rather than `&self` so the caller can pass an open
+/// transaction, keeping the scan atomic with the deletes that follow it.
+fn rowids_with_prefix(conn: &Connection, prefix: &str) -> Result<Vec<i64>> {
+    // The two predicates stay distinct because `prefix_upper_bound` returns
+    // None when nothing can sort above the prefix, and `>= prefix` is then
+    // already exact. Only the execution and collection are shared; merging the
+    // SQL would cost the index range plan, which is the point of all this.
+    let upper = prefix_upper_bound(prefix);
+    let (sql, args): (&str, Vec<&dyn rusqlite::ToSql>) = match &upper {
+        Some(upper) => (
+            "SELECT rowid FROM chunk_id_map WHERE chunk_id >= ?1 AND chunk_id < ?2",
+            vec![&prefix, upper],
+        ),
+        None => (
+            "SELECT rowid FROM chunk_id_map WHERE chunk_id >= ?1",
+            vec![&prefix],
+        ),
+    };
+
+    let mut stmt = conn
+        .prepare_cached(sql)
+        .context("failed to prepare prefix delete query")?;
+    let rows = stmt
+        .query_map(args.as_slice(), |row| row.get::<_, i64>(0))
+        .context("failed to query chunks by prefix")?
+        .collect::<std::result::Result<Vec<_>, _>>()
+        .context("failed to collect prefix results")?;
+    Ok(rows)
 }
 
 /// Smallest string that sorts strictly above every string starting with
@@ -745,6 +753,33 @@ mod tests {
         // Nothing sorts above these.
         assert_eq!(prefix_upper_bound(""), None);
         assert_eq!(prefix_upper_bound(&char::MAX.to_string()), None);
+    }
+
+    #[test]
+    fn prefix_delete_scans_and_deletes_in_one_transaction() {
+        // The scan runs inside the transaction, so a second connection cannot
+        // insert a matching row between finding the rowids and deleting them.
+        // An IMMEDIATE transaction takes the write lock up front, which is
+        // what makes the competing writer wait rather than slip in.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("vectors.db");
+        let store = VectorStore::open(&path, 4).unwrap();
+        store
+            .insert_batch(&[("src/a.rs:0", &[1.0, 0.0, 0.0, 0.0][..])])
+            .unwrap();
+
+        let other = VectorStore::open(&path, 4).unwrap();
+
+        assert_eq!(store.delete_by_file_prefix("src/a.rs:").unwrap(), 1);
+        assert_eq!(store.count().unwrap(), 0);
+
+        // The second connection still works afterwards: the transaction was
+        // committed and released, not left open.
+        other
+            .insert_batch(&[("src/a.rs:1", &[0.0, 1.0, 0.0, 0.0][..])])
+            .unwrap();
+        assert_eq!(other.count().unwrap(), 1);
+        assert_eq!(other.delete_by_file_prefix("src/a.rs:").unwrap(), 1);
     }
 
     #[test]

--- a/crates/vera-core/src/storage/vector.rs
+++ b/crates/vera-core/src/storage/vector.rs
@@ -65,8 +65,13 @@ impl VectorStore {
                     rowid INTEGER PRIMARY KEY AUTOINCREMENT,
                     chunk_id TEXT NOT NULL UNIQUE
                 );
-                CREATE INDEX IF NOT EXISTS idx_chunk_id_map
-                    ON chunk_id_map(chunk_id);",
+                -- `chunk_id` is UNIQUE, which already builds
+                -- `sqlite_autoindex_chunk_id_map_1` over the same column. The
+                -- explicit index duplicated it exactly and only added a second
+                -- B-tree to maintain on every vector insert. Dropped here so
+                -- existing databases shed it on next open; the autoindex
+                -- serves both the equality lookup and the prefix range scan.
+                DROP INDEX IF EXISTS idx_chunk_id_map;",
             )
             .context("failed to create chunk_id_map table")?;
 
@@ -300,41 +305,75 @@ impl VectorStore {
     /// This is used for incremental indexing: when a file is re-indexed, all
     /// old chunks for that file (whose IDs start with "filepath:") are removed.
     pub fn delete_by_file_prefix(&self, prefix: &str) -> Result<u64> {
-        // Find all rowids matching the prefix.
-        // Escape SQL LIKE wildcards (_ and %) in the prefix to avoid
-        // incorrect matches on file paths containing those characters.
-        let mut stmt = self
-            .conn
-            .prepare(
-                "SELECT rowid, chunk_id FROM chunk_id_map \
-                 WHERE chunk_id LIKE ?1 ESCAPE '\\'",
-            )
-            .context("failed to prepare prefix delete query")?;
-
-        let escaped_prefix = prefix
-            .replace('\\', "\\\\")
-            .replace('%', "\\%")
-            .replace('_', "\\_");
-        let like_pattern = format!("{escaped_prefix}%");
-        let rows: Vec<(i64, String)> = stmt
-            .query_map(params![like_pattern], |row| {
-                Ok((row.get::<_, i64>(0)?, row.get::<_, String>(1)?))
-            })
-            .context("failed to query chunks by prefix")?
-            .collect::<std::result::Result<Vec<_>, _>>()
-            .context("failed to collect prefix results")?;
+        // A half-open range rather than `LIKE ?1 ESCAPE '\'`. The ESCAPE
+        // clause disqualifies SQLite's LIKE-prefix optimization, so the LIKE
+        // form scans `chunk_id_map` in full where a range seeks the index. It
+        // also removes the need to escape `%` and `_`, since a range has no
+        // wildcards to confuse.
+        let rows = self.rowids_with_prefix(prefix)?;
 
         let count = rows.len() as u64;
-        for (rowid, _chunk_id) in &rows {
-            self.conn
-                .execute("DELETE FROM vec_chunks WHERE rowid = ?1", params![rowid])
-                .context("failed to delete vector by prefix")?;
-            self.conn
-                .execute("DELETE FROM chunk_id_map WHERE rowid = ?1", params![rowid])
-                .context("failed to delete chunk id by prefix")?;
+        if count == 0 {
+            return Ok(count);
         }
 
+        // One transaction for the whole file instead of two commits per row.
+        let tx = self
+            .conn
+            .unchecked_transaction()
+            .context("failed to begin prefix delete transaction")?;
+        {
+            let mut delete_vector = tx
+                .prepare_cached("DELETE FROM vec_chunks WHERE rowid = ?1")
+                .context("failed to prepare vector delete")?;
+            let mut delete_mapping = tx
+                .prepare_cached("DELETE FROM chunk_id_map WHERE rowid = ?1")
+                .context("failed to prepare chunk id delete")?;
+            for rowid in &rows {
+                delete_vector
+                    .execute(params![rowid])
+                    .context("failed to delete vector by prefix")?;
+                delete_mapping
+                    .execute(params![rowid])
+                    .context("failed to delete chunk id by prefix")?;
+            }
+        }
+        tx.commit().context("failed to commit prefix delete")?;
+
         Ok(count)
+    }
+
+    fn rowids_with_prefix(&self, prefix: &str) -> Result<Vec<i64>> {
+        // `prefix_upper_bound` returns None only when nothing can sort above
+        // the prefix, in which case `>= prefix` is already exact.
+        match prefix_upper_bound(prefix) {
+            Some(upper) => {
+                let mut stmt = self
+                    .conn
+                    .prepare_cached(
+                        "SELECT rowid FROM chunk_id_map WHERE chunk_id >= ?1 AND chunk_id < ?2",
+                    )
+                    .context("failed to prepare prefix delete query")?;
+                let rows = stmt
+                    .query_map(params![prefix, upper], |row| row.get::<_, i64>(0))
+                    .context("failed to query chunks by prefix")?
+                    .collect::<std::result::Result<Vec<_>, _>>()
+                    .context("failed to collect prefix results")?;
+                Ok(rows)
+            }
+            None => {
+                let mut stmt = self
+                    .conn
+                    .prepare_cached("SELECT rowid FROM chunk_id_map WHERE chunk_id >= ?1")
+                    .context("failed to prepare prefix delete query")?;
+                let rows = stmt
+                    .query_map(params![prefix], |row| row.get::<_, i64>(0))
+                    .context("failed to query chunks by prefix")?
+                    .collect::<std::result::Result<Vec<_>, _>>()
+                    .context("failed to collect prefix results")?;
+                Ok(rows)
+            }
+        }
     }
 
     /// Clear all vectors from the store.
@@ -349,6 +388,43 @@ impl VectorStore {
     pub fn dim(&self) -> usize {
         self.dim
     }
+}
+
+/// Smallest string that sorts strictly above every string starting with
+/// `prefix`, giving the exclusive upper bound of a prefix range scan.
+///
+/// SQLite's default `BINARY` collation compares TEXT bytewise, and UTF-8 byte
+/// order matches code point order, so incrementing the final character is
+/// sufficient. Two cases need care: the successor of a code point may land in
+/// the surrogate range, which is not a valid `char`, so it is skipped; and a
+/// trailing `char::MAX` has no successor at all, so it is dropped and the
+/// character before it is incremented instead.
+///
+/// Returns `None` when no upper bound exists (an empty prefix, or one made
+/// entirely of `char::MAX`), in which case `chunk_id >= prefix` is already
+/// exact and needs no upper bound.
+fn prefix_upper_bound(prefix: &str) -> Option<String> {
+    let mut chars: Vec<char> = prefix.chars().collect();
+    while let Some(last) = chars.pop() {
+        if let Some(next) = next_char(last) {
+            let mut bound: String = chars.into_iter().collect();
+            bound.push(next);
+            return Some(bound);
+        }
+    }
+    None
+}
+
+/// Next valid `char` above `c`, skipping the UTF-16 surrogate range.
+fn next_char(c: char) -> Option<char> {
+    let mut code = c as u32 + 1;
+    while code <= char::MAX as u32 {
+        if let Some(next) = char::from_u32(code) {
+            return Some(next);
+        }
+        code += 1;
+    }
+    None
 }
 
 /// Register the sqlite-vec extension globally (idempotent).
@@ -588,5 +664,110 @@ mod tests {
         // Remaining vector should be src/lib.rs:0.
         let results = store.search(&[0.0, 0.0, 1.0, 0.0], 1).unwrap();
         assert_eq!(results[0].chunk_id, "src/lib.rs:0");
+    }
+
+    #[test]
+    fn delete_by_file_prefix_does_not_treat_wildcards_as_patterns() {
+        // `_` matches any character and `%` any sequence in LIKE. A range
+        // predicate has no wildcards, but the paths that would have been
+        // mis-matched are exactly the ones worth pinning.
+        let store = VectorStore::open_in_memory(4).unwrap();
+        let items: Vec<(&str, &[f32])> = vec![
+            ("src/a_b.rs:0", &[1.0, 0.0, 0.0, 0.0]),
+            ("src/axb.rs:0", &[0.0, 1.0, 0.0, 0.0]),
+            ("src/100%.rs:0", &[0.0, 0.0, 1.0, 0.0]),
+            ("src/100pct.rs:0", &[0.0, 0.0, 0.0, 1.0]),
+        ];
+        store.insert_batch(&items).unwrap();
+
+        assert_eq!(store.delete_by_file_prefix("src/a_b.rs:").unwrap(), 1);
+        assert_eq!(store.delete_by_file_prefix("src/100%.rs:").unwrap(), 1);
+        assert_eq!(store.count().unwrap(), 2);
+
+        // The literal-looking siblings survive.
+        let remaining = store.search(&[0.0, 1.0, 0.0, 0.0], 4).unwrap();
+        let ids: Vec<&str> = remaining.iter().map(|r| r.chunk_id.as_str()).collect();
+        assert!(ids.contains(&"src/axb.rs:0"), "{ids:?}");
+        assert!(ids.contains(&"src/100pct.rs:0"), "{ids:?}");
+    }
+
+    #[test]
+    fn delete_by_file_prefix_stops_at_the_prefix_boundary() {
+        // The upper bound must exclude the next sibling but include every
+        // descendant of the prefix, however long.
+        let store = VectorStore::open_in_memory(4).unwrap();
+        let items: Vec<(&str, &[f32])> = vec![
+            ("src/app.rs:0", &[1.0, 0.0, 0.0, 0.0]),
+            ("src/app.rs:10", &[0.0, 1.0, 0.0, 0.0]),
+            ("src/app2.rs:0", &[0.0, 0.0, 1.0, 0.0]),
+            ("src/apq.rs:0", &[0.0, 0.0, 0.0, 1.0]),
+        ];
+        store.insert_batch(&items).unwrap();
+
+        assert_eq!(store.delete_by_file_prefix("src/app.rs:").unwrap(), 2);
+        assert_eq!(store.count().unwrap(), 2);
+        let remaining = store.search(&[0.0, 0.0, 1.0, 0.0], 4).unwrap();
+        let ids: Vec<&str> = remaining.iter().map(|r| r.chunk_id.as_str()).collect();
+        assert!(ids.contains(&"src/app2.rs:0"), "{ids:?}");
+        assert!(ids.contains(&"src/apq.rs:0"), "{ids:?}");
+    }
+
+    #[test]
+    fn delete_by_file_prefix_handles_non_ascii_paths() {
+        let store = VectorStore::open_in_memory(4).unwrap();
+        let items: Vec<(&str, &[f32])> = vec![
+            ("src/café.rs:0", &[1.0, 0.0, 0.0, 0.0]),
+            ("src/cafz.rs:0", &[0.0, 1.0, 0.0, 0.0]),
+        ];
+        store.insert_batch(&items).unwrap();
+
+        assert_eq!(store.delete_by_file_prefix("src/café.rs:").unwrap(), 1);
+        assert_eq!(store.count().unwrap(), 1);
+        let remaining = store.search(&[0.0, 1.0, 0.0, 0.0], 1).unwrap();
+        assert_eq!(remaining[0].chunk_id, "src/cafz.rs:0");
+    }
+
+    #[test]
+    fn prefix_upper_bound_covers_the_awkward_code_points() {
+        assert_eq!(prefix_upper_bound("src/a"), Some("src/b".to_string()));
+        assert_eq!(prefix_upper_bound("a:"), Some("a;".to_string()));
+
+        // Successor lands in the surrogate range and must be skipped.
+        let below_surrogates = char::from_u32(0xD7FF).unwrap();
+        let bound = prefix_upper_bound(&below_surrogates.to_string()).unwrap();
+        assert_eq!(bound.chars().next(), char::from_u32(0xE000));
+
+        // A trailing char::MAX has no successor, so the previous character is
+        // incremented and the max is dropped.
+        let trailing_max = format!("a{}", char::MAX);
+        assert_eq!(prefix_upper_bound(&trailing_max), Some("b".to_string()));
+
+        // Nothing sorts above these.
+        assert_eq!(prefix_upper_bound(""), None);
+        assert_eq!(prefix_upper_bound(&char::MAX.to_string()), None);
+    }
+
+    #[test]
+    fn prefix_range_seeks_the_index_instead_of_scanning() {
+        // The whole point of the range form: `LIKE ... ESCAPE` cannot use the
+        // index, so a plan check is what actually guards this.
+        let store = VectorStore::open_in_memory(4).unwrap();
+        let mut stmt = store
+            .conn
+            .prepare(
+                "EXPLAIN QUERY PLAN
+                 SELECT rowid FROM chunk_id_map WHERE chunk_id >= ?1 AND chunk_id < ?2",
+            )
+            .unwrap();
+        let plan: Vec<String> = stmt
+            .query_map(params!["a", "b"], |row| row.get::<_, String>(3))
+            .unwrap()
+            .map(|r| r.unwrap())
+            .collect();
+        let plan = plan.join(" | ");
+        assert!(
+            plan.contains("USING COVERING INDEX") || plan.contains("USING INDEX"),
+            "prefix range must seek the index: {plan}"
+        );
     }
 }

--- a/crates/vera-core/src/storage/vector.rs
+++ b/crates/vera-core/src/storage/vector.rs
@@ -779,6 +779,54 @@ mod tests {
     }
 
     #[test]
+    fn prefix_delete_takes_the_write_lock_before_it_scans() {
+        // Complements the release test above, which shows the transaction is
+        // committed but not when it opens. The race being guarded is
+        // scan-then-delete: a competing writer inserting a matching row
+        // between the two would survive while the method reported success.
+        // What removes it is that the transaction is IMMEDIATE and opened
+        // *before* the scan, so the write lock is held for the whole window.
+        //
+        // That ordering is observable without thread timing. With a competitor
+        // holding the write lock, taking it up front fails at BEGIN, before
+        // any scanning; scanning first and opening a DEFERRED transaction
+        // afterwards gets as far as the first DELETE. Asserting which step
+        // failed pins the ordering.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("vectors.db");
+        let store = VectorStore::open(&path, 4).unwrap();
+        store
+            .insert_batch(&[("src/a.rs:0", &[1.0, 0.0, 0.0, 0.0][..])])
+            .unwrap();
+
+        // rusqlite defaults to a 5s busy timeout; the contention here is
+        // deliberate, so fail fast rather than waiting it out.
+        store.conn.execute_batch("PRAGMA busy_timeout=0").unwrap();
+
+        let competitor = VectorStore::open(&path, 4).unwrap();
+        competitor
+            .conn
+            .execute_batch("BEGIN IMMEDIATE")
+            .expect("competing writer should take the write lock");
+
+        let err = store
+            .delete_by_file_prefix("src/a.rs:")
+            .expect_err("a held write lock must block the delete");
+        let chain = format!("{err:#}");
+        assert!(
+            chain.contains("begin prefix delete transaction"),
+            "should fail acquiring the lock before scanning, got: {chain}"
+        );
+
+        competitor.conn.execute_batch("ROLLBACK").unwrap();
+
+        // Nothing was deleted, and it works once the lock is free.
+        assert_eq!(store.count().unwrap(), 1);
+        assert_eq!(store.delete_by_file_prefix("src/a.rs:").unwrap(), 1);
+        assert_eq!(store.count().unwrap(), 0);
+    }
+
+    #[test]
     fn prefix_range_seeks_the_index_instead_of_scanning() {
         // The whole point of the range form: `LIKE ... ESCAPE` cannot use the
         // index, so a plan check is what actually guards this.

--- a/crates/vera-core/src/storage/vector.rs
+++ b/crates/vera-core/src/storage/vector.rs
@@ -309,6 +309,13 @@ impl VectorStore {
     /// This is used for incremental indexing: when a file is re-indexed, all
     /// old chunks for that file (whose IDs start with "filepath:") are removed.
     pub fn delete_by_file_prefix(&self, prefix: &str) -> Result<u64> {
+        self.delete_by_file_prefix_after_scan(prefix, || {})
+    }
+
+    fn delete_by_file_prefix_after_scan<F>(&self, prefix: &str, after_scan: F) -> Result<u64>
+    where
+        F: FnOnce(),
+    {
         // A half-open range rather than `LIKE ?1 ESCAPE '\'`. The ESCAPE
         // clause disqualifies SQLite's LIKE-prefix optimization, so the LIKE
         // form scans `chunk_id_map` in full where a range seeks the index. It
@@ -330,6 +337,7 @@ impl VectorStore {
         .context("failed to begin prefix delete transaction")?;
 
         let rows = rowids_with_prefix(&tx, prefix)?;
+        after_scan();
         let count = rows.len() as u64;
         if count == 0 {
             return Ok(count);
@@ -780,18 +788,6 @@ mod tests {
 
     #[test]
     fn prefix_delete_takes_the_write_lock_before_it_scans() {
-        // Complements the release test above, which shows the transaction is
-        // committed but not when it opens. The race being guarded is
-        // scan-then-delete: a competing writer inserting a matching row
-        // between the two would survive while the method reported success.
-        // What removes it is that the transaction is IMMEDIATE and opened
-        // *before* the scan, so the write lock is held for the whole window.
-        //
-        // That ordering is observable without thread timing. With a competitor
-        // holding the write lock, taking it up front fails at BEGIN, before
-        // any scanning; scanning first and opening a DEFERRED transaction
-        // afterwards gets as far as the first DELETE. Asserting which step
-        // failed pins the ordering.
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("vectors.db");
         let store = VectorStore::open(&path, 4).unwrap();
@@ -799,31 +795,38 @@ mod tests {
             .insert_batch(&[("src/a.rs:0", &[1.0, 0.0, 0.0, 0.0][..])])
             .unwrap();
 
-        // rusqlite defaults to a 5s busy timeout; the contention here is
-        // deliberate, so fail fast rather than waiting it out.
-        store.conn.execute_batch("PRAGMA busy_timeout=0").unwrap();
-
         let competitor = VectorStore::open(&path, 4).unwrap();
         competitor
             .conn
-            .execute_batch("BEGIN IMMEDIATE")
-            .expect("competing writer should take the write lock");
+            .execute_batch("PRAGMA busy_timeout=0")
+            .unwrap();
 
-        let err = store
-            .delete_by_file_prefix("src/a.rs:")
-            .expect_err("a held write lock must block the delete");
-        let chain = format!("{err:#}");
-        assert!(
-            chain.contains("begin prefix delete transaction"),
-            "should fail acquiring the lock before scanning, got: {chain}"
-        );
+        let deleted = store
+            .delete_by_file_prefix_after_scan("src/a.rs:", || {
+                let err = competitor
+                    .insert_batch(&[("src/a.rs:1", &[0.0, 1.0, 0.0, 0.0][..])])
+                    .expect_err("the prefix transaction must already hold the write lock");
+                assert!(
+                    err.chain().any(|cause| matches!(
+                        cause.downcast_ref::<rusqlite::Error>(),
+                        Some(rusqlite::Error::SqliteFailure(failure, _))
+                            if matches!(
+                                failure.code,
+                                rusqlite::ErrorCode::DatabaseBusy
+                                    | rusqlite::ErrorCode::DatabaseLocked
+                            )
+                    )),
+                    "competing write should fail because the database is locked: {err:#}"
+                );
+            })
+            .unwrap();
 
-        competitor.conn.execute_batch("ROLLBACK").unwrap();
-
-        // Nothing was deleted, and it works once the lock is free.
-        assert_eq!(store.count().unwrap(), 1);
-        assert_eq!(store.delete_by_file_prefix("src/a.rs:").unwrap(), 1);
+        assert_eq!(deleted, 1);
         assert_eq!(store.count().unwrap(), 0);
+        competitor
+            .insert_batch(&[("src/a.rs:1", &[0.0, 1.0, 0.0, 0.0][..])])
+            .unwrap();
+        assert_eq!(competitor.count().unwrap(), 1);
     }
 
     #[test]


### PR DESCRIPTION
## Problem

`VectorStore::delete_by_file_prefix` runs once per changed file on every incremental update, and had three independent problems.

**1. The predicate could not use the index.** SQLite converts `LIKE 'prefix%'` into a range scan when the column is indexed, but the `ESCAPE` clause disqualifies that optimization outright:

```
sqlite> EXPLAIN QUERY PLAN SELECT rowid, chunk_id FROM chunk_id_map
   ...> WHERE chunk_id LIKE 'crates/vera-core/src/retrieval/%' ESCAPE '\';
`--SCAN chunk_id_map
```

**2. Every row was its own commit.** The deletion loop issued two uncached `Connection::execute` calls per matched rowid with no enclosing transaction.

**3. The table carried a duplicate index.** `chunk_id` is declared `UNIQUE`, which already builds `sqlite_autoindex_chunk_id_map_1` over that column; `idx_chunk_id_map` was then created on the same column — a second B-tree maintained on every vector insert for nothing.

## Change

A half-open range instead of `LIKE ... ESCAPE`, one transaction with cached statements for the deletes, and the redundant index dropped.

The range form also removes the wildcard-escaping logic entirely, because a range predicate has no wildcards to confuse. That is a simplification rather than a behaviour change — the escaping existed only to defend against the `LIKE` semantics.

```
`--SEARCH chunk_id_map USING COVERING INDEX sqlite_autoindex_chunk_id_map_1 (chunk_id>? AND chunk_id<?)
```

## Verification

Against this repository's own `vectors.db` (4790 rows), driving 300 real chunk-id prefixes taken from the table itself:

| | Rows returned | Time |
|---|---|---|
| `LIKE ... ESCAPE` | 19674 | 0.0477 s |
| range | 19674 | 0.0034 s |

Identical results, ~14x faster. The gap widens with table size, since one form is O(rows) and the other O(log n + matches).

On the duplicate index, both access patterns are served by the UNIQUE constraint's automatic index once the explicit one is gone:

```
sqlite> DROP INDEX idx_chunk_id_map;
sqlite> EXPLAIN QUERY PLAN SELECT rowid FROM chunk_id_map WHERE chunk_id = 'x';
`--SEARCH chunk_id_map USING COVERING INDEX sqlite_autoindex_chunk_id_map_1 (chunk_id=?)
```

End to end on a copy of a real index, the migration runs on open and search keeps working:

```
indexes before:  sqlite_autoindex_chunk_id_map_1, idx_chunk_id_map
$ vera search "vector similarity search"
crates/vera-cli/src/commands/search.rs:77-85 struct:SearchRunner
indexes after:   sqlite_autoindex_chunk_id_map_1
```

777 `vera-core` tests, 92 `vera-cli`, `cargo fmt --check` clean, clippy unchanged at the pre-existing warnings.

## The one subtle part

Deriving the exclusive upper bound for an arbitrary UTF-8 prefix. Two cases are easy to get wrong: the successor of a code point can land in the UTF-16 surrogate range, which is not a valid `char`; and a trailing `char::MAX` has no successor at all, so the character before it has to be incremented and the max dropped. `prefix_upper_bound` handles both and returns `None` when no bound exists, in which case `chunk_id >= prefix` is already exact.

This is unit-tested directly rather than only through `delete_by_file_prefix`, because the end-to-end tests cannot distinguish a bound that is off by one character — I checked, by introducing exactly that bug: the unit test caught it, the integration tests did not.

Test coverage added: wildcard-looking paths (`src/a_b.rs`, `src/100%.rs`) must not over-match their literal siblings; the prefix boundary must exclude `src/app2.rs` while including every descendant of `src/app.rs:`; non-ASCII paths; the awkward code points above; and a plan assertion that the range actually seeks the index, since that is the entire point and a result-based test would pass either way.

Worth noting the pre-existing `delete_by_file_prefix` test did not cover the wildcard cases, so the escaping behaviour was previously unpinned.

Fixes #79

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Speeds up and hardens file‑prefix deletions by replacing a `LIKE ... ESCAPE` full scan with an indexed half‑open range and running the scan and deletes inside a single IMMEDIATE transaction. This is ~10–15x faster on real data and closes a race where inserts between scan and delete could survive.

- Review
  - Prefix match uses `chunk_id >= prefix` and, when available, `chunk_id < upper_bound(prefix)`; when no bound exists, `>= prefix` is exact. `prefix_upper_bound` skips UTF‑16 surrogates and handles trailing `char::MAX`.
  - The UNIQUE `chunk_id` autoindex serves equality and range; EXPLAIN confirms an index seek (plan test added).
  - One IMMEDIATE transaction opens before the scan; tests assert a contending writer fails at BEGIN and that the transaction later releases for subsequent writes.
  - Deletes from `vec_chunks` and `chunk_id_map` use cached statements and the same rowids via `rowids_with_prefix`. Tests cover literal `%`/`_`, non‑ASCII paths, and prefix boundaries.

- Rollout
  - On open, drop `idx_chunk_id_map`. No action required; the autoindex remains.

<sup>Written for commit 8fc83c6a3ba053e5a78d36fd3214a918dcd54d1f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/VeraTools/Vera/pull/81?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved prefix-based deletion for paths containing special characters, wildcard literals, non-ASCII text, and boundary cases.
  - Corrected deletion behavior for prefixes without a defined upper limit.
  - Improved handling of empty prefixes and maximum-character boundaries.
  - Ensured related path data is removed consistently and atomically during deletion.

- **Performance**
  - Optimized prefix deletions for faster, more efficient cleanup.
  - Reduced unnecessary storage overhead during initialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->