### PR TITLE
fix(indexing): make update publication cancellation-safe

### DIFF
--- a/crates/vera-cli/src/commands/index.rs
+++ b/crates/vera-cli/src/commands/index.rs
@@ -9,20 +9,8 @@ use vera_core::config::InferenceBackend;
 use vera_core::indexing::IndexProgress;
 
 use crate::helpers::{
-    cancel_on_signal, load_runtime_config, print_human_summary, wait_for_interrupt,
+    cancel_task_on_signal, load_runtime_config, print_human_summary, wait_for_interrupt,
 };
-
-struct AbortIndexTask {
-    abort_handle: tokio::task::AbortHandle,
-    cancellation: vera_core::CancellationToken,
-}
-
-impl Drop for AbortIndexTask {
-    fn drop(&mut self) {
-        self.cancellation.cancel();
-        self.abort_handle.abort();
-    }
-}
 
 /// Run the `vera index <path>` command.
 #[allow(clippy::too_many_arguments)]
@@ -109,7 +97,6 @@ pub fn execute(
     if !show_progress {
         let cancellation = vera_core::CancellationToken::new();
         let task_cancellation = cancellation.clone();
-        let signal_cancellation = cancellation.clone();
         let task_repo_path = repo_path.to_path_buf();
         let task = rt.handle().spawn(async move {
             vera_core::indexing::pipeline::index_repository_with_cancellation(
@@ -121,17 +108,11 @@ pub fn execute(
             )
             .await
         });
-        let abort_handle = task.abort_handle();
         let summary = rt
-            .block_on(cancel_on_signal(
-                async move { task.await.context("indexing task failed")? },
-                async move {
-                    let _task_guard = AbortIndexTask {
-                        abort_handle,
-                        cancellation: signal_cancellation,
-                    };
-                    wait_for_interrupt().await;
-                },
+            .block_on(cancel_task_on_signal(
+                task,
+                wait_for_interrupt(),
+                cancellation,
                 "indexing",
             ))
             .context("indexing failed")?;
@@ -173,7 +154,6 @@ pub fn execute(
 
     let cancellation = vera_core::CancellationToken::new();
     let task_cancellation = cancellation.clone();
-    let signal_cancellation = cancellation.clone();
     let task_repo_path = repo_path.to_path_buf();
     let task = rt.handle().spawn(async move {
         vera_core::indexing::pipeline::index_repository_with_progress_and_cancellation(
@@ -186,16 +166,10 @@ pub fn execute(
         )
         .await
     });
-    let abort_handle = task.abort_handle();
-    let result = rt.block_on(cancel_on_signal(
-        async move { task.await.context("indexing task failed")? },
-        async move {
-            let _task_guard = AbortIndexTask {
-                abort_handle,
-                cancellation: signal_cancellation,
-            };
-            wait_for_interrupt().await;
-        },
+    let result = rt.block_on(cancel_task_on_signal(
+        task,
+        wait_for_interrupt(),
+        cancellation,
         "indexing",
     ));
     multi.stop();

--- a/crates/vera-cli/src/commands/index.rs
+++ b/crates/vera-cli/src/commands/index.rs
@@ -98,6 +98,7 @@ pub fn execute(
         let cancellation = vera_core::CancellationToken::new();
         let task_cancellation = cancellation.clone();
         let task_repo_path = repo_path.to_path_buf();
+        let signal = wait_for_interrupt(rt.handle())?;
         let task = rt.handle().spawn(async move {
             vera_core::indexing::pipeline::index_repository_with_cancellation(
                 &task_repo_path,
@@ -111,7 +112,7 @@ pub fn execute(
         let summary = rt
             .block_on(cancel_task_on_signal(
                 task,
-                wait_for_interrupt(),
+                signal,
                 cancellation,
                 "indexing",
             ))
@@ -155,6 +156,7 @@ pub fn execute(
     let cancellation = vera_core::CancellationToken::new();
     let task_cancellation = cancellation.clone();
     let task_repo_path = repo_path.to_path_buf();
+    let signal = wait_for_interrupt(rt.handle())?;
     let task = rt.handle().spawn(async move {
         vera_core::indexing::pipeline::index_repository_with_progress_and_cancellation(
             &task_repo_path,
@@ -168,7 +170,7 @@ pub fn execute(
     });
     let result = rt.block_on(cancel_task_on_signal(
         task,
-        wait_for_interrupt(),
+        signal,
         cancellation,
         "indexing",
     ));

--- a/crates/vera-cli/src/commands/update.rs
+++ b/crates/vera-cli/src/commands/update.rs
@@ -244,7 +244,7 @@ fn print_update_summary(summary: &vera_core::indexing::UpdateSummary) {
         + summary.files_added
         + summary.files_deleted
         + summary.files_deferred;
-    if total_pending == 0 {
+    if total_pending == 0 && summary.parse_errors.is_empty() {
         println!();
         println!("  Index is up to date — no changes detected.");
     }

--- a/crates/vera-cli/src/commands/update.rs
+++ b/crates/vera-cli/src/commands/update.rs
@@ -8,7 +8,7 @@ use anyhow::{Context, bail};
 use vera_core::config::InferenceBackend;
 use vera_core::indexing::{UpdateOptions, UpdateProgress};
 
-use crate::helpers::{cancel_on_signal, load_runtime_config, wait_for_interrupt};
+use crate::helpers::{cancel_task_on_signal, load_runtime_config, wait_for_interrupt};
 
 pub struct CommandOptions {
     pub backend: InferenceBackend,
@@ -95,14 +95,16 @@ pub fn run(path: &str, json_output: bool, options: CommandOptions) -> anyhow::Re
 
     let show_progress = !json_output && !no_progress && std::io::stderr().is_terminal();
     let options = UpdateOptions { max_files };
+    let cancellation = vera_core::CancellationToken::new();
+    let operation_cancellation = cancellation.clone();
     let summary = if show_progress {
         let multi = cliclack::multi_progress("Updating...");
-        let spinner = multi.add(cliclack::spinner());
+        let spinner = Arc::new(multi.add(cliclack::spinner()));
         spinner.start("Discovering files...");
         let embed_bar: Arc<cliclack::ProgressBar> = Arc::new(multi.add(cliclack::progress_bar(0)));
         let embed_started = Arc::new(std::sync::atomic::AtomicBool::new(false));
 
-        let spinner_ref = &spinner;
+        let spinner_ref = Arc::clone(&spinner);
         let embed_bar_ref = embed_bar.clone();
         let embed_started_ref = embed_started.clone();
 
@@ -152,31 +154,45 @@ pub fn run(path: &str, json_output: bool, options: CommandOptions) -> anyhow::Re
             }
         };
 
-        let result = rt.block_on(cancel_on_signal(
-            vera_core::indexing::update_repository_with_options_and_progress(
-                repo_path,
+        let task_repo_path = repo_path.to_path_buf();
+        let task = rt.handle().spawn(async move {
+            vera_core::indexing::update_repository_with_options_and_progress_and_cancellation(
+                &task_repo_path,
                 &provider,
                 &config,
                 &model_name,
                 &options,
                 on_progress,
-            ),
+                &operation_cancellation,
+            )
+            .await
+        });
+        let result = rt.block_on(cancel_task_on_signal(
+            task,
             wait_for_interrupt(),
+            cancellation,
             "update",
         ));
         multi.stop();
         result.context("update failed")?
     } else {
-        rt.block_on(cancel_on_signal(
-            vera_core::indexing::update_repository_with_options_and_progress(
-                repo_path,
+        let task_repo_path = repo_path.to_path_buf();
+        let task = rt.handle().spawn(async move {
+            vera_core::indexing::update_repository_with_options_and_progress_and_cancellation(
+                &task_repo_path,
                 &provider,
                 &config,
                 &model_name,
                 &options,
                 |_| {},
-            ),
+                &operation_cancellation,
+            )
+            .await
+        });
+        rt.block_on(cancel_task_on_signal(
+            task,
             wait_for_interrupt(),
+            cancellation,
             "update",
         ))
         .context("update failed")?

--- a/crates/vera-cli/src/commands/update.rs
+++ b/crates/vera-cli/src/commands/update.rs
@@ -155,6 +155,7 @@ pub fn run(path: &str, json_output: bool, options: CommandOptions) -> anyhow::Re
         };
 
         let task_repo_path = repo_path.to_path_buf();
+        let signal = wait_for_interrupt(rt.handle())?;
         let task = rt.handle().spawn(async move {
             vera_core::indexing::update_repository_with_options_and_progress_and_cancellation(
                 &task_repo_path,
@@ -167,16 +168,12 @@ pub fn run(path: &str, json_output: bool, options: CommandOptions) -> anyhow::Re
             )
             .await
         });
-        let result = rt.block_on(cancel_task_on_signal(
-            task,
-            wait_for_interrupt(),
-            cancellation,
-            "update",
-        ));
+        let result = rt.block_on(cancel_task_on_signal(task, signal, cancellation, "update"));
         multi.stop();
         result.context("update failed")?
     } else {
         let task_repo_path = repo_path.to_path_buf();
+        let signal = wait_for_interrupt(rt.handle())?;
         let task = rt.handle().spawn(async move {
             vera_core::indexing::update_repository_with_options_and_progress_and_cancellation(
                 &task_repo_path,
@@ -189,13 +186,8 @@ pub fn run(path: &str, json_output: bool, options: CommandOptions) -> anyhow::Re
             )
             .await
         });
-        rt.block_on(cancel_task_on_signal(
-            task,
-            wait_for_interrupt(),
-            cancellation,
-            "update",
-        ))
-        .context("update failed")?
+        rt.block_on(cancel_task_on_signal(task, signal, cancellation, "update"))
+            .context("update failed")?
     };
 
     // Output results.

--- a/crates/vera-cli/src/helpers.rs
+++ b/crates/vera-cli/src/helpers.rs
@@ -4,6 +4,7 @@ use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
+use anyhow::Context;
 use clap::Args;
 use vera_core::presentation::{CompactResult, truncate_to_budget};
 
@@ -12,24 +13,31 @@ pub async fn wait_for_interrupt() {
     let _ = tokio::signal::ctrl_c().await;
 }
 
-/// Run an operation until it completes or an interrupt signal wins.
+/// Cancel a spawned operation when signalled, then wait for it to stop safely.
 ///
-/// Dropping the operation future propagates cancellation through in-flight
-/// client requests instead of leaving the CLI runtime alive until they finish.
-pub async fn cancel_on_signal<T, Operation, Signal>(
-    operation: Operation,
+/// The operation runs separately so the signal handler is active during synchronous discovery
+/// and parsing. If publication has already started, this waits for and returns its real result.
+pub async fn cancel_task_on_signal<T, Signal>(
+    mut task: tokio::task::JoinHandle<anyhow::Result<T>>,
     signal: Signal,
+    cancellation: vera_core::CancellationToken,
     operation_name: &str,
 ) -> anyhow::Result<T>
 where
-    Operation: std::future::Future<Output = anyhow::Result<T>>,
     Signal: std::future::Future<Output = ()>,
 {
-    tokio::select! {
+    tokio::pin!(signal);
+
+    let result = tokio::select! {
         biased;
-        result = operation => result,
-        _ = signal => anyhow::bail!("{operation_name} cancelled"),
-    }
+        result = &mut task => result,
+        _ = &mut signal => {
+            cancellation.cancel();
+            task.await
+        },
+    };
+
+    result.with_context(|| format!("{operation_name} task failed"))?
 }
 
 /// Load the effective runtime configuration.
@@ -497,8 +505,6 @@ pub fn print_human_summary(summary: &vera_core::indexing::IndexSummary, verbose:
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::Arc;
-    use std::sync::atomic::{AtomicBool, Ordering};
 
     #[test]
     fn index_freshness_summary_formats_nonzero_counts() {
@@ -510,20 +516,15 @@ mod tests {
         assert_eq!(freshness.summary(), "2 added, 1 modified, 3 deleted");
     }
 
-    struct DropMarker(Arc<AtomicBool>);
-
-    impl Drop for DropMarker {
-        fn drop(&mut self) {
-            self.0.store(true, Ordering::SeqCst);
-        }
-    }
-
     #[tokio::test]
     async fn ready_operation_error_wins_over_ready_signal() {
         for _ in 0..64 {
-            let error = cancel_on_signal(
-                async { Err::<(), _>(anyhow::anyhow!("provider failed")) },
+            let task = tokio::spawn(async { Err::<(), _>(anyhow::anyhow!("provider failed")) });
+            tokio::task::yield_now().await;
+            let error = cancel_task_on_signal(
+                task,
                 std::future::ready(()),
+                vera_core::CancellationToken::new(),
                 "test operation",
             )
             .await
@@ -534,26 +535,26 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn cancellation_drops_in_flight_operation() {
-        let dropped = Arc::new(AtomicBool::new(false));
-        let dropped_for_operation = dropped.clone();
+    async fn cancellation_waits_for_the_operation_to_stop() {
+        let cancellation = vera_core::CancellationToken::new();
+        let operation_cancellation = cancellation.clone();
         let (started_tx, started_rx) = tokio::sync::oneshot::channel();
 
-        let operation = async move {
-            let _marker = DropMarker(dropped_for_operation);
+        let task = tokio::spawn(async move {
             let _ = started_tx.send(());
-            std::future::pending::<()>().await;
-            Ok::<_, anyhow::Error>(())
-        };
+            while !operation_cancellation.is_cancelled() {
+                tokio::task::yield_now().await;
+            }
+            Err::<(), _>(anyhow::anyhow!("operation cancelled safely"))
+        });
         let signal = async move {
             let _ = started_rx.await;
         };
 
-        let error = cancel_on_signal(operation, signal, "test operation")
+        let error = cancel_task_on_signal(task, signal, cancellation, "test operation")
             .await
             .unwrap_err();
 
-        assert!(error.to_string().contains("test operation cancelled"));
-        assert!(dropped.load(Ordering::SeqCst));
+        assert_eq!(error.to_string(), "operation cancelled safely");
     }
 }

--- a/crates/vera-cli/src/helpers.rs
+++ b/crates/vera-cli/src/helpers.rs
@@ -8,9 +8,28 @@ use anyhow::Context;
 use clap::Args;
 use vera_core::presentation::{CompactResult, truncate_to_budget};
 
-/// Wait for the process interrupt used to cancel long-running CLI operations.
-pub async fn wait_for_interrupt() {
-    let _ = tokio::signal::ctrl_c().await;
+/// Install the process interrupt handler and return a future for its first event.
+#[cfg(unix)]
+pub fn wait_for_interrupt(
+    runtime: &tokio::runtime::Handle,
+) -> std::io::Result<impl std::future::Future<Output = ()> + Send + 'static> {
+    let _guard = runtime.enter();
+    let mut signal = tokio::signal::unix::signal(tokio::signal::unix::SignalKind::interrupt())?;
+    Ok(async move {
+        signal.recv().await;
+    })
+}
+
+/// Install the process interrupt handler and return a future for its first event.
+#[cfg(windows)]
+pub fn wait_for_interrupt(
+    runtime: &tokio::runtime::Handle,
+) -> std::io::Result<impl std::future::Future<Output = ()> + Send + 'static> {
+    let _guard = runtime.enter();
+    let mut signal = tokio::signal::windows::ctrl_c()?;
+    Ok(async move {
+        signal.recv().await;
+    })
 }
 
 /// Cancel a spawned operation when signalled, then wait for it to stop safely.

--- a/crates/vera-core/src/indexing/mod.rs
+++ b/crates/vera-core/src/indexing/mod.rs
@@ -17,7 +17,8 @@ pub use pipeline::{
 };
 pub use update::{
     UpdateOptions, UpdateProgress, UpdateSummary, content_hash, update_repository,
-    update_repository_with_options_and_progress, update_repository_with_progress,
+    update_repository_with_options_and_progress,
+    update_repository_with_options_and_progress_and_cancellation, update_repository_with_progress,
 };
 
 /// Truncate embedding vectors to at most `max_dim` dimensions.

--- a/crates/vera-core/src/indexing/pipeline.rs
+++ b/crates/vera-core/src/indexing/pipeline.rs
@@ -297,7 +297,7 @@ where
         Ok(embeddings) => embeddings,
         Err(error) => {
             // A completed provider error outranks a simultaneous cancellation,
-            // mirroring the biased select in the CLI's cancel_on_signal.
+            // mirroring the biased select in the CLI's cancel_task_on_signal.
             if matches!(error, EmbeddingError::Cancelled) {
                 cancellation.check()?;
             }

--- a/crates/vera-core/src/indexing/update.rs
+++ b/crates/vera-core/src/indexing/update.rs
@@ -106,12 +106,10 @@ struct PreparedFile {
     state: FileIndexState,
 }
 
-fn processed_file_counts(
-    files: impl IntoIterator<Item = (bool, FileIndexStatus)>,
-) -> (usize, usize) {
+fn processed_file_counts(files: impl IntoIterator<Item = bool>) -> (usize, usize) {
     files
         .into_iter()
-        .fold((0, 0), |(modified, added), (is_modified, _status)| {
+        .fold((0, 0), |(modified, added), is_modified| {
             if is_modified {
                 (modified + 1, added)
             } else {
@@ -585,11 +583,8 @@ where
     } else {
         super::truncate_embeddings(&mut embeddings, stored_dim)
     };
-    let (processed_modified, processed_added) = processed_file_counts(
-        prepared_files
-            .iter()
-            .map(|file| (file.modified, file.state.status)),
-    );
+    let (processed_modified, processed_added) =
+        processed_file_counts(prepared_files.iter().map(|file| file.modified));
 
     if !deleted.is_empty() || !prepared_files.is_empty() {
         let vector_path = idx_dir.join("vectors.db");

--- a/crates/vera-core/src/indexing/update.rs
+++ b/crates/vera-core/src/indexing/update.rs
@@ -40,9 +40,9 @@ use super::pipeline::FileError;
 /// Summary of an incremental update run.
 #[derive(Debug, Clone, serde::Serialize)]
 pub struct UpdateSummary {
-    /// Files that were modified and re-indexed.
+    /// Files that were modified and processed.
     pub files_modified: usize,
-    /// New files that were indexed.
+    /// New files that were processed.
     pub files_added: usize,
     /// Files that were deleted from the index.
     pub files_deleted: usize,
@@ -104,6 +104,20 @@ struct PreparedFile {
     references: Vec<parsing::references::RawReference>,
     type_relations: Vec<parsing::type_relations::RawTypeRelation>,
     state: FileIndexState,
+}
+
+fn processed_file_counts(
+    files: impl IntoIterator<Item = (bool, FileIndexStatus)>,
+) -> (usize, usize) {
+    files
+        .into_iter()
+        .fold((0, 0), |(modified, added), (is_modified, _status)| {
+            if is_modified {
+                (modified + 1, added)
+            } else {
+                (modified, added + 1)
+            }
+        })
 }
 
 /// Compute a SHA-256 content hash for a file's contents.
@@ -571,14 +585,11 @@ where
     } else {
         super::truncate_embeddings(&mut embeddings, stored_dim)
     };
-    let successful_modified = prepared_files
-        .iter()
-        .filter(|file| file.modified && file.state.status == FileIndexStatus::Indexed)
-        .count();
-    let successful_added = prepared_files
-        .iter()
-        .filter(|file| !file.modified && file.state.status == FileIndexStatus::Indexed)
-        .count();
+    let (processed_modified, processed_added) = processed_file_counts(
+        prepared_files
+            .iter()
+            .map(|file| (file.modified, file.state.status)),
+    );
 
     if !deleted.is_empty() || !prepared_files.is_empty() {
         let vector_path = idx_dir.join("vectors.db");
@@ -589,6 +600,7 @@ where
             Bm25Index::open(&bm25_dir).context("failed to open BM25 index for update")?;
 
         // All parsing and embedding work is complete. Writes below publish the prepared update.
+        cancellation.check()?;
         for file_path in &deleted {
             remove_file_from_index(&metadata_store, &vector_store, &bm25_index, file_path)?;
         }
@@ -662,8 +674,8 @@ where
     on_progress(UpdateProgress::StorageDone);
 
     let summary = UpdateSummary {
-        files_modified: successful_modified,
-        files_added: successful_added,
+        files_modified: processed_modified,
+        files_added: processed_added,
         files_deleted: deleted.len(),
         files_unchanged: unchanged,
         files_with_tree_sitter_errors: file_states

--- a/crates/vera-core/src/indexing/update.rs
+++ b/crates/vera-core/src/indexing/update.rs
@@ -22,9 +22,12 @@ use anyhow::{Context, Result, bail};
 use sha2::{Digest, Sha256};
 use tracing::{debug, info, warn};
 
+use crate::CancellationToken;
 use crate::config::VeraConfig;
 use crate::discovery;
-use crate::embedding::{EmbeddingProvider, embed_chunks_concurrent_with_progress};
+use crate::embedding::{
+    EmbeddingError, EmbeddingProvider, embed_chunks_concurrent_with_progress_and_cancellation,
+};
 use crate::parsing;
 use crate::storage::bm25::Bm25Index;
 use crate::storage::metadata::{FileIndexState, FileIndexStatus, MetadataStore};
@@ -214,7 +217,38 @@ where
     P: EmbeddingProvider,
     F: Fn(UpdateProgress) + Send + Sync,
 {
+    update_repository_with_options_and_progress_and_cancellation(
+        repo_path,
+        provider,
+        config,
+        model_name,
+        options,
+        on_progress,
+        &CancellationToken::new(),
+    )
+    .await
+}
+
+/// Incrementally update an index with progress reporting and cooperative cancellation.
+///
+/// Cancellation is observed through discovery, parsing, and embedding. Once publication
+/// starts, all index stores are updated before the operation returns so callers never
+/// receive a cancellation result while writes are still in progress.
+pub async fn update_repository_with_options_and_progress_and_cancellation<P, F>(
+    repo_path: &Path,
+    provider: &P,
+    config: &VeraConfig,
+    model_name: &str,
+    options: &UpdateOptions,
+    on_progress: F,
+    cancellation: &CancellationToken,
+) -> Result<UpdateSummary>
+where
+    P: EmbeddingProvider,
+    F: Fn(UpdateProgress) + Send + Sync,
+{
     let start = Instant::now();
+    cancellation.check()?;
 
     // ── 1. Validate path ─────────────────────────────────────────
     if !repo_path.exists() {
@@ -240,7 +274,8 @@ where
 
     // ── 2. Discover current files on disk ────────────────────────
     let disc =
-        discovery::discover_files(&repo_root, &config.indexing).context("file discovery failed")?;
+        discovery::discover_files_with_cancellation(&repo_root, &config.indexing, cancellation)
+            .context("file discovery failed")?;
     on_progress(UpdateProgress::DiscoveryDone {
         file_count: disc.files.len(),
     });
@@ -301,6 +336,7 @@ where
     // Read file contents and compute hashes for current files.
     let mut current_files: HashMap<String, String> = HashMap::new(); // rel_path → content
     for file in &disc.files {
+        cancellation.check()?;
         match discovery::read_source_lossy(&file.absolute_path) {
             Ok(content) => {
                 current_files.insert(file.relative_path.clone(), content);
@@ -324,6 +360,7 @@ where
     let mut unchanged = 0usize;
 
     for (rel_path, content) in &current_files {
+        cancellation.check()?;
         let language = detect_language_for_path(rel_path);
         let hash = hash_for_indexing_source(content, rel_path, language, &repo_root);
         let stored_hash = metadata_store
@@ -404,6 +441,7 @@ where
     if !files_to_index.is_empty() {
         // Parse and chunk new/modified files.
         for (rel_path, content, hash, is_modified) in &files_to_index {
+            cancellation.check()?;
             let language = detect_language_for_path(rel_path);
 
             // For RST, refs come from raw source; chunks from preprocessed.
@@ -446,17 +484,15 @@ where
                 "parsed file"
             );
 
-            if file_state.status == FileIndexStatus::Indexed {
-                prepared_files.push(PreparedFile {
-                    path: rel_path.clone(),
-                    hash: hash.clone(),
-                    modified: *is_modified,
-                    chunks,
-                    references: refs,
-                    type_relations,
-                    state: file_state,
-                });
-            }
+            prepared_files.push(PreparedFile {
+                path: rel_path.clone(),
+                hash: hash.clone(),
+                modified: *is_modified,
+                chunks,
+                references: refs,
+                type_relations,
+                state: file_state,
+            });
         }
     }
 
@@ -504,29 +540,45 @@ where
         let progress_cb = |done: usize, total: usize| {
             on_progress(UpdateProgress::EmbeddingProgress { done, total });
         };
-        let embeddings = embed_chunks_concurrent_with_progress(
+        let embedding_result = embed_chunks_concurrent_with_progress_and_cancellation(
             provider,
             &all_chunks,
             batch_size,
             max_concurrent_requests,
             config.indexing.max_chunk_bytes,
+            cancellation.as_async_token(),
             progress_cb,
         )
-        .await
-        .context("embedding generation failed")?;
+        .await;
+        let embeddings = match embedding_result {
+            Ok(embeddings) => embeddings,
+            Err(error) => {
+                if matches!(error, EmbeddingError::Cancelled) {
+                    cancellation.check()?;
+                }
+                return Err(error).context("embedding generation failed");
+            }
+        };
         on_progress(UpdateProgress::EmbeddingDone {
             count: embeddings.len(),
         });
         embeddings
     };
+    cancellation.check()?;
 
     let final_stored_dim = if embeddings.is_empty() {
         stored_dim
     } else {
         super::truncate_embeddings(&mut embeddings, stored_dim)
     };
-    let successful_modified = prepared_files.iter().filter(|file| file.modified).count();
-    let successful_added = prepared_files.len() - successful_modified;
+    let successful_modified = prepared_files
+        .iter()
+        .filter(|file| file.modified && file.state.status == FileIndexStatus::Indexed)
+        .count();
+    let successful_added = prepared_files
+        .iter()
+        .filter(|file| !file.modified && file.state.status == FileIndexStatus::Indexed)
+        .count();
 
     if !deleted.is_empty() || !prepared_files.is_empty() {
         let vector_path = idx_dir.join("vectors.db");
@@ -541,9 +593,23 @@ where
             remove_file_from_index(&metadata_store, &vector_store, &bm25_index, file_path)?;
         }
 
-        for file in prepared_files.iter().filter(|file| file.modified) {
+        // A previous attempt may have failed after writing one store but before
+        // committing the file hash. Cleaning every prepared path makes retries
+        // idempotent for both modified and newly added files.
+        for file in &prepared_files {
             remove_file_parse_data(&metadata_store, &file.path)?;
-            remove_file_chunk_data(&metadata_store, &vector_store, &bm25_index, &file.path)?;
+            // Chunk metadata is inserted before vectors and BM25 documents and
+            // removed after them, so it witnesses a partial added-file publish.
+            let has_partial_chunks = !metadata_store
+                .get_chunks_by_file(&file.path)
+                .context("failed to inspect existing chunks before publication")?
+                .is_empty();
+            if file.modified || has_partial_chunks {
+                remove_file_chunk_data(&metadata_store, &vector_store, &bm25_index, &file.path)?;
+            }
+            metadata_store
+                .delete_file_state(&file.path)
+                .with_context(|| format!("failed to delete file state for {}", file.path))?;
         }
 
         for file in &prepared_files {

--- a/crates/vera-core/src/indexing/update_tests.rs
+++ b/crates/vera-core/src/indexing/update_tests.rs
@@ -156,14 +156,8 @@ fn content_hash_is_hex_sha256() {
 }
 
 #[test]
-fn processed_file_counts_include_parse_errors() {
-    assert_eq!(
-        processed_file_counts([
-            (true, FileIndexStatus::ParseError),
-            (false, FileIndexStatus::Indexed),
-        ]),
-        (1, 1)
-    );
+fn processed_file_counts_cover_modified_and_added_files() {
+    assert_eq!(processed_file_counts([true, false]), (1, 1));
 }
 
 // ── Update: no changes ──────────────────────────────────────────────

--- a/crates/vera-core/src/indexing/update_tests.rs
+++ b/crates/vera-core/src/indexing/update_tests.rs
@@ -23,7 +23,7 @@ use crate::storage::metadata::{FileIndexState, FileIndexStatus, MetadataStore};
 use crate::storage::vector::VectorStore;
 use crate::types::Language;
 
-use super::content_hash;
+use super::{content_hash, processed_file_counts};
 
 fn default_config() -> VeraConfig {
     VeraConfig::default()
@@ -153,6 +153,17 @@ fn content_hash_is_hex_sha256() {
     // SHA-256 hex is 64 characters.
     assert_eq!(h.len(), 64);
     assert!(h.chars().all(|c| c.is_ascii_hexdigit()));
+}
+
+#[test]
+fn processed_file_counts_include_parse_errors() {
+    assert_eq!(
+        processed_file_counts([
+            (true, FileIndexStatus::ParseError),
+            (false, FileIndexStatus::Indexed),
+        ]),
+        (1, 1)
+    );
 }
 
 // ── Update: no changes ──────────────────────────────────────────────
@@ -358,7 +369,7 @@ async fn update_cancellation_stops_embedding_before_publication() {
         &operation_cancellation,
     );
 
-    let (result, ()) = tokio::time::timeout(Duration::from_millis(250), async {
+    let (result, ()) = tokio::time::timeout(Duration::from_secs(5), async {
         tokio::join!(update, cancel_after_start)
     })
     .await

--- a/crates/vera-core/src/indexing/update_tests.rs
+++ b/crates/vera-core/src/indexing/update_tests.rs
@@ -1,21 +1,27 @@
 //! Tests for incremental update logic.
 
+use std::collections::HashSet;
 use std::fs;
+use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;
 
 use tempfile::TempDir;
 
+use crate::CancellationToken;
 use crate::config::VeraConfig;
 use crate::embedding::test_helpers::MockProvider;
 use crate::embedding::{EmbeddingError, EmbeddingProvider};
 use crate::indexing::{
     UpdateOptions, UpdateProgress, index_dir, index_repository, update_repository,
-    update_repository_with_options_and_progress, update_repository_with_progress,
+    update_repository_with_options_and_progress,
+    update_repository_with_options_and_progress_and_cancellation, update_repository_with_progress,
 };
+use crate::parsing::type_relations::{RawTypeRelation, TypeRelationKind};
 use crate::storage::bm25::Bm25Index;
-use crate::storage::metadata::MetadataStore;
+use crate::storage::metadata::{FileIndexState, FileIndexStatus, MetadataStore};
 use crate::storage::vector::VectorStore;
+use crate::types::Language;
 
 use super::content_hash;
 
@@ -57,12 +63,27 @@ struct BatchBoundProvider {
 
 struct FailingProvider;
 
+struct BlockingProvider {
+    started: Arc<tokio::sync::Notify>,
+}
+
 impl EmbeddingProvider for FailingProvider {
     async fn embed_batch(&self, _texts: &[String]) -> Result<Vec<Vec<f32>>, EmbeddingError> {
         Err(EmbeddingError::ApiError {
             status: 503,
             message: "provider unavailable".to_string(),
         })
+    }
+
+    fn expected_dim(&self) -> Option<usize> {
+        Some(8)
+    }
+}
+
+impl EmbeddingProvider for BlockingProvider {
+    async fn embed_batch(&self, _texts: &[String]) -> Result<Vec<Vec<f32>>, EmbeddingError> {
+        self.started.notify_one();
+        std::future::pending().await
     }
 
     fn expected_dim(&self) -> Option<usize> {
@@ -279,6 +300,7 @@ async fn update_embedding_failure_preserves_existing_parse_data() {
     .await;
     let idx = index_dir(&dir.path().canonicalize().unwrap());
     let metadata = MetadataStore::open(&idx.join("metadata.db")).unwrap();
+    let hash_before = metadata.get_file_hash("types.ts").unwrap();
     assert_eq!(metadata.find_type_relations("Loader").unwrap().len(), 1);
 
     fs::write(
@@ -291,8 +313,171 @@ async fn update_embedding_failure_preserves_existing_parse_data() {
         .await
         .unwrap_err();
     assert!(error.to_string().contains("embedding generation failed"));
+    assert_eq!(metadata.get_file_hash("types.ts").unwrap(), hash_before);
     assert_eq!(metadata.find_type_relations("Loader").unwrap().len(), 1);
     assert!(metadata.find_type_relations("Saver").unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn update_cancellation_stops_embedding_before_publication() {
+    let (dir, _provider, config, _) =
+        indexed_repo(&[("main.rs", "fn preserved_symbol() -> u32 { 42 }\n")]).await;
+    let idx = index_dir(&dir.path().canonicalize().unwrap());
+    let metadata = MetadataStore::open(&idx.join("metadata.db")).unwrap();
+    let hash_before = metadata.get_file_hash("main.rs").unwrap();
+    let chunks_before: Vec<_> = metadata
+        .get_chunks_by_file("main.rs")
+        .unwrap()
+        .into_iter()
+        .map(|chunk| (chunk.id, chunk.content))
+        .collect();
+    fs::write(
+        dir.path().join("main.rs"),
+        "fn replacement_symbol() -> u32 { 7 }\n",
+    )
+    .unwrap();
+
+    let started = Arc::new(tokio::sync::Notify::new());
+    let provider = BlockingProvider {
+        started: Arc::clone(&started),
+    };
+    let cancellation = CancellationToken::new();
+    let operation_cancellation = cancellation.clone();
+    let cancel_after_start = async {
+        started.notified().await;
+        cancellation.cancel();
+    };
+    let options = UpdateOptions::default();
+    let update = update_repository_with_options_and_progress_and_cancellation(
+        dir.path(),
+        &provider,
+        &config,
+        "mock-model",
+        &options,
+        |_| {},
+        &operation_cancellation,
+    );
+
+    let (result, ()) = tokio::time::timeout(Duration::from_millis(250), async {
+        tokio::join!(update, cancel_after_start)
+    })
+    .await
+    .expect("cancellation must stop the active update embedding request");
+    let error = result.unwrap_err();
+    assert!(format!("{error:#}").contains("cancel"));
+    assert_eq!(metadata.get_file_hash("main.rs").unwrap(), hash_before);
+    let chunks_after: Vec<_> = metadata
+        .get_chunks_by_file("main.rs")
+        .unwrap()
+        .into_iter()
+        .map(|chunk| (chunk.id, chunk.content))
+        .collect();
+    assert_eq!(chunks_after, chunks_before);
+}
+
+#[tokio::test]
+async fn update_cancellation_after_embedding_does_not_publish_changes() {
+    let (dir, provider, config, _) =
+        indexed_repo(&[("main.rs", "fn preserved_symbol() -> u32 { 42 }\n")]).await;
+    let idx = index_dir(&dir.path().canonicalize().unwrap());
+    let metadata = MetadataStore::open(&idx.join("metadata.db")).unwrap();
+    let hash_before = metadata.get_file_hash("main.rs").unwrap();
+    fs::write(
+        dir.path().join("main.rs"),
+        "fn replacement_symbol() -> u32 { 7 }\n",
+    )
+    .unwrap();
+
+    let cancellation = CancellationToken::new();
+    let progress_cancellation = cancellation.clone();
+    let error = update_repository_with_options_and_progress_and_cancellation(
+        dir.path(),
+        &provider,
+        &config,
+        "mock-model",
+        &UpdateOptions::default(),
+        move |event| {
+            if matches!(event, UpdateProgress::EmbeddingDone { .. }) {
+                progress_cancellation.cancel();
+            }
+        },
+        &cancellation,
+    )
+    .await
+    .unwrap_err();
+
+    assert!(error.to_string().contains("cancel"));
+    assert_eq!(metadata.get_file_hash("main.rs").unwrap(), hash_before);
+    let bm25 = Bm25Index::open(&idx.join("bm25")).unwrap();
+    assert!(!bm25.search("preserved_symbol", 10).unwrap().is_empty());
+    assert!(bm25.search("replacement_symbol", 10).unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn update_cleans_partial_added_file_artifacts_before_retry() {
+    let (dir, provider, config, _) = indexed_repo(&[("main.rs", "fn main() {}\n")]).await;
+    let idx = index_dir(&dir.path().canonicalize().unwrap());
+    let metadata = MetadataStore::open(&idx.join("metadata.db")).unwrap();
+    let source = "class Loader {}\nclass CachedLoader extends Loader {}\n";
+    fs::write(dir.path().join("types.ts"), source).unwrap();
+
+    let (partial_chunks, _) =
+        crate::parsing::parse_file(source, "types.ts", Language::TypeScript, &config.indexing)
+            .unwrap();
+    metadata.insert_chunks(&partial_chunks).unwrap();
+    let partial_vectors: Vec<_> = partial_chunks
+        .iter()
+        .map(|chunk| (chunk.id.as_str(), vec![0.0; 8]))
+        .collect();
+    let partial_vector_refs: Vec<_> = partial_vectors
+        .iter()
+        .map(|(id, vector)| (*id, vector.as_slice()))
+        .collect();
+    VectorStore::open(&idx.join("vectors.db"), 8)
+        .unwrap()
+        .insert_batch(&partial_vector_refs)
+        .unwrap();
+    let bm25 = Bm25Index::open(&idx.join("bm25")).unwrap();
+    bm25.insert_chunks(&partial_chunks).unwrap();
+
+    let partial_relation = RawTypeRelation {
+        owner: "CachedLoader".to_string(),
+        target: "Loader".to_string(),
+        line: 2,
+        kind: TypeRelationKind::Extends,
+    };
+    metadata
+        .insert_type_relations("types.ts", &[partial_relation])
+        .unwrap();
+    metadata
+        .upsert_file_state(&FileIndexState {
+            file_path: "types.ts".to_string(),
+            language: "typescript".to_string(),
+            status: FileIndexStatus::Indexed,
+            tree_has_error: false,
+            tier0_fallback: false,
+            chunk_count: 1,
+        })
+        .unwrap();
+    assert!(metadata.get_file_hash("types.ts").unwrap().is_none());
+
+    let summary = update_repository(dir.path(), &provider, &config, "mock-model")
+        .await
+        .unwrap();
+
+    assert_eq!(summary.files_added, 1);
+    assert_eq!(metadata.find_type_relations("Loader").unwrap().len(), 1);
+    assert!(metadata.get_file_hash("types.ts").unwrap().is_some());
+    let bm25_results = bm25.search("Loader", 100).unwrap();
+    let unique_chunk_ids: HashSet<_> = bm25_results.iter().map(|result| &result.chunk_id).collect();
+    assert_eq!(bm25_results.len(), unique_chunk_ids.len());
+    assert_eq!(
+        VectorStore::open(&idx.join("vectors.db"), 8)
+            .unwrap()
+            .count()
+            .unwrap(),
+        metadata.chunk_count().unwrap()
+    );
 }
 
 #[tokio::test]

--- a/crates/vera-core/src/retrieval/vector.rs
+++ b/crates/vera-core/src/retrieval/vector.rs
@@ -199,7 +199,6 @@ mod tests {
     use super::*;
     use crate::embedding::test_helpers::MockProvider;
     use crate::types::{Chunk, Language, SymbolType};
-    use anyhow::Context;
 
     /// The pool must never ask sqlite-vec for more than it will serve, and must
     /// report the shortfall so a degraded pool is diagnosable rather than silent.


### PR DESCRIPTION

---

## Summary

This follows PR #60 and closes the remaining indexing publication gaps found during review.

- Thread the shared cancellation token through incremental discovery, parsing, and embedding.
- Run CLI indexing operations in spawned tasks so SIGINT handling is active before synchronous discovery begins.
- Cancel cooperatively and await the operation instead of aborting a task while index publication may still be running.
- Persist current hashes and `ParseError` states for files that no longer parse, removing stale searchable content.
- Clean partial artifacts before retrying added files so references, vectors, and BM25 documents are not duplicated.

## Behavior

Existing update APIs keep their behavior and call the new cancellation-aware entry point with a fresh token. `vera index` and `vera update` now return cancellation before publication starts. If SIGINT arrives after synchronous publication begins, the CLI waits and returns the actual publication result.

A modified file that fails parsing no longer remains searchable under its previous `Indexed` state. The update removes its old chunks and stores the new hash with `ParseError`, matching full-index behavior. No schema migration is required.

The file hash remains the publication marker. Retry cleanup uses chunk metadata as evidence of partial vector or BM25 publication because chunk metadata is inserted first and removed last.

## Review Hotspots

- `crates/vera-cli/src/helpers.rs`: signal handling cancels the token and awaits the spawned task without aborting publication.
- `crates/vera-core/src/indexing/update.rs`: cancellation stops before writes; publication then runs to completion. Cleanup covers modified files and partially published additions.

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p vera-core -p vera-cli`: 774 core tests and 92 CLI tests passed.
- `cargo clippy -p vera-core -p vera-cli --all-targets`: passed with two pre-existing warnings in untouched files.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes incremental update publication cancellation-safe and idempotent. Interrupted updates no longer leave stale content or duplicate artifacts; the CLI installs an interrupt handler before work starts, cancels cooperatively, and returns the real publication result if a signal arrives after publishing begins. Summaries now count processed files regardless of final status, and “up to date” only prints when there are no changes and no parse errors. No schema migration.

- Review focus
  - `crates/vera-cli/src/helpers.rs`: `wait_for_interrupt(rt.handle())` and `cancel_task_on_signal` semantics; callers in `commands/index.rs` and `commands/update.rs` spawn tasks and pass a shared cancellation token.
  - `crates/vera-core/src/indexing/update.rs`: new `update_repository_with_options_and_progress_and_cancellation`; cancellation checkpoints across discovery (`discover_files_with_cancellation`), content reads, parsing, and embedding (`embed_chunks_concurrent_with_progress_and_cancellation`); idempotent cleanup of parse/chunk data and file state before publication; provider errors outrank simultaneous cancellation.
  - `crates/vera-core/src/indexing/update_tests.rs`: coverage for cancellation timing, processed-counts semantics, and partial added-file cleanup.

<sup>Written for commit 72bada9d6ef7b1a8630f62ce04e9ee05fa54d8d2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/VeraTools/Vera/pull/83?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Indexing and repository updates can now be cancelled safely during processing.
  * Interrupted updates preserve data consistency and support reliable retries.
* **Bug Fixes**
  * Improved cleanup of partial indexing results after failures or cancellation.
  * Prevented duplicate search entries and inconsistent metadata, chunk, and vector counts.
* **Tests**
  * Expanded coverage for cancellation, failures, retries, and partial update cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->