### PR TITLE
docs(parsing): pin the naming convention for dotted JSX components

### DIFF
--- a/crates/vera-core/src/parsing/references.rs
+++ b/crates/vera-core/src/parsing/references.rs
@@ -3,6 +3,29 @@
 //! Walks the AST looking for function/method call expressions and records
 //! the callee name, source file, and line number. These lightweight edges
 //! power `vera references`, `vera impact`, and `vera dead-code`.
+//!
+//! # Naming convention for dotted callees
+//!
+//! A callee is stored under its **rightmost segment**. `obj.method()` records
+//! `method`, and JSX follows the same rule, so `<Icons.Arrow />` records
+//! `Arrow` rather than `Icons.Arrow`.
+//!
+//! This is what makes a reference link to a definition. Definitions are
+//! indexed under their bare declared name — a component reached as
+//! `Icons.Arrow` is declared somewhere as `export function Arrow` — and
+//! `find_callers` matches the callee against that name. Storing the full
+//! member path would leave the reference matching no definition, which is the
+//! invisibility that indexing JSX call sites exists to fix.
+//!
+//! A lowercase root does not change this: `<icons.Arrow />` is a member
+//! expression, and a member expression is always a value lookup. Only a bare
+//! lowercase identifier is an intrinsic host element (see
+//! `is_jsx_host_element`).
+//!
+//! The trade-off is deliberate: two components sharing a final segment
+//! (`Icons.Arrow` and `Shapes.Arrow`) collapse onto one name. Separating them
+//! needs import and module resolution, which this layer does not do — it reads
+//! one file at a time with no cross-file symbol table.
 
 use crate::types::Language;
 

--- a/crates/vera-core/src/parsing/references.rs
+++ b/crates/vera-core/src/parsing/references.rs
@@ -18,9 +18,14 @@
 //! invisibility that indexing JSX call sites exists to fix.
 //!
 //! A lowercase root does not change this: `<icons.Arrow />` is a member
-//! expression, and a member expression is always a value lookup. Only a bare
-//! lowercase identifier is an intrinsic host element (see
-//! `is_jsx_host_element`).
+//! expression, and a member expression is always a value lookup — the
+//! intrinsic test never applies to one.
+//!
+//! For *bare* tags there are two intrinsic forms, not one: a name starting
+//! with a lowercase ASCII letter (`<div />`), and any name containing a hyphen
+//! whatever its case (`<My-element />`, `<my-element />`), which is the
+//! custom-element form. Both are host elements and stay out of the call graph.
+//! See `is_jsx_host_element`.
 //!
 //! The trade-off is deliberate: two components sharing a final segment
 //! (`Icons.Arrow` and `Shapes.Arrow`) collapse onto one name. Separating them

--- a/crates/vera-core/src/parsing/tests.rs
+++ b/crates/vera-core/src/parsing/tests.rs
@@ -397,6 +397,67 @@ export function App() {
     );
 }
 
+#[test]
+fn jsx_dotted_components_index_under_the_rightmost_segment() {
+    // Pins the naming convention for dotted JSX components.
+    //
+    // `<Icons.Arrow />` is recorded as `Arrow`, not `Icons.Arrow`. That is not
+    // an accident of `extract_callee` — it is what makes the call site link to
+    // the definition. A component re-exported as `Icons.Arrow` is *defined*
+    // somewhere as `Arrow` (`export function Arrow`), and definitions are
+    // indexed under that bare name, as is every other member call
+    // (`obj.method()` records `method`). Recording `Icons.Arrow` would leave
+    // the reference matching no definition, which is the invisibility this
+    // whole path exists to fix.
+    //
+    // A lowercase root stays a component too: `<icons.Arrow />` is a member
+    // expression, and a member expression is always a value lookup. Only a
+    // bare lowercase identifier is an intrinsic host element.
+    let source = r#"import * as Icons from "./icons";
+import * as icons from "./icons";
+
+export function Toolbar() {
+    return (
+        <div className="bar">
+            <Icons.Arrow />
+            <icons.Chevron />
+            <span />
+        </div>
+    );
+}
+"#;
+    let (_, refs, diagnostics) = parse_file_with_diagnostics(
+        source,
+        "src/toolbar.tsx",
+        Language::TypeScript,
+        &default_config(),
+    )
+    .unwrap();
+
+    assert!(
+        !diagnostics.tree_has_error,
+        "tsx should parse without errors"
+    );
+    let callees: Vec<&str> = refs.iter().map(|r| r.callee.as_str()).collect();
+
+    assert!(
+        callees.contains(&"Arrow"),
+        "uppercase-rooted dotted component should index as its rightmost segment: {callees:?}"
+    );
+    assert!(
+        callees.contains(&"Chevron"),
+        "lowercase-rooted dotted component is still a value lookup: {callees:?}"
+    );
+    assert!(
+        !callees.iter().any(|c| c.contains('.')),
+        "no callee should carry the full member path: {callees:?}"
+    );
+    assert!(
+        !callees.contains(&"div") && !callees.contains(&"span"),
+        "intrinsic host elements must stay out of the call graph: {callees:?}"
+    );
+}
+
 // =========================================================
 // Go tests
 // =========================================================

--- a/crates/vera-core/src/parsing/tests.rs
+++ b/crates/vera-core/src/parsing/tests.rs
@@ -438,23 +438,17 @@ export function Toolbar() {
         !diagnostics.tree_has_error,
         "tsx should parse without errors"
     );
-    let callees: Vec<&str> = refs.iter().map(|r| r.callee.as_str()).collect();
+    let mut callees: Vec<&str> = refs.iter().map(|r| r.callee.as_str()).collect();
+    callees.sort_unstable();
 
-    assert!(
-        callees.contains(&"Arrow"),
-        "uppercase-rooted dotted component should index as its rightmost segment: {callees:?}"
-    );
-    assert!(
-        callees.contains(&"Chevron"),
-        "lowercase-rooted dotted component is still a value lookup: {callees:?}"
-    );
-    assert!(
-        !callees.iter().any(|c| c.contains('.')),
-        "no callee should carry the full member path: {callees:?}"
-    );
-    assert!(
-        !callees.contains(&"div") && !callees.contains(&"span"),
-        "intrinsic host elements must stay out of the call graph: {callees:?}"
+    // An exact set, not `contains`: a root segment leaking in as its own
+    // reference (`Icons`, `icons`) is precisely the failure mode worth
+    // catching, and a containment check would not see it. `div`/`span` are
+    // intrinsic by the lowercase rule and `My-element` by the hyphen rule.
+    assert_eq!(
+        callees,
+        vec!["Arrow", "Chevron"],
+        "expected exactly the two dotted components, rightmost segment only"
     );
 }
 

--- a/crates/vera-core/src/parsing/tests.rs
+++ b/crates/vera-core/src/parsing/tests.rs
@@ -422,6 +422,7 @@ export function Toolbar() {
             <Icons.Arrow />
             <icons.Chevron />
             <span />
+            <My-element />
         </div>
     );
 }


### PR DESCRIPTION
## Verified

Both observations in the issue are accurate. `extract_callee` returns the rightmost identifier, so `<Icons.Arrow />` records `Arrow`. And `is_jsx_host_element` returns early for a `member_expression`, so `<icons.Arrow />` with a lowercase root is kept as a component and also recorded as `Arrow`.

The issue asks for a decision, documentation and a pinning test rather than reporting a defect. This keeps the current behaviour, and writes down why.

## The decision: rightmost segment

The deciding argument is linkage, not developer grep habits.

Definitions are indexed under their bare declared name. A component reached as `Icons.Arrow` is declared somewhere as `export function Arrow`, and `find_callers` matches `lower(callee)` against that name. Storing the full member path would leave the reference matching **no** definition — reintroducing precisely the invisibility that indexing JSX call sites was added to fix in #58.

It also keeps JSX consistent with the rest of the extractor, where `obj.method()` already records `method`. Special-casing JSX to store dotted paths would make `vera references` behave differently depending on whether the call site happened to be JSX.

Verified end-to-end on a real index:

```
$ vera references Arrow
src/toolbar.tsx:4-7 function:Toolbar
    return <div><Icons.Arrow /><span /></div>;
```

## Lowercase roots

`<icons.Arrow />` staying a component is correct rather than an oversight. TypeScript's intrinsic test applies only to identifiers — a property access is never intrinsic, whatever the case of its root. So a dotted tag is always a value lookup, and treating `icons.Arrow` as an HTML tag would drop a real reference.

## The trade-off, stated rather than hidden

Two components sharing a final segment (`Icons.Arrow` and `Shapes.Arrow`) collapse onto one name. Separating them needs import and module resolution, which this layer does not do — it reads one file at a time with no cross-file symbol table. That limitation is now in the module documentation rather than being something a reader has to infer from the code.

## Test

`jsx_dotted_components_index_under_the_rightmost_segment` pins all four properties: the uppercase-rooted dotted component indexes as its rightmost segment, the lowercase-rooted one does too, no callee carries a dotted path, and intrinsic host elements (`div`, `span`) stay out of the call graph. If someone later switches to full member paths, that test is where the decision gets re-opened deliberately instead of silently.

773 `vera-core` tests, `cargo fmt --check` clean, clippy unchanged.

Fixes #76

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins and documents the naming convention for dotted JSX components in `vera-core` parsing to preserve reference → definition links. Behavior is unchanged: we index the rightmost segment (e.g., `<Icons.Arrow />` → `Arrow`), consistent with `obj.method()`.

- Documents in `references.rs` that dotted JSX tags index by their rightmost segment; member expressions with lowercase roots remain components; bare host elements are excluded by the lowercase or hyphen rule (e.g., `div`, `my-element`, `My-element`).
- Adds test `jsx_dotted_components_index_under_the_rightmost_segment` asserting the exact callee set (`Arrow`, `Chevron`), including `<My-element />` to cover the hyphen rule; ensures no dotted paths or host elements leak into references.
- Notes the trade-off: components sharing a final segment collapse onto one name; import/module resolution is out of scope for this layer.

<sup>Written for commit bff96b344b0c09f6d86fbf8b96b355d4aa649f67. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/VeraTools/Vera/pull/88?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added documentation clarifying how dotted callees and JSX member expressions are normalized, including known symbol-resolution limitations.

* **Tests**
  * Added TSX coverage for dotted JSX components.
  * Verified handling of uppercase and lowercase member expressions, while excluding intrinsic elements and full dotted paths from call-site references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->