### PR TITLE
fix(embedding): pool jina-embeddings-v5 on the last token, not the mean

### DIFF
--- a/crates/vera-cli/src/commands/repair.rs
+++ b/crates/vera-cli/src/commands/repair.rs
@@ -9,7 +9,7 @@ use crate::state;
 
 /// The embedding model `vera repair` hands to `configure_backend`.
 ///
-/// Deliberately the raw stored value, not `state::saved_local_embedding_model`:
+/// Deliberately the raw stored value, not `state::repaired_local_embedding_model`:
 /// `configure_backend` persists whatever it is handed, so the in-memory pooling
 /// repair would be laundered into `config.json` and an older Vera on the same
 /// machine would then abort on every command, its `FromStr` knowing only `mean`

--- a/crates/vera-cli/src/commands/repair.rs
+++ b/crates/vera-cli/src/commands/repair.rs
@@ -2,9 +2,37 @@
 //! or re-persisting API configuration from the current environment.
 
 use vera_core::config::InferenceBackend;
+use vera_core::local_models::LocalEmbeddingModelConfig;
 
 use crate::commands::setup;
 use crate::state;
+
+/// The embedding model `vera repair` hands to `configure_backend`.
+///
+/// Deliberately the raw stored value, not `state::saved_local_embedding_model`:
+/// `configure_backend` persists whatever it is handed, so the in-memory pooling
+/// repair would be laundered into `config.json` and an older Vera on the same
+/// machine would then abort on every command, its `FromStr` knowing only `mean`
+/// and `cls`. Unlike `vera setup`, nobody asked this command to change a
+/// pooling mode.
+///
+/// The repair still reaches this command's runtime: `configure_backend` calls
+/// `state::apply_saved_env_force`, which applies it on the way to the process
+/// environment. Asset prefetching never reads `pooling`.
+/// `pub(crate)` so the regression test can live beside the other stored-pooling
+/// tests in `state`, which own the `VERA_HOME` lock this needs.
+pub(crate) fn embedding_model_to_persist(
+    effective_backend: InferenceBackend,
+) -> anyhow::Result<Option<LocalEmbeddingModelConfig>> {
+    if !effective_backend.is_onnx() {
+        return Ok(None);
+    }
+    Ok(Some(
+        state::load_saved_config()?
+            .local_embedding_model
+            .unwrap_or_default(),
+    ))
+}
 
 pub fn run(backend: Option<InferenceBackend>, api: bool, json_output: bool) -> anyhow::Result<()> {
     let effective_backend = if api {
@@ -16,12 +44,7 @@ pub fn run(backend: Option<InferenceBackend>, api: bool, json_output: bool) -> a
     } else {
         vera_core::config::resolve_backend(None)
     };
-    let local_embedding_model = if effective_backend.is_onnx() {
-        state::saved_local_embedding_model()?
-            .or_else(|| Some(vera_core::local_models::LocalEmbeddingModelConfig::default()))
-    } else {
-        None
-    };
+    let local_embedding_model = embedding_model_to_persist(effective_backend)?;
 
     setup::configure_backend(
         effective_backend,

--- a/crates/vera-cli/src/helpers.rs
+++ b/crates/vera-cli/src/helpers.rs
@@ -273,7 +273,7 @@ pub struct LocalEmbeddingModelFlags {
     #[arg(long = "embedding-dim", value_name = "DIM")]
     pub embedding_dim: Option<usize>,
     /// Pooling strategy for token-level output models.
-    #[arg(long = "embedding-pooling", value_name = "POOLING", value_parser = ["mean", "cls"])]
+    #[arg(long = "embedding-pooling", value_name = "POOLING", value_parser = ["mean", "cls", "last-token"])]
     pub embedding_pooling: Option<String>,
     /// Tokenizer truncation length for local embedding inference.
     #[arg(long = "embedding-max-length", value_name = "TOKENS")]

--- a/crates/vera-cli/src/state.rs
+++ b/crates/vera-cli/src/state.rs
@@ -91,6 +91,18 @@ pub fn save_local_embedding_model(
     save_config(&config)
 }
 
+/// The single point where a stored model config becomes a runtime one.
+///
+/// Every runtime reader of `local_embedding_model` goes through here, so the
+/// repair cannot be forgotten by a future one and silently reinstate the
+/// mean-pooled jina config. Nothing here reaches disk; see `load_saved_config`
+/// for why the repair must stay out of the load path.
+fn repaired_local_embedding_model(
+    stored: Option<vera_core::local_models::LocalEmbeddingModelConfig>,
+) -> Option<vera_core::local_models::LocalEmbeddingModelConfig> {
+    stored.map(vera_core::local_models::LocalEmbeddingModelConfig::repair_stored_defaults)
+}
+
 /// The stored model config as runtime should see it.
 ///
 /// `setup` freezes the resolved model config into `config.json` and that copy
@@ -99,9 +111,9 @@ pub fn save_local_embedding_model(
 /// memory only; the file keeps whatever `setup` wrote.
 pub fn saved_local_embedding_model()
 -> Result<Option<vera_core::local_models::LocalEmbeddingModelConfig>> {
-    Ok(load_saved_config()?
-        .local_embedding_model
-        .map(vera_core::local_models::LocalEmbeddingModelConfig::repair_stored_defaults))
+    Ok(repaired_local_embedding_model(
+        load_saved_config()?.local_embedding_model,
+    ))
 }
 
 pub fn saved_backend() -> Result<Option<vera_core::config::InferenceBackend>> {
@@ -231,9 +243,7 @@ fn apply_saved_env_impl(force: bool) -> Result<()> {
 
     // Repaired in memory on the way to the process environment; see
     // `saved_local_embedding_model`.
-    let local_embedding_model = config
-        .local_embedding_model
-        .map(vera_core::local_models::LocalEmbeddingModelConfig::repair_stored_defaults);
+    let local_embedding_model = repaired_local_embedding_model(config.local_embedding_model);
     apply_local_embedding_env(local_embedding_model.as_ref(), force);
 
     Ok(())

--- a/crates/vera-cli/src/state.rs
+++ b/crates/vera-cli/src/state.rs
@@ -103,19 +103,6 @@ fn repaired_local_embedding_model(
     stored.map(vera_core::local_models::LocalEmbeddingModelConfig::repair_stored_defaults)
 }
 
-/// The stored model config as runtime should see it.
-///
-/// `setup` freezes the resolved model config into `config.json` and that copy
-/// outranks the preset, so an install created before jina's pooling was
-/// corrected would keep mean-pooling it indefinitely. The repair is applied in
-/// memory only; the file keeps whatever `setup` wrote.
-pub fn saved_local_embedding_model()
--> Result<Option<vera_core::local_models::LocalEmbeddingModelConfig>> {
-    Ok(repaired_local_embedding_model(
-        load_saved_config()?.local_embedding_model,
-    ))
-}
-
 pub fn saved_backend() -> Result<Option<vera_core::config::InferenceBackend>> {
     use vera_core::config::{InferenceBackend, OnnxExecutionProvider};
 
@@ -242,7 +229,7 @@ fn apply_saved_env_impl(force: bool) -> Result<()> {
     }
 
     // Repaired in memory on the way to the process environment; see
-    // `saved_local_embedding_model`.
+    // `repaired_local_embedding_model`.
     let local_embedding_model = repaired_local_embedding_model(config.local_embedding_model);
     apply_local_embedding_env(local_embedding_model.as_ref(), force);
 
@@ -569,9 +556,9 @@ mod tests {
     fn runtime_readers_repair_stored_pooling_in_memory() {
         let _guard = with_stored_config(LEGACY_JINA_CONFIG);
 
-        let model = saved_local_embedding_model()
-            .unwrap()
-            .expect("stored config carries a local embedding model");
+        let model =
+            repaired_local_embedding_model(load_saved_config().unwrap().local_embedding_model)
+                .expect("stored config carries a local embedding model");
         assert_eq!(
             model.pooling,
             vera_core::local_models::LocalEmbeddingPooling::LastToken

--- a/crates/vera-cli/src/state.rs
+++ b/crates/vera-cli/src/state.rs
@@ -59,7 +59,14 @@ pub struct ApiSetupInput {
 }
 
 pub fn load_saved_config() -> Result<StoredConfig> {
-    load_json_file(&config_path()?)
+    let mut config: StoredConfig = load_json_file(&config_path()?)?;
+    // `setup` freezes the resolved model config here, and this copy outranks
+    // the preset. Without repair, an install created before jina's pooling was
+    // corrected keeps mean-pooling it indefinitely.
+    config.local_embedding_model = config
+        .local_embedding_model
+        .map(vera_core::local_models::LocalEmbeddingModelConfig::repair_stored_defaults);
+    Ok(config)
 }
 
 pub fn load_saved_secrets() -> Result<StoredSecrets> {

--- a/crates/vera-cli/src/state.rs
+++ b/crates/vera-cli/src/state.rs
@@ -411,8 +411,16 @@ fn apply_local_embedding_env(
 }
 
 fn set_process_env(key: &str, value: &str) {
-    // Safe because Vera only mutates process environment during single-threaded
-    // CLI startup, before any background work or runtime threads are created.
+    // In production this runs only during single-threaded CLI startup, before
+    // any background work or runtime threads exist, so no concurrent reader can
+    // observe the write.
+    //
+    // The unit tests below break that condition: libtest runs them on several
+    // threads at once. They are sound instead because every test that reads or
+    // writes any of `RESTORED_ENV_KEYS` holds `VERA_HOME_LOCK` for its whole
+    // body, and nothing else in the test binary touches those variables. Any
+    // new test that calls this, `clear_process_env`, or a helper reaching them
+    // must take the same lock.
     unsafe {
         std::env::set_var(key, value);
     }

--- a/crates/vera-cli/src/state.rs
+++ b/crates/vera-cli/src/state.rs
@@ -536,6 +536,28 @@ mod tests {
     }
 
     #[test]
+    fn repair_command_does_not_rewrite_stored_pooling() {
+        let _guard = with_stored_config(LEGACY_JINA_CONFIG);
+        assert_eq!(stored_pooling_on_disk(), "mean");
+
+        // `vera repair` resolves an embedding model and hands it to
+        // `setup::configure_backend`, which persists it verbatim. Sourcing it
+        // from the repaired accessor put `last-token` in the file and bricked
+        // an older Vera installed alongside — and unlike `vera setup`, the user
+        // never picked a pooling mode here.
+        let model = crate::commands::repair::embedding_model_to_persist(
+            vera_core::config::InferenceBackend::OnnxJina(
+                vera_core::config::OnnxExecutionProvider::Cpu,
+            ),
+        )
+        .unwrap()
+        .expect("an ONNX backend always carries an embedding model");
+        save_local_embedding_model(&model).unwrap();
+
+        assert_eq!(stored_pooling_on_disk(), "mean");
+    }
+
+    #[test]
     fn runtime_readers_repair_stored_pooling_in_memory() {
         let _guard = with_stored_config(LEGACY_JINA_CONFIG);
 

--- a/crates/vera-cli/src/state.rs
+++ b/crates/vera-cli/src/state.rs
@@ -58,15 +58,14 @@ pub struct ApiSetupInput {
     pub api_key: String,
 }
 
+/// Load `config.json` verbatim. Every save helper re-reads through here and
+/// writes the result back, so anything this function changes is persisted as a
+/// side effect of unrelated commands. In particular a repaired `pooling` would
+/// be written to disk and then refuse to parse under an older Vera on the same
+/// machine, whose `FromStr` only knows `mean` and `cls`. Repairs therefore
+/// belong at the points of use, not here.
 pub fn load_saved_config() -> Result<StoredConfig> {
-    let mut config: StoredConfig = load_json_file(&config_path()?)?;
-    // `setup` freezes the resolved model config here, and this copy outranks
-    // the preset. Without repair, an install created before jina's pooling was
-    // corrected keeps mean-pooling it indefinitely.
-    config.local_embedding_model = config
-        .local_embedding_model
-        .map(vera_core::local_models::LocalEmbeddingModelConfig::repair_stored_defaults);
-    Ok(config)
+    load_json_file(&config_path()?)
 }
 
 pub fn load_saved_secrets() -> Result<StoredSecrets> {
@@ -92,9 +91,17 @@ pub fn save_local_embedding_model(
     save_config(&config)
 }
 
+/// The stored model config as runtime should see it.
+///
+/// `setup` freezes the resolved model config into `config.json` and that copy
+/// outranks the preset, so an install created before jina's pooling was
+/// corrected would keep mean-pooling it indefinitely. The repair is applied in
+/// memory only; the file keeps whatever `setup` wrote.
 pub fn saved_local_embedding_model()
 -> Result<Option<vera_core::local_models::LocalEmbeddingModelConfig>> {
-    Ok(load_saved_config()?.local_embedding_model)
+    Ok(load_saved_config()?
+        .local_embedding_model
+        .map(vera_core::local_models::LocalEmbeddingModelConfig::repair_stored_defaults))
 }
 
 pub fn saved_backend() -> Result<Option<vera_core::config::InferenceBackend>> {
@@ -222,7 +229,12 @@ fn apply_saved_env_impl(force: bool) -> Result<()> {
         set_env_value("RERANKER_MODEL_API_KEY", api_key, force);
     }
 
-    apply_local_embedding_env(config.local_embedding_model.as_ref(), force);
+    // Repaired in memory on the way to the process environment; see
+    // `saved_local_embedding_model`.
+    let local_embedding_model = config
+        .local_embedding_model
+        .map(vera_core::local_models::LocalEmbeddingModelConfig::repair_stored_defaults);
+    apply_local_embedding_env(local_embedding_model.as_ref(), force);
 
     Ok(())
 }
@@ -410,6 +422,129 @@ const LOCAL_EMBEDDING_SOURCE_ENV_KEYS: &[&str] = &[
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Mutex;
+
+    /// `VERA_HOME` is process-global, so the tests that redirect it at the
+    /// config directory must not overlap with each other.
+    static VERA_HOME_LOCK: Mutex<()> = Mutex::new(());
+
+    /// What `vera setup` wrote to `config.json` before the pooling fix.
+    const LEGACY_JINA_CONFIG: &str = r#"{
+      "local_embedding_model": {
+        "source": {"source": "hugging-face",
+                   "repo": "jinaai/jina-embeddings-v5-text-nano-retrieval"},
+        "onnx_file": "onnx/model_quantized.onnx",
+        "onnx_data_file": "onnx/model_quantized.onnx_data",
+        "tokenizer_file": "tokenizer.json",
+        "embedding_dim": 768,
+        "pooling": "mean",
+        "max_length": 512
+      }
+    }"#;
+
+    /// Everything `apply_saved_env_impl` can write, plus the redirect itself.
+    const RESTORED_ENV_KEYS: &[&str] = &[
+        "VERA_HOME",
+        "VERA_BACKEND",
+        "VERA_LOCAL",
+        "EMBEDDING_MODEL_BASE_URL",
+        "EMBEDDING_MODEL_ID",
+        "EMBEDDING_MODEL_API_KEY",
+        "RERANKER_MODEL_BASE_URL",
+        "RERANKER_MODEL_ID",
+        "RERANKER_MODEL_API_KEY",
+        vera_core::local_models::LOCAL_EMBEDDING_REPO_ENV,
+        vera_core::local_models::LOCAL_EMBEDDING_DIR_ENV,
+        vera_core::local_models::LOCAL_EMBEDDING_ONNX_FILE_ENV,
+        vera_core::local_models::LOCAL_EMBEDDING_ONNX_DATA_FILE_ENV,
+        vera_core::local_models::LOCAL_EMBEDDING_TOKENIZER_FILE_ENV,
+        vera_core::local_models::LOCAL_EMBEDDING_DIM_ENV,
+        vera_core::local_models::LOCAL_EMBEDDING_POOLING_ENV,
+        vera_core::local_models::LOCAL_EMBEDDING_MAX_LENGTH_ENV,
+        vera_core::local_models::LOCAL_EMBEDDING_QUERY_PREFIX_ENV,
+        vera_core::local_models::LEGACY_EMBEDDING_QUERY_PREFIX_ENV,
+    ];
+
+    struct VeraHomeGuard {
+        _dir: tempfile::TempDir,
+        _lock: std::sync::MutexGuard<'static, ()>,
+        previous: Vec<Option<std::ffi::OsString>>,
+    }
+
+    impl Drop for VeraHomeGuard {
+        fn drop(&mut self) {
+            for (key, value) in RESTORED_ENV_KEYS.iter().zip(&self.previous) {
+                match value {
+                    Some(value) => set_process_env(key, &value.to_string_lossy()),
+                    None => clear_process_env(key),
+                }
+            }
+        }
+    }
+
+    /// Point `VERA_HOME` at a temp dir seeded with `contents` so no test can
+    /// reach the developer's real `~/.vera/config.json`.
+    fn with_stored_config(contents: &str) -> VeraHomeGuard {
+        let lock = VERA_HOME_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let previous = RESTORED_ENV_KEYS.iter().map(std::env::var_os).collect();
+        let dir = tempfile::tempdir().unwrap();
+        set_process_env("VERA_HOME", dir.path().to_str().unwrap());
+        fs::write(config_path().unwrap(), contents).unwrap();
+        VeraHomeGuard {
+            _dir: dir,
+            _lock: lock,
+            previous,
+        }
+    }
+
+    fn stored_pooling_on_disk() -> String {
+        let raw = fs::read(config_path().unwrap()).unwrap();
+        let value: serde_json::Value = serde_json::from_slice(&raw).unwrap();
+        value["local_embedding_model"]["pooling"]
+            .as_str()
+            .expect("stored config should still carry a pooling field")
+            .to_string()
+    }
+
+    #[test]
+    fn unrelated_save_does_not_rewrite_stored_pooling() {
+        let _guard = with_stored_config(LEGACY_JINA_CONFIG);
+        assert_eq!(stored_pooling_on_disk(), "mean");
+
+        // Every save helper is a load-mutate-save cycle over the same struct,
+        // so a repair applied at load time would be persisted from here.
+        save_backend(vera_core::config::InferenceBackend::OnnxJina(
+            vera_core::config::OnnxExecutionProvider::Cpu,
+        ))
+        .unwrap();
+
+        // A Vera older than `last-token` still has to be able to parse this
+        // file; its `FromStr` accepts only `mean` and `cls`.
+        assert_eq!(stored_pooling_on_disk(), "mean");
+    }
+
+    #[test]
+    fn runtime_readers_repair_stored_pooling_in_memory() {
+        let _guard = with_stored_config(LEGACY_JINA_CONFIG);
+
+        let model = saved_local_embedding_model()
+            .unwrap()
+            .expect("stored config carries a local embedding model");
+        assert_eq!(
+            model.pooling,
+            vera_core::local_models::LocalEmbeddingPooling::LastToken
+        );
+
+        apply_saved_env_force().unwrap();
+        assert_eq!(
+            std::env::var(vera_core::local_models::LOCAL_EMBEDDING_POOLING_ENV).unwrap(),
+            "last-token"
+        );
+
+        assert_eq!(stored_pooling_on_disk(), "mean");
+    }
 
     #[test]
     fn stored_config_defaults_are_empty() {

--- a/crates/vera-core/src/embedding/local_provider.rs
+++ b/crates/vera-core/src/embedding/local_provider.rs
@@ -501,6 +501,11 @@ impl LocalEmbeddingProvider {
                         }
                         emb
                     }
+                    LocalEmbeddingPooling::LastToken => {
+                        let last = last_unpadded_index(&attention_mask, i, max_len);
+                        let start = i * seq_len * dim + last * dim;
+                        data[start..start + dim].to_vec()
+                    }
                 };
                 let mut emb = emb;
                 normalize_embedding(&mut emb);
@@ -795,6 +800,17 @@ fn load_tokenizer(tokenizer_path: std::path::PathBuf, max_length: usize) -> Resu
     Ok(tokenizer)
 }
 
+/// Index of the final unpadded token in row `row` of `attention_mask`.
+///
+/// Scanning for the highest set position rather than counting ones keeps this
+/// correct under both left and right padding. An all-padding row yields 0.
+fn last_unpadded_index(attention_mask: &ndarray::Array2<i64>, row: usize, len: usize) -> usize {
+    (0..len)
+        .rev()
+        .find(|&j| attention_mask[[row, j]] == 1)
+        .unwrap_or(0)
+}
+
 fn normalize_embedding(embedding: &mut [f32]) {
     let norm: f32 = embedding
         .iter()
@@ -984,6 +1000,43 @@ fn register_execution_provider(
 mod tests {
     use super::*;
     use tempfile::tempdir;
+
+    /// Right padding: the model's real final token sits before the pad run.
+    #[test]
+    fn last_unpadded_index_right_padded() {
+        let mask = ndarray::arr2(&[[1i64, 1, 1, 0, 0]]);
+        assert_eq!(last_unpadded_index(&mask, 0, 5), 2);
+    }
+
+    /// Left padding: the real final token is the last column. Counting set
+    /// bits would answer 2 here, which is a pad position.
+    #[test]
+    fn last_unpadded_index_left_padded() {
+        let mask = ndarray::arr2(&[[0i64, 0, 1, 1, 1]]);
+        assert_eq!(last_unpadded_index(&mask, 0, 5), 4);
+    }
+
+    #[test]
+    fn last_unpadded_index_full_row_and_single_token() {
+        assert_eq!(
+            last_unpadded_index(&ndarray::arr2(&[[1i64, 1, 1]]), 0, 3),
+            2
+        );
+        assert_eq!(last_unpadded_index(&ndarray::arr2(&[[1i64]]), 0, 1), 0);
+    }
+
+    #[test]
+    fn last_unpadded_index_is_per_row() {
+        let mask = ndarray::arr2(&[[1i64, 1, 0, 0], [1, 1, 1, 1]]);
+        assert_eq!(last_unpadded_index(&mask, 0, 4), 1);
+        assert_eq!(last_unpadded_index(&mask, 1, 4), 3);
+    }
+
+    #[test]
+    fn last_unpadded_index_all_padding_falls_back_to_zero() {
+        let mask = ndarray::arr2(&[[0i64, 0, 0]]);
+        assert_eq!(last_unpadded_index(&mask, 0, 3), 0);
+    }
 
     #[tokio::test]
     async fn test_local_embedding_provider() {

--- a/crates/vera-core/src/local_models/mod.rs
+++ b/crates/vera-core/src/local_models/mod.rs
@@ -233,10 +233,10 @@ impl LocalEmbeddingModelConfig {
     }
 
     pub fn from_directory(path: PathBuf) -> Self {
-        Self {
-            source: LocalEmbeddingSource::Directory { path },
-            ..Self::default()
-        }
+        let source = LocalEmbeddingSource::Directory { path };
+        let mut defaults = Self::defaults_for_source(&source);
+        defaults.source = source;
+        defaults
     }
 
     /// Switch to the FP16 ONNX model when running on a GPU execution provider.

--- a/crates/vera-core/src/local_models/mod.rs
+++ b/crates/vera-core/src/local_models/mod.rs
@@ -92,6 +92,9 @@ pub(super) static MODEL_DOWNLOAD_ATTEMPT: AtomicU64 = AtomicU64::new(0);
 pub enum LocalEmbeddingPooling {
     Mean,
     Cls,
+    /// Take the final unpadded token. Required by decoder-style embedding
+    /// models (Qwen3-Embedding, F2LLM) and by jina-embeddings-v5.
+    LastToken,
 }
 
 impl fmt::Display for LocalEmbeddingPooling {
@@ -99,6 +102,7 @@ impl fmt::Display for LocalEmbeddingPooling {
         match self {
             Self::Mean => write!(f, "mean"),
             Self::Cls => write!(f, "cls"),
+            Self::LastToken => write!(f, "last-token"),
         }
     }
 }
@@ -110,8 +114,9 @@ impl std::str::FromStr for LocalEmbeddingPooling {
         match value.trim().to_ascii_lowercase().as_str() {
             "mean" => Ok(Self::Mean),
             "cls" => Ok(Self::Cls),
+            "last-token" | "lasttoken" | "last_token" => Ok(Self::LastToken),
             other => Err(format!(
-                "invalid pooling mode: {other} (expected `mean` or `cls`)"
+                "invalid pooling mode: {other} (expected `mean`, `cls` or `last-token`)"
             )),
         }
     }
@@ -173,11 +178,15 @@ impl LocalEmbeddingModelConfig {
         }
     }
 
+    /// `jina-embeddings-v5-text-nano-retrieval` pools on the final token, not
+    /// the mean: `1_Pooling/config.json` sets `pooling_mode_lasttoken`, and the
+    /// ONNX graph carries a matching `lasttoken_squeeze` + normalize path whose
+    /// result it exposes as a second `sentence_embedding` output.
     pub fn jina() -> Self {
         Self::preset(
             EMBEDDING_REPO,
             Some(EMBEDDING_ONNX_DATA_FILE),
-            LocalEmbeddingPooling::Mean,
+            LocalEmbeddingPooling::LastToken,
             None,
         )
     }
@@ -189,6 +198,31 @@ impl LocalEmbeddingModelConfig {
             LocalEmbeddingPooling::Cls,
             Some(CODERANK_QUERY_PREFIX),
         )
+    }
+
+    /// Repair a stored config that froze jina's old mean-pooling default.
+    ///
+    /// `vera setup` writes the resolved model config to `config.json` and that
+    /// copy wins over the preset, so an install created before this fix would
+    /// keep mean-pooling jina forever. Only the exact old preset is upgraded;
+    /// a config differing in any field is treated as deliberate and left
+    /// alone.
+    ///
+    /// The literal below coincides with `generic_defaults()` today, but the
+    /// two express different things: this one is a historical value that must
+    /// stay pinned even if the fallback shape changes.
+    pub fn repair_stored_defaults(self) -> Self {
+        let legacy_jina = Self::preset(
+            EMBEDDING_REPO,
+            Some(EMBEDDING_ONNX_DATA_FILE),
+            LocalEmbeddingPooling::Mean,
+            None,
+        );
+        if self == legacy_jina {
+            Self::jina()
+        } else {
+            self
+        }
     }
 
     pub fn from_huggingface_repo(repo: impl Into<String>) -> Self {
@@ -277,8 +311,12 @@ impl LocalEmbeddingModelConfig {
     }
 
     pub fn model_identity(&self) -> String {
+        // Presets keep a readable identity, but pooling has to stay in it.
+        // Vectors pooled two different ways are not comparable, so a pooling
+        // change must invalidate an existing index rather than silently query
+        // mean-pooled rows with last-token vectors.
         if self == &Self::jina() || self == &Self::coderankembed() {
-            return self.display_name();
+            return format!("{}|pooling={}", self.display_name(), self.pooling);
         }
 
         let source = match &self.source {
@@ -328,8 +366,24 @@ impl LocalEmbeddingModelConfig {
             LocalEmbeddingSource::HuggingFace { repo } if repo == CODERANK_EMBEDDING_REPO => {
                 Self::coderankembed()
             }
-            _ => Self::default(),
+            LocalEmbeddingSource::HuggingFace { repo } if repo == EMBEDDING_REPO => Self::jina(),
+            _ => Self::generic_defaults(),
         }
+    }
+
+    /// Asset shape for a repo Vera has no preset for: jina's file layout and
+    /// dimensions, with mean pooling.
+    ///
+    /// Held separate from `jina()` so that jina's own pooling can be correct
+    /// without changing how every custom repo is pooled. `from_source`
+    /// overwrites `source`, so only the non-source fields are inherited.
+    fn generic_defaults() -> Self {
+        Self::preset(
+            EMBEDDING_REPO,
+            Some(EMBEDDING_ONNX_DATA_FILE),
+            LocalEmbeddingPooling::Mean,
+            None,
+        )
     }
 
     fn apply_env_overrides(defaults: Self) -> Result<Self> {

--- a/crates/vera-core/src/local_models/mod.rs
+++ b/crates/vera-core/src/local_models/mod.rs
@@ -200,6 +200,32 @@ impl LocalEmbeddingModelConfig {
         )
     }
 
+    /// The exact model config `vera setup` froze into `config.json` for jina
+    /// before the pooling fix.
+    ///
+    /// Frozen literals, never the `EMBEDDING_*` constants. This describes a
+    /// file already sitting on someone's disk, so it must not follow the live
+    /// preset: deriving it from the constants means the day one of them moves
+    /// — raising `EMBEDDING_MAX_LENGTH` for #67, renaming an ONNX export — the
+    /// literal stops matching any real pre-fix config and the migration
+    /// silently never fires again, leaving every such install mean-pooled with
+    /// no error. `legacy_jina_literal_stays_pinned_when_the_constants_move` is
+    /// the tripwire for that.
+    fn legacy_jina_before_pooling_fix() -> Self {
+        Self {
+            source: LocalEmbeddingSource::HuggingFace {
+                repo: "jinaai/jina-embeddings-v5-text-nano-retrieval".to_string(),
+            },
+            onnx_file: "onnx/model_quantized.onnx".to_string(),
+            onnx_data_file: Some("onnx/model_quantized.onnx_data".to_string()),
+            tokenizer_file: "tokenizer.json".to_string(),
+            embedding_dim: 768,
+            pooling: LocalEmbeddingPooling::Mean,
+            max_length: 512,
+            query_prefix: None,
+        }
+    }
+
     /// Repair a stored config that froze jina's old mean-pooling default.
     ///
     /// `vera setup` writes the resolved model config to `config.json` and that
@@ -207,18 +233,8 @@ impl LocalEmbeddingModelConfig {
     /// keep mean-pooling jina forever. Only the exact old preset is upgraded;
     /// a config differing in any field is treated as deliberate and left
     /// alone.
-    ///
-    /// The literal below coincides with `generic_defaults()` today, but the
-    /// two express different things: this one is a historical value that must
-    /// stay pinned even if the fallback shape changes.
     pub fn repair_stored_defaults(self) -> Self {
-        let legacy_jina = Self::preset(
-            EMBEDDING_REPO,
-            Some(EMBEDDING_ONNX_DATA_FILE),
-            LocalEmbeddingPooling::Mean,
-            None,
-        );
-        if self == legacy_jina {
+        if self == Self::legacy_jina_before_pooling_fix() {
             Self::jina()
         } else {
             self

--- a/crates/vera-core/src/local_models/mod.rs
+++ b/crates/vera-core/src/local_models/mod.rs
@@ -92,8 +92,8 @@ pub(super) static MODEL_DOWNLOAD_ATTEMPT: AtomicU64 = AtomicU64::new(0);
 pub enum LocalEmbeddingPooling {
     Mean,
     Cls,
-    /// Take the final unpadded token. Required by decoder-style embedding
-    /// models (Qwen3-Embedding, F2LLM) and by jina-embeddings-v5.
+    /// Take the final unpadded token. Required by jina-embeddings-v5, whose
+    /// `1_Pooling/config.json` sets `pooling_mode_lasttoken`.
     LastToken,
 }
 

--- a/crates/vera-core/src/local_models/tests.rs
+++ b/crates/vera-core/src/local_models/tests.rs
@@ -478,3 +478,146 @@ fn resolve_macos_rpath_executable_path_with_slash() {
         expected
     );
 }
+
+#[test]
+fn pooling_display_and_from_str_round_trip() {
+    // `state.rs` writes pooling to the environment via Display and reads it
+    // back through FromStr, so any spelling those two disagree on silently
+    // fails to reload a saved config.
+    for mode in [
+        LocalEmbeddingPooling::Mean,
+        LocalEmbeddingPooling::Cls,
+        LocalEmbeddingPooling::LastToken,
+    ] {
+        let rendered = mode.to_string();
+        assert_eq!(
+            rendered.parse::<LocalEmbeddingPooling>(),
+            Ok(mode),
+            "Display emitted `{rendered}`, which FromStr does not accept"
+        );
+    }
+}
+
+#[test]
+fn pooling_from_str_accepts_last_token_spellings() {
+    for spelling in [
+        "last-token",
+        "lasttoken",
+        "last_token",
+        "LAST-TOKEN",
+        " last-token ",
+    ] {
+        assert_eq!(
+            spelling.parse::<LocalEmbeddingPooling>(),
+            Ok(LocalEmbeddingPooling::LastToken),
+            "rejected `{spelling}`"
+        );
+    }
+}
+
+#[test]
+fn pooling_from_str_error_lists_every_accepted_mode() {
+    let err = "bogus".parse::<LocalEmbeddingPooling>().unwrap_err();
+    for mode in [
+        LocalEmbeddingPooling::Mean,
+        LocalEmbeddingPooling::Cls,
+        LocalEmbeddingPooling::LastToken,
+    ] {
+        assert!(
+            err.contains(&mode.to_string()),
+            "error `{err}` omits `{mode}`, so the CLI cannot advertise it"
+        );
+    }
+}
+
+#[test]
+fn jina_preset_pools_on_the_last_token() {
+    // jina-embeddings-v5-text-nano-retrieval declares `pooling_mode_lasttoken`
+    // in 1_Pooling/config.json. Mean pooling of its last_hidden_state scores
+    // cos 0.59-0.66 against the graph's own `sentence_embedding` output;
+    // last-token pooling reproduces it exactly.
+    assert_eq!(
+        LocalEmbeddingModelConfig::jina().pooling,
+        LocalEmbeddingPooling::LastToken
+    );
+    assert_eq!(
+        LocalEmbeddingModelConfig::default().pooling,
+        LocalEmbeddingPooling::LastToken
+    );
+    assert_eq!(
+        LocalEmbeddingModelConfig::from_huggingface_repo(EMBEDDING_REPO).pooling,
+        LocalEmbeddingPooling::LastToken
+    );
+}
+
+#[test]
+fn unknown_repo_still_defaults_to_mean_pooling() {
+    // Fixing jina's pooling must not reach through the shared fallback and
+    // repool every custom model.
+    let config = LocalEmbeddingModelConfig::from_huggingface_repo("some-org/some-encoder");
+    assert_eq!(config.pooling, LocalEmbeddingPooling::Mean);
+    assert_eq!(
+        LocalEmbeddingModelConfig::coderankembed().pooling,
+        LocalEmbeddingPooling::Cls
+    );
+}
+
+#[test]
+fn preset_identity_changes_with_pooling_so_stale_indexes_are_detected() {
+    // Vectors pooled two ways are not comparable. If the preset identity
+    // ignored pooling, upgrading would query mean-pooled rows with last-token
+    // vectors and silently return worse results instead of asking for a
+    // re-index.
+    let jina = LocalEmbeddingModelConfig::jina();
+    let mut mean_pooled = jina.clone();
+    mean_pooled.pooling = LocalEmbeddingPooling::Mean;
+
+    assert_ne!(jina.model_identity(), mean_pooled.model_identity());
+    assert_ne!(jina.model_identity(), jina.display_name());
+    assert!(jina.model_identity().contains("last-token"));
+    // The repo still has to be recognisable in the stored name.
+    assert!(jina.model_identity().starts_with(&jina.display_name()));
+}
+
+#[test]
+fn stored_legacy_jina_config_is_repaired_to_last_token() {
+    // What `vera setup` wrote to config.json before the pooling fix.
+    let stored: LocalEmbeddingModelConfig = serde_json::from_str(
+        r#"{
+            "source": {"source": "hugging-face",
+                       "repo": "jinaai/jina-embeddings-v5-text-nano-retrieval"},
+            "onnx_file": "onnx/model_quantized.onnx",
+            "onnx_data_file": "onnx/model_quantized.onnx_data",
+            "tokenizer_file": "tokenizer.json",
+            "embedding_dim": 768,
+            "pooling": "mean",
+            "max_length": 512
+        }"#,
+    )
+    .expect("legacy config should still deserialize");
+    assert_eq!(stored.pooling, LocalEmbeddingPooling::Mean);
+
+    let repaired = stored.repair_stored_defaults();
+    assert_eq!(repaired.pooling, LocalEmbeddingPooling::LastToken);
+    assert_eq!(repaired, LocalEmbeddingModelConfig::jina());
+}
+
+#[test]
+fn repair_leaves_customised_and_unrelated_configs_alone() {
+    // A deliberate non-default choice on the same repo must survive.
+    let mut customised = LocalEmbeddingModelConfig::jina();
+    customised.pooling = LocalEmbeddingPooling::Mean;
+    customised.max_length = 256;
+    assert_eq!(customised.clone().repair_stored_defaults(), customised);
+
+    // A different repo that happens to be mean-pooled must survive.
+    let other = LocalEmbeddingModelConfig::from_huggingface_repo("some-org/some-encoder");
+    assert_eq!(other.pooling, LocalEmbeddingPooling::Mean);
+    assert_eq!(other.clone().repair_stored_defaults(), other);
+
+    // Repair is idempotent and does not touch the other preset.
+    let jina = LocalEmbeddingModelConfig::jina();
+    assert_eq!(jina.clone().repair_stored_defaults(), jina);
+    let coderank = LocalEmbeddingModelConfig::coderankembed();
+    assert_eq!(coderank.clone().repair_stored_defaults(), coderank);
+}

--- a/crates/vera-core/src/local_models/tests.rs
+++ b/crates/vera-core/src/local_models/tests.rs
@@ -586,15 +586,25 @@ fn preset_identity_changes_with_pooling_so_stale_indexes_are_detected() {
     // ignored pooling, upgrading would query mean-pooled rows with last-token
     // vectors and silently return worse results instead of asking for a
     // re-index.
+    // Assert the exact preset form. Comparing jina's identity against a
+    // mean-pooled clone proves nothing on its own: changing `pooling` breaks
+    // struct equality with `Self::jina()`, so the clone leaves the preset
+    // branch of `model_identity` and renders through the generic one. The two
+    // strings then differ because of the branch, not because pooling is in the
+    // preset identity, and the assertion still passes with pooling dropped
+    // from that branch entirely.
     let jina = LocalEmbeddingModelConfig::jina();
-    let mut mean_pooled = jina.clone();
-    mean_pooled.pooling = LocalEmbeddingPooling::Mean;
-
-    assert_ne!(jina.model_identity(), mean_pooled.model_identity());
-    assert_ne!(jina.model_identity(), jina.display_name());
-    assert!(jina.model_identity().contains("last-token"));
+    assert_eq!(
+        jina.model_identity(),
+        format!("{}|pooling=last-token", jina.display_name())
+    );
     // The repo still has to be recognisable in the stored name.
     assert!(jina.model_identity().starts_with(&jina.display_name()));
+
+    let mut mean_pooled = jina.clone();
+    mean_pooled.pooling = LocalEmbeddingPooling::Mean;
+    assert_ne!(jina.model_identity(), mean_pooled.model_identity());
+    assert!(mean_pooled.model_identity().contains("pooling=mean"));
 }
 
 #[test]

--- a/crates/vera-core/src/local_models/tests.rs
+++ b/crates/vera-core/src/local_models/tests.rs
@@ -563,6 +563,24 @@ fn unknown_repo_still_defaults_to_mean_pooling() {
 }
 
 #[test]
+fn directory_source_still_defaults_to_mean_pooling() {
+    // `--embedding-dir` and VERA_LOCAL_EMBEDDING_DIR point at a model Vera has
+    // no preset for, so they must inherit the generic fallback. Deriving them
+    // from `Default` instead handed every custom directory model jina's
+    // last-token pooling the moment jina's own pooling was fixed.
+    let path = PathBuf::from("/models/some-encoder");
+    let config = LocalEmbeddingModelConfig::from_directory(path.clone());
+
+    assert_eq!(config.pooling, LocalEmbeddingPooling::Mean);
+    assert_eq!(config.source, LocalEmbeddingSource::Directory { path });
+    assert!(
+        config.model_identity().contains("pooling=mean"),
+        "identity `{}` should record mean pooling",
+        config.model_identity()
+    );
+}
+
+#[test]
 fn preset_identity_changes_with_pooling_so_stale_indexes_are_detected() {
     // Vectors pooled two ways are not comparable. If the preset identity
     // ignored pooling, upgrading would query mean-pooled rows with last-token

--- a/crates/vera-core/src/local_models/tests.rs
+++ b/crates/vera-core/src/local_models/tests.rs
@@ -598,6 +598,31 @@ fn preset_identity_changes_with_pooling_so_stale_indexes_are_detected() {
 }
 
 #[test]
+fn coderank_preset_identity_records_its_pooling() {
+    // The preset branch of `model_identity` covers CodeRankEmbed as well as
+    // jina, so it carries the same obligation: pooling stays in the identity,
+    // and the repo stays readable in it. Asserting the exact preset form keeps
+    // this from passing on a CodeRankEmbed that quietly fell through to the
+    // generic branch.
+    let coderank = LocalEmbeddingModelConfig::coderankembed();
+    assert_eq!(
+        coderank.model_identity(),
+        format!("{}|pooling=cls", coderank.display_name())
+    );
+    assert!(
+        coderank
+            .model_identity()
+            .starts_with(&coderank.display_name())
+    );
+
+    // CodeRankEmbed is CLS-pooled, so mean is the contrasting choice.
+    let mut mean_pooled = coderank.clone();
+    mean_pooled.pooling = LocalEmbeddingPooling::Mean;
+    assert_ne!(coderank.model_identity(), mean_pooled.model_identity());
+    assert!(mean_pooled.model_identity().contains("pooling=mean"));
+}
+
+#[test]
 fn stored_legacy_jina_config_is_repaired_to_last_token() {
     // What `vera setup` wrote to config.json before the pooling fix.
     let stored: LocalEmbeddingModelConfig = serde_json::from_str(

--- a/crates/vera-core/src/local_models/tests.rs
+++ b/crates/vera-core/src/local_models/tests.rs
@@ -646,6 +646,58 @@ fn stored_legacy_jina_config_is_repaired_to_last_token() {
 }
 
 #[test]
+fn legacy_jina_literal_stays_pinned_when_the_constants_move() {
+    // Half one: the literal itself. It describes a config.json an older Vera
+    // already wrote, so editing it changes which installs the migration
+    // reaches.
+    let legacy = LocalEmbeddingModelConfig::legacy_jina_before_pooling_fix();
+    assert_eq!(
+        legacy,
+        LocalEmbeddingModelConfig {
+            source: LocalEmbeddingSource::HuggingFace {
+                repo: "jinaai/jina-embeddings-v5-text-nano-retrieval".to_string(),
+            },
+            onnx_file: "onnx/model_quantized.onnx".to_string(),
+            onnx_data_file: Some("onnx/model_quantized.onnx_data".to_string()),
+            tokenizer_file: "tokenizer.json".to_string(),
+            embedding_dim: 768,
+            pooling: LocalEmbeddingPooling::Mean,
+            max_length: 512,
+            query_prefix: None,
+        }
+    );
+
+    // Half two: the tripwire. Today's constants still happen to describe that
+    // same file. When one of them moves, this fails and the reader decides.
+    const GUIDANCE: &str = "A live EMBEDDING_* constant no longer matches the pre-fix \
+         config.json that `repair_stored_defaults` migrates. Leave \
+         `legacy_jina_before_pooling_fix` exactly as it is — it is a historical value, not a \
+         preset — and update this assertion to record the divergence. Only edit the frozen \
+         literal if you have confirmed real pre-fix installs carried the new value: making it \
+         follow the constant stops it matching any of them, and every pre-fix install then \
+         stays mean-pooled with no error.";
+    assert_eq!(
+        legacy.source,
+        LocalEmbeddingSource::HuggingFace {
+            repo: EMBEDDING_REPO.to_string(),
+        },
+        "{GUIDANCE}"
+    );
+    assert_eq!(legacy.onnx_file, EMBEDDING_ONNX_FILE, "{GUIDANCE}");
+    assert_eq!(
+        legacy.onnx_data_file.as_deref(),
+        Some(EMBEDDING_ONNX_DATA_FILE),
+        "{GUIDANCE}"
+    );
+    assert_eq!(
+        legacy.tokenizer_file, EMBEDDING_TOKENIZER_FILE,
+        "{GUIDANCE}"
+    );
+    assert_eq!(legacy.embedding_dim, EMBEDDING_DIM, "{GUIDANCE}");
+    assert_eq!(legacy.max_length, EMBEDDING_MAX_LENGTH, "{GUIDANCE}");
+}
+
+#[test]
 fn repair_leaves_customised_and_unrelated_configs_alone() {
     // A deliberate non-default choice on the same repo must survive.
     let mut customised = LocalEmbeddingModelConfig::jina();

--- a/crates/vera-core/src/local_models/tests.rs
+++ b/crates/vera-core/src/local_models/tests.rs
@@ -698,8 +698,33 @@ fn legacy_jina_literal_stays_pinned_when_the_constants_move() {
 }
 
 #[test]
+fn explicit_mean_on_the_default_repo_is_repaired_with_the_legacy_default() {
+    // `--embedding-pooling mean` on the default repo, changing nothing else,
+    // writes byte-for-byte the config.json an older `vera setup` wrote on its
+    // own. Nothing in the file distinguishes the two, so the migration cannot
+    // spare this user's choice without sparing every pre-fix install as well.
+    // Overwriting it is the knowingly accepted side of that trade, not a bug
+    // to fix here, and this asserts the behaviour that actually ships rather
+    // than the behaviour the neighbouring test's comment implies.
+    let mut explicit_mean = LocalEmbeddingModelConfig::jina();
+    explicit_mean.pooling = LocalEmbeddingPooling::Mean;
+    assert_eq!(
+        explicit_mean,
+        LocalEmbeddingModelConfig::legacy_jina_before_pooling_fix()
+    );
+
+    assert_eq!(
+        explicit_mean.repair_stored_defaults(),
+        LocalEmbeddingModelConfig::jina()
+    );
+}
+
+#[test]
 fn repair_leaves_customised_and_unrelated_configs_alone() {
-    // A deliberate non-default choice on the same repo must survive.
+    // A deliberate non-default choice on the same repo survives as long as
+    // some field other than pooling also differs from the historical default —
+    // `max_length` here. Pooling alone does not; see
+    // `explicit_mean_on_the_default_repo_is_repaired_with_the_legacy_default`.
     let mut customised = LocalEmbeddingModelConfig::jina();
     customised.pooling = LocalEmbeddingPooling::Mean;
     customised.max_length = 256;

--- a/docs/models.md
+++ b/docs/models.md
@@ -76,7 +76,7 @@ Use this when you already downloaded or exported the model yourself.
 | `--embedding-no-onnx-data` | Use models that do not ship an external data file |
 | `--embedding-tokenizer-file <path>` | Relative path to the tokenizer file |
 | `--embedding-dim <n>` | Embedding dimension stored in the index |
-| `--embedding-pooling mean|cls|last-token` | Pooling method for token-level outputs |
+| `--embedding-pooling <mode>` | Pooling method for token-level outputs: `mean`, `cls`, or `last-token` |
 | `--embedding-max-length <n>` | Tokenizer truncation length |
 | `--embedding-query-prefix <text>` | Optional prefix prepended to local embedding queries |
 

--- a/docs/models.md
+++ b/docs/models.md
@@ -76,7 +76,7 @@ Use this when you already downloaded or exported the model yourself.
 | `--embedding-no-onnx-data` | Use models that do not ship an external data file |
 | `--embedding-tokenizer-file <path>` | Relative path to the tokenizer file |
 | `--embedding-dim <n>` | Embedding dimension stored in the index |
-| `--embedding-pooling mean|cls` | Pooling method for token-level outputs |
+| `--embedding-pooling mean|cls|last-token` | Pooling method for token-level outputs |
 | `--embedding-max-length <n>` | Tokenizer truncation length |
 | `--embedding-query-prefix <text>` | Optional prefix prepended to local embedding queries |
 


### PR DESCRIPTION
## What was wrong

`LocalEmbeddingModelConfig::jina()` configured the default model with mean pooling. `jinaai/jina-embeddings-v5-text-nano-retrieval` is a last-token model:

- `1_Pooling/config.json` sets `"pooling_mode_lasttoken": true`, every other mode `false`
- the model card's spec table says `| Pooling Strategy | Last-token pooling |`
- the card's own ONNX example comments `# Jina-v5 uses LAST-TOKEN pooling.`

The shipped graph declares two outputs, `last_hidden_state` `[batch, seq, 768]` then `sentence_embedding` `[batch, 768]`, and contains `/model/st/pool_0/lasttoken_squeeze/` and `/model/st/normalize_1/` nodes. `do_embed_once` takes `outputs.values().next()`; in `ort` 2.0.0-rc.11 `SessionOutputs` is a `SmallVec` pair in graph-declaration order, so that is `last_hidden_state`, which lands in the rank-3 pooling branch. The model's own correct vector was sitting unused as output 1.

## Verification

The second output is the model author's own pooled result, so it can referee the pooling choice with no external reference implementation. Cosine against it, on the cached fp16 export, right padding to mirror how Vera fills its arrays:

| text | tokens | cos(mean, oracle) | cos(last-token, oracle) | cos(cls, oracle) |
|---|---|---|---|---|
| 0 | 12 | +0.5913 | **+1.0000** | +0.4350 |
| 1 | 24 | +0.6159 | **+1.0000** | +0.4039 |
| 2 | 27 | +0.6021 | **+1.0000** | +0.4135 |
| 3 | 18 | +0.6122 | **+1.0000** | +0.4197 |
| 4 | 12 | +0.6562 | **+1.0000** | +0.4565 |
| 5 | 30 | +0.6441 | **+1.0000** | +0.4265 |

On a single query against five code snippets, mean pooling inflated an unrelated `SELECT * FROM users` row from 0.0624 to 0.1938 and promoted it above a closer match. Ranking by mean was `[1, 3, 4, 2, 5]`; by last-token and by the oracle, `[1, 3, 2, 4, 5]`.

End to end against released `vera 1.0.0` as control, same 29-file corpus, 903 chunks both sides, four queries: three of the four returned a different top-5. I am **not** claiming a measured relevance win from that run, only that the change is material. The correctness claim rests on the exact oracle match above.

## Why the diff is bigger than one constant

**Finding the unpadded token.** Counting set bits in the attention mask is correct only under right padding. Scanning for the highest set position is correct under both, and `last_unpadded_index_left_padded` is the test that discriminates: with a count-based implementation the other four index tests still pass.

**Not repooling every other model.** `defaults_for_source` fell through to `Default::default()`, which is `jina()`, so correcting jina would have silently switched every custom repo to last-token as well. The generic fallback is now explicit and stays on mean, pinned by `unknown_repo_still_defaults_to_mean_pooling`.

**Making stale indexes visible.** `model_identity()` short-circuited presets to a bare repo name, dropping pooling from the fingerprint. Left alone, an upgraded install would have queried mean-pooled rows with last-token vectors and quietly returned worse results. Preset identities now include the pooling mode, so the existing check fires:

````
Error: Index was created with model 'jinaai/jina-embeddings-v5-text-nano-retrieval' (768 dimensions),
but you are using model 'jinaai/jina-embeddings-v5-text-nano-retrieval|pooling=last-token'.
Please re-index with matching provider.
````

This does mean CodeRankEmbed indexes also re-index once, since their identity gains `|pooling=cls`. I took that over special-casing one preset; happy to narrow it if you would rather.

**Reaching installs that already exist.** This is the part that nearly made the fix a no-op. `vera setup` writes the resolved model config into `~/.vera/config.json`, and that copy outranks the preset. My first end-to-end run showed the built binary still indexing with `pooling=mean` for exactly this reason. `repair_stored_defaults` upgrades a stored config that matches the old jina preset exactly, and leaves anything customised alone.

**The first version of that repair could brick an older install, and `6bc9676` fixes it.** I had put it inside `load_saved_config`, but every save helper re-reads through that function and writes the result back, so an unrelated command such as `vera setup --backend ...` laundered the repaired value onto disk. A released `vera 1.0.0` on the same machine then refused to start, because its `FromStr` only knows `mean` and `cls`:

````
Error: failed to parse persistent state: /Users/<user>/.vera/config.json:
unknown variant `last-token`, expected `mean` or `cls` at line 16 column 27
````

This was not hypothetical. It happened on my machine and took the installed CLI down until I restored the file. The repair now runs only at the two points of use, `saved_local_embedding_model` and the env export in `apply_saved_env_impl`, so the struct reaching `save_config` is byte-identical to what was read. `unrelated_save_does_not_rewrite_stored_pooling` asserts the on-disk value is still `mean` after a save cycle, and fails with `left: "last-token", right: "mean"` if the repair is moved back.

An explicit `vera setup` or `vera repair` on a new build still writes `last-token`, and an older binary still cannot read that. That is inherent to adding a variant to a shared config file and it is a deliberate user action; the bug was the incidental rewrite.

Verified with an untouched `config.json` still containing `"pooling": "mean"`:

````
--- stored identity with NO env override:
jinaai/jina-embeddings-v5-text-nano-retrieval|pooling=last-token
````

## Testing

`cargo test -p vera-core --lib` 806 passed, `cargo test -p vera-cli --bin vera` 99 passed, `cargo fmt --check` clean, `cargo clippy -p vera-core --lib` unchanged at the five pre-existing warnings.

Every new assertion was checked by reinjecting the defect. Reverting the preset to `Mean` fails `jina_preset_pools_on_the_last_token` with `left: Mean, right: LastToken`; reverting the identity short-circuit fails `preset_identity_changes_with_pooling_so_stale_indexes_are_detected` with both sides printing the bare repo name; replacing the index scan with a bit count fails `last_unpadded_index_left_padded`; reverting the error text fails `pooling_from_str_error_lists_every_accepted_mode`.

## Deliberately not in this PR

The model also expects `Query: ` and `Document: ` prefixes, which Vera never applies and currently has no document-side mechanism for. Adding only the query half would make the two sides asymmetric, so it is filed separately with the plumbing it needs. `max_length` stays at 512, so nothing here touches the `bucket_for` retuning.

## Review hotspots

`repair_stored_defaults` compares against a literal that coincides with `generic_defaults()` today. That is intentional, and commented: one is a historical value that must stay pinned, the other is a live fallback that may change.

Fixes #91
Fixes #92

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pools `jinaai/jina-embeddings-v5-text-nano-retrieval` on the last token instead of the mean to match the model and avoid ranking drift. Old behavior: mean-pooled `last_hidden_state`; new behavior: last-token from the final unpadded token (works with left- and right-padding), matching the model’s intended `sentence_embedding`.

- Adds a `last-token` pooling mode in `vera-core` and `vera-cli`; `--embedding-pooling` now accepts `mean`, `cls`, or `last-token`; docs updated.
- Implements last-token by scanning the attention mask for the highest set position; tests cover both padding directions and edge cases.
- Limits behavior change to presets and fixes defaults:
  - Jina now pools last-token; unknown repos and `--embedding-dir` use explicit generic defaults and stay on mean; `CodeRankEmbed` remains CLS.
  - `from_directory` now derives defaults from the source instead of `Default`, so directory models no longer inherit Jina’s pooling.
- Preset model identity now includes pooling (for example, `...|pooling=last-token`) to surface stale indexes. Action: re-index any collections created with the old Jina preset; `CodeRankEmbed` indexes will also re-index once due to the identity change.
- Existing installs: repairs the legacy Jina mean-pooled config at runtime only. No on-disk rewrite of `~/.vera/config.json`; `vera repair` persists the raw stored value and applies the fix only to the process environment, avoiding bricking older CLIs.

<sup>Written for commit ebaf6bd3b31f7443ba91d8fb5089e819bf655c03. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/VeraTools/Vera/pull/94?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added `last-token` pooling support for local embedding models.
  - Updated the Jina embedding preset to use last-token pooling.
  - Added support for left- and right-padded inputs.
  - Pooling settings now contribute to consistent model identification.
  - Added accepted aliases and validation for pooling configuration values.

- **Bug Fixes**
  - Legacy saved configurations are repaired at runtime without rewriting saved files.

- **Documentation**
  - Updated embedding pooling options to include `mean`, `cls`, and `last-token`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
