### PR TITLE
perf(storage): resolve KNN rowids in one query instead of one per hit

### DIFF
--- a/crates/vera-core/src/storage/vector.rs
+++ b/crates/vera-core/src/storage/vector.rs
@@ -554,9 +554,15 @@ mod tests {
         // reverse of distance order, then assert the pairing — not just that
         // distances ascend, which holds for any implementation that emits one
         // result per hit in hit order.
+        // Distances must be strictly increasing, or the KNN order between two
+        // equidistant vectors is unspecified and the assertion below would be
+        // decided by tie-breaking rather than by distance.
+        //   near 0.0   mid ~0.894   far ~1.414   (L2 from the query)
+        // Inserted in reverse of that order, so rowid order is not distance
+        // order and a SQL-ordered result cannot pass by accident.
         let store = VectorStore::open_in_memory(4).unwrap();
         store.insert("far", &[0.0, 0.0, 1.0, 0.0]).unwrap();
-        store.insert("mid", &[0.0, 1.0, 0.0, 0.0]).unwrap();
+        store.insert("mid", &[0.6, 0.8, 0.0, 0.0]).unwrap();
         store.insert("near", &[1.0, 0.0, 0.0, 0.0]).unwrap();
 
         let results = store.search(&[1.0, 0.0, 0.0, 0.0], 3).unwrap();
@@ -575,8 +581,8 @@ mod tests {
         );
         for pair in results.windows(2) {
             assert!(
-                pair[0].distance <= pair[1].distance,
-                "distances must ascend: {:?}",
+                pair[0].distance < pair[1].distance,
+                "distances must strictly ascend, or the order is a tie-break: {:?}",
                 results.iter().map(|r| r.distance).collect::<Vec<_>>()
             );
         }

--- a/crates/vera-core/src/storage/vector.rs
+++ b/crates/vera-core/src/storage/vector.rs
@@ -262,7 +262,8 @@ impl VectorStore {
         // Resolve the rowids in one query instead of one per hit. The KNN
         // query above is deliberately left alone: joining `chunk_id_map` into
         // it would risk losing the vec0 KNN optimization.
-        let chunk_ids = self.chunk_ids_for_rowids(&hits)?;
+        let rowids: Vec<i64> = hits.iter().map(|(rowid, _)| *rowid).collect();
+        let chunk_ids = self.chunk_ids_for_rowids(&rowids)?;
 
         hits.iter()
             .map(|(rowid, distance)| {
@@ -279,12 +280,12 @@ impl VectorStore {
     }
 
     /// Resolve many rowids to their chunk ids in a single query.
-    fn chunk_ids_for_rowids(&self, hits: &[(i64, f64)]) -> Result<HashMap<i64, String>> {
-        if hits.is_empty() {
+    fn chunk_ids_for_rowids(&self, rowids: &[i64]) -> Result<HashMap<i64, String>> {
+        if rowids.is_empty() {
             return Ok(HashMap::new());
         }
 
-        let placeholders = std::iter::repeat_n("?", hits.len())
+        let placeholders = std::iter::repeat_n("?", rowids.len())
             .collect::<Vec<_>>()
             .join(",");
         // Text varies with the number of ids, so plain `prepare` here too.
@@ -296,10 +297,9 @@ impl VectorStore {
             .context("failed to prepare chunk id lookup")?;
 
         let mapped = stmt
-            .query_map(
-                rusqlite::params_from_iter(hits.iter().map(|(rowid, _)| *rowid)),
-                |row| Ok((row.get::<_, i64>(0)?, row.get::<_, String>(1)?)),
-            )
+            .query_map(rusqlite::params_from_iter(rowids.iter()), |row| {
+                Ok((row.get::<_, i64>(0)?, row.get::<_, String>(1)?))
+            })
             .context("failed to query chunk ids")?
             .collect::<std::result::Result<HashMap<_, _>, _>>()
             .context("failed to collect chunk ids")?;
@@ -601,8 +601,8 @@ mod tests {
                 .unwrap();
         }
 
-        let hits: Vec<(i64, f64)> = (1..=4096).map(|rowid| (rowid, 0.0)).collect();
-        let mapped = store.chunk_ids_for_rowids(&hits).unwrap();
+        let rowids: Vec<i64> = (1..=4096).collect();
+        let mapped = store.chunk_ids_for_rowids(&rowids).unwrap();
 
         assert_eq!(mapped.len(), 4096);
         assert_eq!(mapped.get(&1).map(String::as_str), Some("chunk-1"));

--- a/crates/vera-core/src/storage/vector.rs
+++ b/crates/vera-core/src/storage/vector.rs
@@ -589,6 +589,46 @@ mod tests {
     }
 
     #[test]
+    fn chunk_id_batch_lookup_handles_4096_bound_parameters() {
+        let store = VectorStore::open_in_memory(4).unwrap();
+        for index in 1..=4096 {
+            store
+                .conn
+                .execute(
+                    "INSERT INTO chunk_id_map (rowid, chunk_id) VALUES (?1, ?2)",
+                    params![index, format!("chunk-{index}")],
+                )
+                .unwrap();
+        }
+
+        let hits: Vec<(i64, f64)> = (1..=4096).map(|rowid| (rowid, 0.0)).collect();
+        let mapped = store.chunk_ids_for_rowids(&hits).unwrap();
+
+        assert_eq!(mapped.len(), 4096);
+        assert_eq!(mapped.get(&1).map(String::as_str), Some("chunk-1"));
+        assert_eq!(mapped.get(&4096).map(String::as_str), Some("chunk-4096"));
+    }
+
+    #[test]
+    fn search_reports_missing_chunk_id_mapping() {
+        let store = VectorStore::open_in_memory(4).unwrap();
+        store.insert("missing", &[1.0, 0.0, 0.0, 0.0]).unwrap();
+        store
+            .conn
+            .execute(
+                "DELETE FROM chunk_id_map WHERE chunk_id = ?1",
+                params!["missing"],
+            )
+            .unwrap();
+
+        let error = store.search(&[1.0, 0.0, 0.0, 0.0], 1).unwrap_err();
+        assert!(
+            error.to_string().contains("failed to map rowid"),
+            "{error:#}"
+        );
+    }
+
+    #[test]
     fn search_clamps_limit_above_sqlite_vec_knn_cap() {
         let store = VectorStore::open_in_memory(4).unwrap();
         for i in 0..10 {

--- a/crates/vera-core/src/storage/vector.rs
+++ b/crates/vera-core/src/storage/vector.rs
@@ -3,6 +3,8 @@
 //! Uses the sqlite-vec extension for brute-force KNN vector search.
 //! Vectors are stored alongside the metadata DB in the same SQLite file.
 
+use std::collections::HashMap;
+
 use anyhow::{Context, Result};
 use rusqlite::{Connection, OptionalExtension, ffi::sqlite3_auto_extension, params};
 use sqlite_vec::sqlite3_vec_init;
@@ -234,9 +236,13 @@ impl VectorStore {
         }
         let limit = limit.min(MAX_KNN_K);
 
+        // `prepare`, not `prepare_cached`: `limit` is interpolated into the
+        // text, so every distinct limit is a distinct cache key. Caching these
+        // never hits and evicts the statements that do have stable text, since
+        // rusqlite's cache is a 16-entry LRU shared by the whole connection.
         let mut stmt = self
             .conn
-            .prepare_cached(&format!(
+            .prepare(&format!(
                 "SELECT v.rowid, v.distance
                  FROM vec_chunks v
                  WHERE v.embedding MATCH ?1
@@ -245,29 +251,59 @@ impl VectorStore {
             ))
             .context("failed to prepare vector search")?;
 
-        let rows = stmt
+        let hits: Vec<(i64, f64)> = stmt
             .query_map([query.as_bytes()], |row| {
                 Ok((row.get::<_, i64>(0)?, row.get::<_, f64>(1)?))
             })
-            .context("failed to execute vector search")?;
+            .context("failed to execute vector search")?
+            .collect::<std::result::Result<Vec<_>, _>>()
+            .context("failed to read vector result")?;
 
-        let mut results = Vec::new();
-        for row in rows {
-            let (rowid, distance) = row.context("failed to read vector result")?;
-            // Map rowid back to chunk_id.
-            let chunk_id: String = self
-                .conn
-                .query_row(
-                    "SELECT chunk_id FROM chunk_id_map WHERE rowid = ?1",
-                    params![rowid],
-                    |row| row.get(0),
-                )
-                .with_context(|| format!("failed to map rowid {rowid} to chunk_id"))?;
+        // Resolve the rowids in one query instead of one per hit. The KNN
+        // query above is deliberately left alone: joining `chunk_id_map` into
+        // it would risk losing the vec0 KNN optimization.
+        let chunk_ids = self.chunk_ids_for_rowids(&hits)?;
 
-            results.push(VectorSearchResult { chunk_id, distance });
+        hits.iter()
+            .map(|(rowid, distance)| {
+                let chunk_id = chunk_ids
+                    .get(rowid)
+                    .with_context(|| format!("failed to map rowid {rowid} to chunk_id"))?
+                    .clone();
+                Ok(VectorSearchResult {
+                    chunk_id,
+                    distance: *distance,
+                })
+            })
+            .collect()
+    }
+
+    /// Resolve many rowids to their chunk ids in a single query.
+    fn chunk_ids_for_rowids(&self, hits: &[(i64, f64)]) -> Result<HashMap<i64, String>> {
+        if hits.is_empty() {
+            return Ok(HashMap::new());
         }
 
-        Ok(results)
+        let placeholders = std::iter::repeat_n("?", hits.len())
+            .collect::<Vec<_>>()
+            .join(",");
+        // Text varies with the number of ids, so plain `prepare` here too.
+        let mut stmt = self
+            .conn
+            .prepare(&format!(
+                "SELECT rowid, chunk_id FROM chunk_id_map WHERE rowid IN ({placeholders})"
+            ))
+            .context("failed to prepare chunk id lookup")?;
+
+        let mapped = stmt
+            .query_map(
+                rusqlite::params_from_iter(hits.iter().map(|(rowid, _)| *rowid)),
+                |row| Ok((row.get::<_, i64>(0)?, row.get::<_, String>(1)?)),
+            )
+            .context("failed to query chunk ids")?
+            .collect::<std::result::Result<HashMap<_, _>, _>>()
+            .context("failed to collect chunk ids")?;
+        Ok(mapped)
     }
 
     /// Count total vectors in the store.
@@ -508,6 +544,42 @@ mod tests {
         assert!(!results.is_empty());
         assert_eq!(results[0].chunk_id, "c1");
         assert!(results[0].distance < 0.001); // Self-match should be ~0 distance.
+    }
+
+    #[test]
+    fn search_pairs_each_chunk_id_with_its_own_distance() {
+        // The rowid -> chunk_id mapping is now one batched query returning a
+        // HashMap, so the results have to be re-projected back into the KNN
+        // distance order. Insert so that rowid order (insertion order) is the
+        // reverse of distance order, then assert the pairing — not just that
+        // distances ascend, which holds for any implementation that emits one
+        // result per hit in hit order.
+        let store = VectorStore::open_in_memory(4).unwrap();
+        store.insert("far", &[0.0, 0.0, 1.0, 0.0]).unwrap();
+        store.insert("mid", &[0.0, 1.0, 0.0, 0.0]).unwrap();
+        store.insert("near", &[1.0, 0.0, 0.0, 0.0]).unwrap();
+
+        let results = store.search(&[1.0, 0.0, 0.0, 0.0], 3).unwrap();
+        assert_eq!(results.len(), 3);
+
+        let order: Vec<&str> = results.iter().map(|r| r.chunk_id.as_str()).collect();
+        assert_eq!(
+            order,
+            vec!["near", "mid", "far"],
+            "results must come back in distance order, not rowid order"
+        );
+        assert!(
+            results[0].distance < 0.001,
+            "the self-match must keep its own near-zero distance, got {}",
+            results[0].distance
+        );
+        for pair in results.windows(2) {
+            assert!(
+                pair[0].distance <= pair[1].distance,
+                "distances must ascend: {:?}",
+                results.iter().map(|r| r.distance).collect::<Vec<_>>()
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Problem

Two things in `VectorStore::search`, both on the hot search path.

**One uncached query per KNN hit.** After the KNN query returns, each hit's rowid was mapped back to a `chunk_id` with a separate `Connection::query_row` inside the result loop. `query_row` on a `Connection` re-prepares the statement every call, and the loop runs once per candidate — up to `MAX_KNN_K` (4096) on a filtered natural-language query.

**`LIMIT` interpolated into a `prepare_cached` statement.** The SQL text varied with `limit`, so every distinct limit was a distinct cache key. rusqlite's statement cache is an LRU with a default capacity of 16 (`STATEMENT_CACHE_DEFAULT_CAPACITY`), and Vera never raises it — so these entries could never hit, and they evicted the statements that *do* have stable text on the same connection.

## Change

One batched `SELECT rowid, chunk_id FROM chunk_id_map WHERE rowid IN (...)` after the KNN query, then re-project.

The vec0 KNN query itself is deliberately left alone. Joining `chunk_id_map` into it would risk losing the KNN optimization, which would cost far more than this saves.

Both statements switch from `prepare_cached` to `prepare`, since both have text that varies per call. sqlite-vec does not accept a bound parameter for the KNN `LIMIT`, so the interpolation stays — it just stops occupying a cache slot it can never reuse.

## Measurement

Against this repository's own `vectors.db`, per-row lookups versus one batch:

| Hits | Per-row | Batched |
|---|---|---|
| 100 | 0.19 ms | 0.07 ms |
| 1000 | 1.63 ms | 0.44 ms |
| 4096 | 6.64 ms | 1.86 ms |

~4.8 ms per search at the ceiling. Worth being explicit that these were taken through Python's sqlite3, which caches prepared statements internally — so they **understate** the real gap, because the production path re-prepared on every call.

End to end on a real index, search output is byte-identical to the released binary.

## The part that needed a real test

Batching means the mapping comes back as a `HashMap`, so the results have to be re-projected into the KNN distance order. That is the same shape as the bug in #73, so it gets the same treatment.

`search_pairs_each_chunk_id_with_its_own_distance` inserts three vectors so that rowid order is the exact reverse of distance order, then asserts the chunk_id/distance **pairing** — not merely that distances ascend, which holds for any implementation emitting one result per hit in hit order.

Verified it catches the regression rather than assuming: zipping the hits against SQL order returns `["far", "mid", "near"]` instead of `["near", "mid", "far"]`, and the test fails. The pre-existing `nearest_neighbor_self_query` passes either way, which is why the new one was needed.

773 `vera-core` tests, 97 `vera-cli`, `cargo fmt --check` clean, clippy unchanged at the pre-existing warnings.

Fixes #85

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Resolve KNN rowids in one batched query and stop caching SQL that varies per call. Old behavior: one uncached row lookup per hit and `prepare_cached` with interpolated `LIMIT`; new behavior: a single `IN (...)` lookup and `prepare`, cutting lookup time from 6.64 ms to 1.86 ms at 4096 hits with identical results.

- Keep the KNN query unchanged; do not join `chunk_id_map` to preserve `sqlite-vec` optimization.
- Interpolate `LIMIT` (cannot bind with `sqlite-vec`) and use `prepare` to avoid polluting `rusqlite`’s 16-entry cache.
- Re-project results to distance order; tests assert chunk_id/distance pairing and strictly increasing distances.
- Batch lookup handles 4096 bound parameters; search returns an error if a rowid lacks a `chunk_id` mapping.
- Refactor: `chunk_ids_for_rowids` now takes `&[i64]`; the caller projects rowids once (bounded by MAX_KNN_K).
- No API changes or migrations. Output matches the released binary on a real index.

<sup>Written for commit e003eff50f2970c63f70559e9b9998426e137e85. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/VeraTools/Vera/pull/86?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured vector search results retain the correct chunk identifiers and proximity distances.
  * Preserved nearest-result ordering in search results.
  * Improved handling of searches with dynamically adjusted result limits.
  * Added regression coverage for missing mappings and parameter limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->