### PR TITLE
fix(retrieval): resolve the reranker provider before acquiring its runtime

### DIFF
--- a/crates/vera-core/src/local_models/ort.rs
+++ b/crates/vera-core/src/local_models/ort.rs
@@ -42,6 +42,13 @@ pub fn ensure_ort_runtime(lib_path: Option<&std::path::Path>) -> Result<()> {
     }
 }
 
+/// Return whether ONNX Runtime has already been initialized successfully.
+pub(crate) fn ort_runtime_initialized() -> bool {
+    ORT_INIT_RESULT
+        .get()
+        .is_some_and(std::result::Result::is_ok)
+}
+
 /// Returns the pip package name for EPs that require pip-based installation, or None
 /// for EPs that have pre-built GitHub release archives.
 pub(super) fn pip_package_for_ep(ep: OnnxExecutionProvider) -> Option<&'static str> {

--- a/crates/vera-core/src/retrieval/local_reranker.rs
+++ b/crates/vera-core/src/retrieval/local_reranker.rs
@@ -20,6 +20,14 @@ pub struct LocalReranker {
 
 impl LocalReranker {
     pub async fn new_with_ep(ep: OnnxExecutionProvider) -> Result<Self, RerankerError> {
+        // Resolve before acquiring anything. No prebuilt reranker export runs
+        // on the CoreML GPU, so `reranker_execution_provider` maps CoreMl to
+        // Cpu; acquiring and dependency-checking the requested provider's
+        // library would validate one library and then build a session that
+        // wants another. `ensure_ort_runtime` is a process-wide OnceLock, so
+        // only the first path passed to it in a process is actually loaded,
+        // which makes that mismatch silent rather than loud.
+        let ep = crate::local_models::reranker_execution_provider(ep);
         let ort_path = crate::local_models::ensure_ort_library_for_ep(ep)
             .await
             .map_err(|e| RerankerError::ApiError {
@@ -74,6 +82,7 @@ impl LocalReranker {
     }
 
     pub fn probe_session(ep: OnnxExecutionProvider) -> Result<()> {
+        let ep = crate::local_models::reranker_execution_provider(ep);
         let ort_path = crate::local_models::ort_library_path_for_ep(ep)?;
         crate::local_models::ensure_ort_runtime(Some(&ort_path))?;
         let (onnx_path, _) = default_asset_paths()?;
@@ -82,6 +91,7 @@ impl LocalReranker {
     }
 
     pub fn probe_inference(ep: OnnxExecutionProvider) -> Result<()> {
+        let ep = crate::local_models::reranker_execution_provider(ep);
         let ort_path = crate::local_models::ort_library_path_for_ep(ep)?;
         crate::local_models::ensure_ort_runtime(Some(&ort_path))?;
         let (onnx_path, tokenizer_path) = default_asset_paths()?;
@@ -250,8 +260,12 @@ fn load_tokenizer(tokenizer_path: std::path::PathBuf) -> Result<Tokenizer> {
         .map_err(|e| anyhow::anyhow!("Tokenizer init failed: {}", e))
 }
 
+/// Build a session on an already-resolved execution provider.
+///
+/// `ep` must come from `reranker_execution_provider`. Resolving again here
+/// would put the same contract in two places that could drift apart; all three
+/// callers resolve at their entry point.
 fn build_session(ep: OnnxExecutionProvider, onnx_path: std::path::PathBuf) -> Result<Session> {
-    let ep = crate::local_models::reranker_execution_provider(ep);
     let threads = std::thread::available_parallelism()
         .map(|n| n.get())
         .unwrap_or(1);
@@ -376,6 +390,29 @@ fn register_execution_provider(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Asset-free, so it runs when ONNX Runtime is absent. The test below
+    /// early-returns in that case and passes without asserting anything.
+    #[test]
+    fn resolution_is_idempotent_so_build_session_need_not_repeat_it() {
+        use crate::config::OnnxExecutionProvider as Ep;
+        use crate::local_models::reranker_execution_provider as resolve;
+
+        // `build_session` no longer re-resolves; it trusts what the entry
+        // points pass. Resolving an already-resolved provider must therefore
+        // be a no-op, or a second pass anywhere would change the answer.
+        for requested in [Ep::CoreMl, Ep::Cpu, Ep::Cuda] {
+            let once = resolve(requested);
+            assert_eq!(once, resolve(once), "resolving {requested} twice differed");
+        }
+
+        // The mapping this exists for: no prebuilt reranker export runs on the
+        // CoreML GPU, so CoreML must resolve to CPU before any library is
+        // acquired. Other providers are left alone.
+        assert_eq!(resolve(Ep::CoreMl), Ep::Cpu);
+        assert_eq!(resolve(Ep::Cuda), Ep::Cuda);
+        assert_eq!(resolve(Ep::Cpu), Ep::Cpu);
+    }
 
     #[tokio::test]
     async fn test_local_reranker() {

--- a/crates/vera-core/src/retrieval/local_reranker.rs
+++ b/crates/vera-core/src/retrieval/local_reranker.rs
@@ -27,25 +27,43 @@ impl LocalReranker {
         // wants another. `ensure_ort_runtime` is a process-wide OnceLock, so
         // only the first path passed to it in a process is actually loaded,
         // which makes that mismatch silent rather than loud.
-        let ep = crate::local_models::reranker_execution_provider(ep);
-        let ort_path = crate::local_models::ensure_ort_library_for_ep(ep)
-            .await
-            .map_err(|e| RerankerError::ApiError {
-                status: 500,
-                message: e.to_string(),
+        let requested_ep = ep;
+        let ep = crate::local_models::reranker_execution_provider(requested_ep);
+        // A CoreML embedding provider may have already initialized ORT with
+        // its CoreML-capable runtime. The reranker is CPU-only under CoreML,
+        // but that process-wide runtime is still valid for its CPU session;
+        // requiring the separate CPU cache here would make initialization
+        // depend on an unused download. A cold start still acquires the CPU
+        // runtime, and other providers retain their existing acquisition path.
+        let ort_path = if should_acquire_ort_library(
+            requested_ep,
+            crate::local_models::ort::ort_runtime_initialized(),
+        ) {
+            Some(
+                crate::local_models::ensure_ort_library_for_ep(ep)
+                    .await
+                    .map_err(|e| RerankerError::ApiError {
+                        status: 500,
+                        message: e.to_string(),
+                    })?,
+            )
+        } else {
+            None
+        };
+        if let Some(ort_path) = ort_path.as_deref() {
+            crate::local_models::ensure_ort_runtime(Some(ort_path)).map_err(|e| {
+                RerankerError::ApiError {
+                    status: 500,
+                    message: e.to_string(),
+                }
             })?;
-        crate::local_models::ensure_ort_runtime(Some(&ort_path)).map_err(|e| {
-            RerankerError::ApiError {
-                status: 500,
-                message: e.to_string(),
-            }
-        })?;
-        crate::local_models::ensure_provider_dependencies(ep, &ort_path).map_err(|e| {
-            RerankerError::ApiError {
-                status: 500,
-                message: e.to_string(),
-            }
-        })?;
+            crate::local_models::ensure_provider_dependencies(ep, ort_path).map_err(|e| {
+                RerankerError::ApiError {
+                    status: 500,
+                    message: e.to_string(),
+                }
+            })?;
+        }
 
         let components = load_reranker_components(ep).await;
         let (session, tokenizer) = match components {
@@ -387,6 +405,13 @@ fn register_execution_provider(
     }
 }
 
+fn should_acquire_ort_library(
+    requested_ep: OnnxExecutionProvider,
+    runtime_initialized: bool,
+) -> bool {
+    requested_ep != OnnxExecutionProvider::CoreMl || !runtime_initialized
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -414,6 +439,19 @@ mod tests {
         assert_eq!(resolve(Ep::CoreMl), Ep::Cpu);
         assert_eq!(resolve(Ep::Cuda), Ep::Cuda);
         assert_eq!(resolve(Ep::Cpu), Ep::Cpu);
+    }
+
+    #[test]
+    fn coreml_reranker_reuses_an_initialized_runtime_without_cpu_acquisition() {
+        use crate::config::OnnxExecutionProvider as Ep;
+
+        assert!(!should_acquire_ort_library(Ep::CoreMl, true));
+        assert!(should_acquire_ort_library(Ep::CoreMl, false));
+        assert!(should_acquire_ort_library(Ep::Cpu, true));
+        assert!(should_acquire_ort_library(Ep::Cuda, true));
+        assert!(should_acquire_ort_library(Ep::Rocm, true));
+        assert!(should_acquire_ort_library(Ep::OpenVino, true));
+        assert!(should_acquire_ort_library(Ep::DirectMl, true));
     }
 
     #[tokio::test]

--- a/crates/vera-core/src/retrieval/local_reranker.rs
+++ b/crates/vera-core/src/retrieval/local_reranker.rs
@@ -391,8 +391,10 @@ fn register_execution_provider(
 mod tests {
     use super::*;
 
-    /// Asset-free, so it runs when ONNX Runtime is absent. The test below
-    /// early-returns in that case and passes without asserting anything.
+    /// Loads neither model assets nor ONNX Runtime, so it always runs and
+    /// always asserts. Deliberate: `test_local_reranker` below early-returns
+    /// when ONNX Runtime is not on the default lookup path, and would pass
+    /// without checking anything on a machine that lacks it.
     #[test]
     fn resolution_is_idempotent_so_build_session_need_not_repeat_it() {
         use crate::config::OnnxExecutionProvider as Ep;


### PR DESCRIPTION
## Problem

`LocalReranker::new_with_ep` acquired, initialized and dependency-checked the ONNX Runtime library for the **requested** execution provider, and only `build_session` resolved. Under CoreML those differ: `reranker_execution_provider` maps CoreMl to Cpu unconditionally, because no prebuilt reranker export runs on the CoreML GPU (the fix from #33/#41).

Three consequences, in increasing order of seriousness:

1. Every Apple Silicon run downloaded and validated `~/.vera/lib/coreml/libonnxruntime.dylib` for a session that is always built on CPU.
2. `ensure_provider_dependencies` ran the CoreML shared-library check that production reranking never needs, since it early-returns for Cpu.
3. `ensure_ort_runtime` is a process-wide `OnceLock`, so only the first path passed to it in a process is actually loaded. The embedding provider resolves its own library first, so the reranker could validate the CoreML dylib and then build against whichever library the embedding path had already loaded.

Point 3 is why this is more than wasted bandwidth: the check and the load could disagree, so a green check was not evidence the session would get that library.

## Change

All three entry points (`new_with_ep`, `probe_session`, `probe_inference`) resolve first, which is the shape `LocalEmbeddingProvider::new_with_ep_and_mem_limit` already uses via `resolve_provider_and_config`.

`build_session` no longer re-resolves, since all three of its callers now do. Keeping it would put the same contract in two places that could drift, which is the defect this PR is fixing one layer up.

## Verification

The behavioural change, measured by resolving each provider to its library path:

```
requested=coreml -> /Users/citron07r/.vera/lib/coreml/libonnxruntime.dylib
resolved =cpu    -> /Users/citron07r/.vera/lib/libonnxruntime.dylib
```

So under CoreML the reranker now acquires the library it actually builds against, rather than a second copy it never loads.

End to end on this Apple Silicon machine with the CoreML backend, reranking still works and nothing regressed:

```
ok  probe-reranker-session  reranker session created
ok  probe-tiny-inference    embedding and reranker returned finite outputs
```

`vera search` returns the expected match, which exercises the rerank path.

## Test

Asset-free on purpose. The existing `test_local_reranker` early-returns when ONNX Runtime is not on the default lookup path and passes without asserting anything, so a test routed through session creation would prove nothing on a machine without ORT.

The new test pins the two properties the change depends on: that resolution is idempotent, which is what makes dropping the second resolve in `build_session` safe, and that CoreML maps to CPU while CUDA and CPU are untouched.

786 `vera-core` tests, 97 `vera-cli`, `cargo fmt --check` clean, clippy unchanged at the 5 pre-existing warnings.

## Note

Found while fixing the doctor-side half in #72, where `vera doctor --probe` preflighted the requested provider but probed the effective one. That PR is scoped to `doctor.rs`; this is the vera-core half, kept separate because it changes what gets downloaded and which library is initialized at runtime.

Fixes #89

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Resolves the reranker’s execution provider before acquiring ONNX Runtime and reuses an already-initialized runtime under CoreML. This removes unnecessary downloads/checks and prevents library mismatches caused by the process-wide runtime lock.

- Entry points resolve first: new_with_ep, probe_session, probe_inference. build_session trusts the caller and does not re-resolve.
- CoreML-specific guard: if ORT is already initialized, the reranker skips acquiring a CPU runtime; otherwise it acquires for the effective provider and runs dependency checks only when a library is acquired.
- Adds ort_runtime_initialized and asset-free tests that assert idempotent resolution, CoreML→CPU mapping, and CoreML runtime reuse without extra CPU acquisition.
- Behavior on Apple Silicon: acquires ~/.vera/lib/libonnxruntime.dylib (CPU) instead of the CoreML dylib, or skips acquisition when the runtime is pre-initialized. No API or migration changes.

<sup>Written for commit 96892b843a3b3b1c1b7641e421eb2ee9634aa7cc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/VeraTools/Vera/pull/90?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved execution provider handling during reranker setup and runtime initialization.
  * Added reliable fallback from CoreML to CPU execution when needed.
  * Prevented duplicate provider resolution and unnecessary runtime acquisition.
  * Improved reuse of initialized runtime components for more efficient reranker startup.
  * Added checks to ensure runtime-dependent operations proceed only after successful initialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->