### PR TITLE
fix(parsing): select the signature grammar by path, like indexing does

### DIFF
--- a/crates/vera-cli/src/helpers.rs
+++ b/crates/vera-cli/src/helpers.rs
@@ -341,7 +341,7 @@ pub fn output_results(
     let compacted: Vec<String> = if compact {
         results
             .iter()
-            .map(|r| extract_signature(&r.content, r.language))
+            .map(|r| extract_signature(&r.content, r.language, &r.file_path))
             .collect()
     } else {
         Vec::new()

--- a/crates/vera-cli/src/helpers.rs
+++ b/crates/vera-cli/src/helpers.rs
@@ -335,13 +335,13 @@ pub fn output_results(
     compact: bool,
     budget: usize,
 ) {
-    use vera_core::parsing::signatures::extract_signature;
+    use vera_core::parsing::signatures::extract_signature_for_path;
 
     // When compact mode is on, pre-compute signature-only content for each result.
     let compacted: Vec<String> = if compact {
         results
             .iter()
-            .map(|r| extract_signature(&r.content, r.language, &r.file_path))
+            .map(|r| extract_signature_for_path(&r.content, r.language, &r.file_path))
             .collect()
     } else {
         Vec::new()

--- a/crates/vera-core/src/parsing/signatures.rs
+++ b/crates/vera-core/src/parsing/signatures.rs
@@ -185,12 +185,13 @@ mod tests {
         );
 
         // The same content under a .ts path keeps the old behaviour, which is
-        // correct: there the angle brackets really are type syntax.
+        // correct: there the angle brackets really are type syntax. Assert the
+        // exact `first_n_lines` output rather than merely "not the tsx one" —
+        // a differently malformed signature would satisfy a negative check.
         let ts = extract_signature(code, Language::TypeScript, "Widget.ts");
-        assert_ne!(ts, tsx);
-        assert!(
-            !ts.contains("{ ... }"),
-            "the .ts path should fall back, got: {ts}"
+        assert_eq!(
+            ts,
+            "const A = <p>{ q }</p>;\nfunction Later(x: number) {\n  return x;\n[... 1 more lines]"
         );
     }
 

--- a/crates/vera-core/src/parsing/signatures.rs
+++ b/crates/vera-core/src/parsing/signatures.rs
@@ -8,7 +8,7 @@ use tree_sitter::Parser;
 
 use crate::types::Language;
 
-use super::languages::tree_sitter_grammar;
+use super::languages::tree_sitter_grammar_for_path;
 
 /// Body node kinds per language family. The first match wins.
 fn body_node_kinds(lang: Language) -> &'static [&'static str] {
@@ -84,8 +84,8 @@ fn body_placeholder(lang: Language) -> &'static str {
 ///
 /// Returns `None` if the language has no grammar, parsing fails, or no
 /// body node is found (caller should use the fallback).
-fn extract_signature_inner(content: &str, lang: Language) -> Option<String> {
-    let grammar = tree_sitter_grammar(lang)?;
+fn extract_signature_inner(content: &str, lang: Language, file_path: &str) -> Option<String> {
+    let grammar = tree_sitter_grammar_for_path(lang, file_path)?;
     let kinds = body_node_kinds(lang);
     if kinds.is_empty() {
         return None;
@@ -149,8 +149,13 @@ fn first_n_lines(content: &str, max_lines: usize) -> String {
 ///
 /// Tries tree-sitter body stripping first. Falls back to first 3 lines
 /// for unsupported languages or non-symbol chunks.
-pub fn extract_signature(content: &str, lang: Language) -> String {
-    extract_signature_inner(content, lang).unwrap_or_else(|| first_n_lines(content, 3))
+///
+/// `file_path` selects the grammar dialect, the same way indexing does: a
+/// `.tsx` file must be parsed with the tsx grammar. Parsing JSX with the plain
+/// TypeScript grammar can fail to locate the body at all, in which case this
+/// silently degrades to the raw first-three-lines fallback.
+pub fn extract_signature(content: &str, lang: Language, file_path: &str) -> String {
+    extract_signature_inner(content, lang, file_path).unwrap_or_else(|| first_n_lines(content, 3))
 }
 
 #[cfg(test)]
@@ -160,21 +165,46 @@ mod tests {
     #[test]
     fn typescript_interface_signature() {
         let code = "export interface Repo extends Base {\n    get(id: string): Item;\n}\n";
-        let sig = extract_signature(code, Language::TypeScript);
+        let sig = extract_signature(code, Language::TypeScript, "");
         assert_eq!(sig, "export interface Repo extends Base { ... }");
+    }
+
+    #[test]
+    fn tsx_signature_uses_the_tsx_grammar() {
+        // JSX ahead of a declaration derails the plain TypeScript grammar
+        // badly enough that no body node is found within the depth limit, so
+        // `extract_signature` silently degrades to the raw first-three-lines
+        // fallback instead of a stripped signature. Selecting the grammar by
+        // path, as indexing does, keeps it working.
+        let code = "const A = <p>{ q }</p>;\nfunction Later(x: number) {\n  return x;\n}\n";
+
+        let tsx = extract_signature(code, Language::TypeScript, "Widget.tsx");
+        assert_eq!(
+            tsx,
+            "const A = <p>{ q }</p>;\nfunction Later(x: number) { ... }"
+        );
+
+        // The same content under a .ts path keeps the old behaviour, which is
+        // correct: there the angle brackets really are type syntax.
+        let ts = extract_signature(code, Language::TypeScript, "Widget.ts");
+        assert_ne!(ts, tsx);
+        assert!(
+            !ts.contains("{ ... }"),
+            "the .ts path should fall back, got: {ts}"
+        );
     }
 
     #[test]
     fn rust_pub_trait_signature() {
         let code = "pub trait Child: Parent + Send {\n    fn child(&self);\n}\n";
-        let sig = extract_signature(code, Language::Rust);
+        let sig = extract_signature(code, Language::Rust, "");
         assert_eq!(sig, "pub trait Child: Parent + Send { ... }");
     }
 
     #[test]
     fn rust_function_signature() {
         let code = "pub fn authenticate(credentials: &Credentials) -> Result<Token> {\n    let user = db.find_user(&credentials.username)?;\n    validate(user)?;\n    Ok(Token::new())\n}";
-        let sig = extract_signature(code, Language::Rust);
+        let sig = extract_signature(code, Language::Rust, "");
         assert!(sig.contains("pub fn authenticate"));
         assert!(sig.contains("{ ... }"));
         assert!(!sig.contains("find_user"));
@@ -183,7 +213,7 @@ mod tests {
     #[test]
     fn python_function_signature() {
         let code = "def authenticate(credentials: Credentials) -> Token:\n    user = db.find_user(credentials.username)\n    validate(user)\n    return Token()";
-        let sig = extract_signature(code, Language::Python);
+        let sig = extract_signature(code, Language::Python, "");
         assert!(sig.contains("def authenticate"));
         assert!(sig.contains("..."));
         assert!(!sig.contains("find_user"));
@@ -192,7 +222,7 @@ mod tests {
     #[test]
     fn typescript_function_signature() {
         let code = "function authenticate(credentials: Credentials): Token {\n    const user = db.findUser(credentials.username);\n    return new Token();\n}";
-        let sig = extract_signature(code, Language::TypeScript);
+        let sig = extract_signature(code, Language::TypeScript, "");
         assert!(sig.contains("function authenticate"));
         assert!(sig.contains("{ ... }"));
         assert!(!sig.contains("findUser"));
@@ -201,7 +231,7 @@ mod tests {
     #[test]
     fn go_function_signature() {
         let code = "func authenticate(creds Credentials) (Token, error) {\n\tuser := db.FindUser(creds.Username)\n\treturn Token{}, nil\n}";
-        let sig = extract_signature(code, Language::Go);
+        let sig = extract_signature(code, Language::Go, "");
         assert!(sig.contains("func authenticate"));
         assert!(sig.contains("{ ... }"));
         assert!(!sig.contains("FindUser"));
@@ -210,7 +240,7 @@ mod tests {
     #[test]
     fn java_method_signature() {
         let code = "public Token authenticate(Credentials creds) {\n    User user = db.findUser(creds.username);\n    return new Token();\n}";
-        let sig = extract_signature(code, Language::Java);
+        let sig = extract_signature(code, Language::Java, "");
         assert!(sig.contains("public Token authenticate"));
         assert!(sig.contains("{ ... }"));
         assert!(!sig.contains("findUser"));
@@ -219,7 +249,7 @@ mod tests {
     #[test]
     fn c_function_signature() {
         let code = "int authenticate(const char* user, const char* pass) {\n    int result = check_db(user, pass);\n    return result;\n}";
-        let sig = extract_signature(code, Language::C);
+        let sig = extract_signature(code, Language::C, "");
         assert!(sig.contains("int authenticate"));
         assert!(sig.contains("{ ... }"));
         assert!(!sig.contains("check_db"));
@@ -228,7 +258,7 @@ mod tests {
     #[test]
     fn fallback_for_unknown_language() {
         let code = "line1\nline2\nline3\nline4\nline5\nline6";
-        let sig = extract_signature(code, Language::Unknown);
+        let sig = extract_signature(code, Language::Unknown, "");
         assert!(sig.contains("line1"));
         assert!(sig.contains("line3"));
         assert!(sig.contains("[... 3 more lines]"));
@@ -238,7 +268,7 @@ mod tests {
     #[test]
     fn short_content_unchanged() {
         let code = "const X: i32 = 42;";
-        let sig = extract_signature(code, Language::Rust);
+        let sig = extract_signature(code, Language::Rust, "");
         // No body to strip, fallback returns as-is since <= 3 lines.
         assert_eq!(sig, code);
     }
@@ -246,7 +276,7 @@ mod tests {
     #[test]
     fn rust_struct_signature() {
         let code = "pub struct Config {\n    pub name: String,\n    pub value: i32,\n}";
-        let sig = extract_signature(code, Language::Rust);
+        let sig = extract_signature(code, Language::Rust, "");
         assert!(sig.contains("pub struct Config"));
         assert!(sig.contains("{ ... }"));
         assert!(!sig.contains("pub name"));

--- a/crates/vera-core/src/parsing/signatures.rs
+++ b/crates/vera-core/src/parsing/signatures.rs
@@ -145,7 +145,16 @@ fn first_n_lines(content: &str, max_lines: usize) -> String {
     out
 }
 
-/// Extract a compact signature from a search result's content.
+/// Extract a compact signature from a code snippet using the language grammar.
+///
+/// This preserves the original public API. Call [`extract_signature_for_path`]
+/// when the source path is available and the grammar dialect may depend on its
+/// extension.
+pub fn extract_signature(content: &str, lang: Language) -> String {
+    extract_signature_inner(content, lang, "").unwrap_or_else(|| first_n_lines(content, 3))
+}
+
+/// Extract a compact signature using the grammar selected for `file_path`.
 ///
 /// Tries tree-sitter body stripping first. Falls back to first 3 lines
 /// for unsupported languages or non-symbol chunks.
@@ -154,7 +163,7 @@ fn first_n_lines(content: &str, max_lines: usize) -> String {
 /// `.tsx` file must be parsed with the tsx grammar. Parsing JSX with the plain
 /// TypeScript grammar can fail to locate the body at all, in which case this
 /// silently degrades to the raw first-three-lines fallback.
-pub fn extract_signature(content: &str, lang: Language, file_path: &str) -> String {
+pub fn extract_signature_for_path(content: &str, lang: Language, file_path: &str) -> String {
     extract_signature_inner(content, lang, file_path).unwrap_or_else(|| first_n_lines(content, 3))
 }
 
@@ -165,7 +174,7 @@ mod tests {
     #[test]
     fn typescript_interface_signature() {
         let code = "export interface Repo extends Base {\n    get(id: string): Item;\n}\n";
-        let sig = extract_signature(code, Language::TypeScript, "");
+        let sig = extract_signature(code, Language::TypeScript);
         assert_eq!(sig, "export interface Repo extends Base { ... }");
     }
 
@@ -178,7 +187,7 @@ mod tests {
         // path, as indexing does, keeps it working.
         let code = "const A = <p>{ q }</p>;\nfunction Later(x: number) {\n  return x;\n}\n";
 
-        let tsx = extract_signature(code, Language::TypeScript, "Widget.tsx");
+        let tsx = extract_signature_for_path(code, Language::TypeScript, "Widget.tsx");
         assert_eq!(
             tsx,
             "const A = <p>{ q }</p>;\nfunction Later(x: number) { ... }"
@@ -188,7 +197,7 @@ mod tests {
         // correct: there the angle brackets really are type syntax. Assert the
         // exact `first_n_lines` output rather than merely "not the tsx one" —
         // a differently malformed signature would satisfy a negative check.
-        let ts = extract_signature(code, Language::TypeScript, "Widget.ts");
+        let ts = extract_signature_for_path(code, Language::TypeScript, "Widget.ts");
         assert_eq!(
             ts,
             "const A = <p>{ q }</p>;\nfunction Later(x: number) {\n  return x;\n[... 1 more lines]"
@@ -198,14 +207,14 @@ mod tests {
     #[test]
     fn rust_pub_trait_signature() {
         let code = "pub trait Child: Parent + Send {\n    fn child(&self);\n}\n";
-        let sig = extract_signature(code, Language::Rust, "");
+        let sig = extract_signature(code, Language::Rust);
         assert_eq!(sig, "pub trait Child: Parent + Send { ... }");
     }
 
     #[test]
     fn rust_function_signature() {
         let code = "pub fn authenticate(credentials: &Credentials) -> Result<Token> {\n    let user = db.find_user(&credentials.username)?;\n    validate(user)?;\n    Ok(Token::new())\n}";
-        let sig = extract_signature(code, Language::Rust, "");
+        let sig = extract_signature(code, Language::Rust);
         assert!(sig.contains("pub fn authenticate"));
         assert!(sig.contains("{ ... }"));
         assert!(!sig.contains("find_user"));
@@ -214,7 +223,7 @@ mod tests {
     #[test]
     fn python_function_signature() {
         let code = "def authenticate(credentials: Credentials) -> Token:\n    user = db.find_user(credentials.username)\n    validate(user)\n    return Token()";
-        let sig = extract_signature(code, Language::Python, "");
+        let sig = extract_signature(code, Language::Python);
         assert!(sig.contains("def authenticate"));
         assert!(sig.contains("..."));
         assert!(!sig.contains("find_user"));
@@ -223,7 +232,7 @@ mod tests {
     #[test]
     fn typescript_function_signature() {
         let code = "function authenticate(credentials: Credentials): Token {\n    const user = db.findUser(credentials.username);\n    return new Token();\n}";
-        let sig = extract_signature(code, Language::TypeScript, "");
+        let sig = extract_signature(code, Language::TypeScript);
         assert!(sig.contains("function authenticate"));
         assert!(sig.contains("{ ... }"));
         assert!(!sig.contains("findUser"));
@@ -232,7 +241,7 @@ mod tests {
     #[test]
     fn go_function_signature() {
         let code = "func authenticate(creds Credentials) (Token, error) {\n\tuser := db.FindUser(creds.Username)\n\treturn Token{}, nil\n}";
-        let sig = extract_signature(code, Language::Go, "");
+        let sig = extract_signature(code, Language::Go);
         assert!(sig.contains("func authenticate"));
         assert!(sig.contains("{ ... }"));
         assert!(!sig.contains("FindUser"));
@@ -241,7 +250,7 @@ mod tests {
     #[test]
     fn java_method_signature() {
         let code = "public Token authenticate(Credentials creds) {\n    User user = db.findUser(creds.username);\n    return new Token();\n}";
-        let sig = extract_signature(code, Language::Java, "");
+        let sig = extract_signature(code, Language::Java);
         assert!(sig.contains("public Token authenticate"));
         assert!(sig.contains("{ ... }"));
         assert!(!sig.contains("findUser"));
@@ -250,7 +259,7 @@ mod tests {
     #[test]
     fn c_function_signature() {
         let code = "int authenticate(const char* user, const char* pass) {\n    int result = check_db(user, pass);\n    return result;\n}";
-        let sig = extract_signature(code, Language::C, "");
+        let sig = extract_signature(code, Language::C);
         assert!(sig.contains("int authenticate"));
         assert!(sig.contains("{ ... }"));
         assert!(!sig.contains("check_db"));
@@ -259,7 +268,7 @@ mod tests {
     #[test]
     fn fallback_for_unknown_language() {
         let code = "line1\nline2\nline3\nline4\nline5\nline6";
-        let sig = extract_signature(code, Language::Unknown, "");
+        let sig = extract_signature(code, Language::Unknown);
         assert!(sig.contains("line1"));
         assert!(sig.contains("line3"));
         assert!(sig.contains("[... 3 more lines]"));
@@ -269,7 +278,7 @@ mod tests {
     #[test]
     fn short_content_unchanged() {
         let code = "const X: i32 = 42;";
-        let sig = extract_signature(code, Language::Rust, "");
+        let sig = extract_signature(code, Language::Rust);
         // No body to strip, fallback returns as-is since <= 3 lines.
         assert_eq!(sig, code);
     }
@@ -277,7 +286,7 @@ mod tests {
     #[test]
     fn rust_struct_signature() {
         let code = "pub struct Config {\n    pub name: String,\n    pub value: i32,\n}";
-        let sig = extract_signature(code, Language::Rust, "");
+        let sig = extract_signature(code, Language::Rust);
         assert!(sig.contains("pub struct Config"));
         assert!(sig.contains("{ ... }"));
         assert!(!sig.contains("pub name"));

--- a/crates/vera-core/src/parsing/type_relations.rs
+++ b/crates/vera-core/src/parsing/type_relations.rs
@@ -155,7 +155,7 @@ fn relation_header(chunk: &Chunk) -> String {
             .unwrap_or_default()
             .to_string()
     } else {
-        signatures::extract_signature(&chunk.content, chunk.language, &chunk.file_path)
+        signatures::extract_signature_for_path(&chunk.content, chunk.language, &chunk.file_path)
     };
     normalize_header(&raw)
 }

--- a/crates/vera-core/src/parsing/type_relations.rs
+++ b/crates/vera-core/src/parsing/type_relations.rs
@@ -155,7 +155,7 @@ fn relation_header(chunk: &Chunk) -> String {
             .unwrap_or_default()
             .to_string()
     } else {
-        signatures::extract_signature(&chunk.content, chunk.language)
+        signatures::extract_signature(&chunk.content, chunk.language, &chunk.file_path)
     };
     normalize_header(&raw)
 }

--- a/crates/vera-core/src/retrieval/type_relations.rs
+++ b/crates/vera-core/src/retrieval/type_relations.rs
@@ -72,7 +72,11 @@ pub fn search_explicit_implementations(
         if let Some(chunk) = smallest_symbol_chunk_for_line(&chunks, line) {
             line_start = chunk.line_start;
             line_end = chunk.line_end;
-            snippet = Some(signatures::extract_signature(&chunk.content, language));
+            snippet = Some(signatures::extract_signature(
+                &chunk.content,
+                language,
+                &chunk.file_path,
+            ));
             symbol_type = match chunk.symbol_type {
                 Some(SymbolType::Block) | None => None,
                 other => other,

--- a/crates/vera-core/src/retrieval/type_relations.rs
+++ b/crates/vera-core/src/retrieval/type_relations.rs
@@ -72,7 +72,7 @@ pub fn search_explicit_implementations(
         if let Some(chunk) = smallest_symbol_chunk_for_line(&chunks, line) {
             line_start = chunk.line_start;
             line_end = chunk.line_end;
-            snippet = Some(signatures::extract_signature(
+            snippet = Some(signatures::extract_signature_for_path(
                 &chunk.content,
                 language,
                 &chunk.file_path,

--- a/crates/vera-mcp/src/tools.rs
+++ b/crates/vera-mcp/src/tools.rs
@@ -37,12 +37,12 @@ fn compact_results_json(
     budget: usize,
     signatures_only: bool,
 ) -> Result<String, serde_json::Error> {
-    use vera_core::parsing::signatures::extract_signature;
+    use vera_core::parsing::signatures::extract_signature_for_path;
 
     let signatures: Vec<String> = if signatures_only {
         results
             .iter()
-            .map(|r| extract_signature(&r.content, r.language, &r.file_path))
+            .map(|r| extract_signature_for_path(&r.content, r.language, &r.file_path))
             .collect()
     } else {
         Vec::new()

--- a/crates/vera-mcp/src/tools.rs
+++ b/crates/vera-mcp/src/tools.rs
@@ -42,7 +42,7 @@ fn compact_results_json(
     let signatures: Vec<String> = if signatures_only {
         results
             .iter()
-            .map(|r| extract_signature(&r.content, r.language))
+            .map(|r| extract_signature(&r.content, r.language, &r.file_path))
             .collect()
     } else {
         Vec::new()


### PR DESCRIPTION
## Verified

The premise holds. `extract_signature_inner` called `tree_sitter_grammar(lang)`, selecting by the `Language` enum alone, while indexing goes through `tree_sitter_grammar_for_path`. For a `.tsx` file the two parsed the same content with different grammars.

## Does it actually diverge?

Yes, but not where I first expected, and the honest answer about impact is more limited than the issue assumes.

`extract_signature` finds the byte offset of the first body node and returns everything before it. JSX lives *inside* bodies, so the grammars agree on where a body starts. I tried nine realistic samples — components, generic-vs-JSX ambiguity (`<T,>`), arrow components, default parameters containing JSX, class property initializers, type assertions, fragments — and every one produced an identical signature under both grammars.

The divergence appears when JSX precedes a declaration in the same content. Then the TypeScript grammar fails to locate a body within the depth limit at all, and `extract_signature` silently falls back to dumping raw lines:

```
typescript: "const A = <p>{ q }</p>;\nfunction Later(x: number) {\n  return x;\n[... 1 more lines]"
tsx:        "const A = <p>{ q }</p>;\nfunction Later(x: number) { ... }"
```

**I could not reach that through the normal chunking path.** The chunker gives each top-level declaration its own chunk, so a chunk's content does not start with JSX ahead of a declaration. Indexing the case above produces four chunks, and the `Toolbar` chunk begins at the declaration — `vera search --compact` output is identical before and after this change.

So: a real inconsistency in a public API, with a demonstrable output difference at the function level, but no user-visible symptom I could produce. I would rather say that plainly than dress it up.

## Change

`extract_signature` takes a `file_path` and routes through `tree_sitter_grammar_for_path`, the same selection indexing uses. All four call sites already had a path to hand (`SearchResult::file_path`, `Chunk::file_path`), so nothing needed plumbing.

The regression test pins both directions: the same content under a `.tsx` path yields a stripped signature, and under a `.ts` path keeps the old fallback — which is correct there, since outside a `.tsx` file the angle brackets really are type syntax. Confirmed the test fails when the grammar selection is reverted.

774 `vera-core` tests, 97 `vera-cli`, `cargo fmt --check` clean, clippy unchanged at the pre-existing warnings.

Fixes #75

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Selects the signature grammar by file path to match indexing. Previously grammar came from `Language` only; `.tsx` could parse as TypeScript and fall back to raw lines when JSX precedes a declaration. Now `.tsx` uses the TSX grammar, producing stripped signatures and aligning outputs.

- Adds `extract_signature_for_path(content, lang, file_path)` and routes `vera-core` (including `retrieval/type_relations`), `vera-cli`, and `vera-mcp` to it; keeps `extract_signature` for callers without a path.
- Behavior: function-level output now matches indexing for `.tsx`; chunked results remain unchanged. Tests add a `.tsx` vs `.ts` regression and pin the exact `.ts` first-three-lines fallback.

<sup>Written for commit d62119e1c759bd5d42af8d8670ca5e4e487048bd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/VeraTools/Vera/pull/87?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved code signature extraction for files with extensions such as `.tsx`.
  * Preserved reliable fallback behavior for TypeScript files.
  * Updated result displays and relationship information to use file-specific parsing for more accurate output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->