### PR TITLE
fix(cli): honour --client and --scope on `vera agent sync`

### DIFF
--- a/crates/vera-cli/src/commands/agent.rs
+++ b/crates/vera-cli/src/commands/agent.rs
@@ -938,6 +938,8 @@ pub(crate) fn sync_skills_only() -> anyhow::Result<()> {
 struct SyncOutcome {
     updated: Vec<PathBuf>,
     refreshed_snippets: Vec<PathBuf>,
+    /// `--scope all` was asked for but only the global half could run.
+    project_scope_skipped: bool,
 }
 
 /// Whether project-scoped paths under `cwd` can be resolved at all.
@@ -991,6 +993,7 @@ fn sync_to_roots(
     Ok(SyncOutcome {
         updated,
         refreshed_snippets,
+        project_scope_skipped: scope == AgentScope::All && scan_scope == AgentScope::Global,
     })
 }
 
@@ -1007,6 +1010,7 @@ fn sync_with_options(
     let SyncOutcome {
         updated,
         refreshed_snippets,
+        project_scope_skipped,
     } = sync_to_roots(
         client,
         scope,
@@ -1017,6 +1021,16 @@ fn sync_with_options(
 
     if quiet {
         return Ok(());
+    }
+
+    // Half of what `--scope all` asked for could not run. The global half is
+    // still work the user wants, so proceed, but do not let the project half
+    // vanish into a report that reads as a complete success.
+    if project_scope_skipped {
+        eprintln!(
+            "Warning: --scope all needs a readable current directory for the project scope. \
+             Synced global scope only."
+        );
     }
 
     if json_output {
@@ -1846,6 +1860,75 @@ mod tests {
         assert!(
             error.to_string().contains("current directory"),
             "unexpected error: {error}"
+        );
+    }
+
+    /// `--scope all` keeps the global half rather than failing outright, so the
+    /// only thing standing between "half the request ran" and a report that
+    /// reads as complete success is this flag.
+    #[cfg(unix)]
+    #[test]
+    fn sync_to_roots_flags_a_project_scope_all_could_not_search() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp = tempdir().unwrap();
+        let home = temp.path().join("home");
+        let cwd = temp.path().join("project");
+        fs::create_dir_all(&home).unwrap();
+
+        for &(client, scope) in SCOPED_SYNC_FIXTURE {
+            let path = skill_path_for(client, scope, &cwd, &home).unwrap();
+            fs::create_dir_all(&path).unwrap();
+            fs::write(path.join("SKILL.md"), "stale").unwrap();
+            fs::write(path.join(".version"), "0.0.0").unwrap();
+        }
+
+        let searchable = sync_to_roots(
+            AgentClient::All,
+            AgentScope::All,
+            Some(cwd.as_path()),
+            &home,
+            true,
+        )
+        .unwrap();
+        assert!(
+            !searchable.project_scope_skipped,
+            "a searchable project directory must not report a skipped scope"
+        );
+
+        for &(client, scope) in SCOPED_SYNC_FIXTURE {
+            let path = skill_path_for(client, scope, &cwd, &home).unwrap();
+            fs::write(path.join(".version"), "0.0.0").unwrap();
+        }
+
+        fs::set_permissions(&cwd, fs::Permissions::from_mode(0o000)).unwrap();
+        let _restore = RestoreMode(cwd.clone());
+        if fs::metadata(cwd.join(".")).is_ok() {
+            // Running as root, or on a filesystem that ignores mode bits.
+            return;
+        }
+
+        let outcome = sync_to_roots(
+            AgentClient::All,
+            AgentScope::All,
+            Some(cwd.as_path()),
+            &home,
+            true,
+        )
+        .unwrap();
+
+        assert!(
+            outcome.project_scope_skipped,
+            "--scope all silently degraded to global for an unsearchable project directory"
+        );
+        let global: Vec<PathBuf> = SCOPED_SYNC_FIXTURE
+            .iter()
+            .filter(|(_, scope)| *scope == AgentScope::Global)
+            .map(|(client, scope)| skill_path_for(*client, *scope, &cwd, &home).unwrap())
+            .collect();
+        assert_eq!(
+            outcome.updated, global,
+            "the global half of --scope all must still run"
         );
     }
 }

--- a/crates/vera-cli/src/commands/agent.rs
+++ b/crates/vera-cli/src/commands/agent.rs
@@ -940,6 +940,16 @@ struct SyncOutcome {
     refreshed_snippets: Vec<PathBuf>,
 }
 
+/// Whether project-scoped paths under `cwd` can be resolved at all.
+///
+/// `getcwd` still succeeds on Linux for a directory the process has no search
+/// permission on, so `project_cwd` can be `Some` for a directory every
+/// `Path::exists()` probe underneath reports as missing. Stat a path inside it
+/// so that access error is not read as "nothing is installed".
+fn project_root_is_searchable(cwd: &Path) -> bool {
+    fs::metadata(cwd.join(".")).is_ok()
+}
+
 fn sync_to_roots(
     client: AgentClient,
     scope: AgentScope,
@@ -947,6 +957,7 @@ fn sync_to_roots(
     home: &Path,
     refresh_project_snippets: bool,
 ) -> anyhow::Result<SyncOutcome> {
+    let project_cwd = project_cwd.filter(|cwd| project_root_is_searchable(cwd));
     let scan_scope = match (scope, project_cwd) {
         (AgentScope::Project, None) => {
             bail!("--scope project needs a readable current directory")
@@ -1787,5 +1798,54 @@ mod tests {
         assert_eq!(outcome.updated, vec![stale]);
         assert!(outcome.refreshed_snippets.is_empty());
         assert_eq!(fs::read_to_string(&claude_md).unwrap(), managed);
+    }
+
+    /// Restores a directory's mode on unwind so a failing test cannot leave an
+    /// unreadable directory behind for `TempDir` to fail cleaning up.
+    #[cfg(unix)]
+    struct RestoreMode(PathBuf);
+
+    #[cfg(unix)]
+    impl Drop for RestoreMode {
+        fn drop(&mut self) {
+            use std::os::unix::fs::PermissionsExt;
+            let _ = fs::set_permissions(&self.0, fs::Permissions::from_mode(0o755));
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn sync_to_roots_rejects_a_project_scope_it_cannot_search() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp = tempdir().unwrap();
+        let home = temp.path().join("home");
+        let cwd = temp.path().join("project");
+        fs::create_dir_all(&home).unwrap();
+
+        let stale = skill_path_for(AgentClient::Claude, AgentScope::Project, &cwd, &home).unwrap();
+        fs::create_dir_all(&stale).unwrap();
+        fs::write(stale.join("SKILL.md"), "stale").unwrap();
+        fs::write(stale.join(".version"), "0.0.0").unwrap();
+
+        fs::set_permissions(&cwd, fs::Permissions::from_mode(0o000)).unwrap();
+        let _restore = RestoreMode(cwd.clone());
+        if fs::metadata(cwd.join(".")).is_ok() {
+            // Running as root, or on a filesystem that ignores mode bits.
+            return;
+        }
+
+        let error = sync_to_roots(
+            AgentClient::All,
+            AgentScope::Project,
+            Some(cwd.as_path()),
+            &home,
+            true,
+        )
+        .expect_err("an unsearchable project directory must not report success");
+        assert!(
+            error.to_string().contains("current directory"),
+            "unexpected error: {error}"
+        );
     }
 }

--- a/crates/vera-cli/src/commands/agent.rs
+++ b/crates/vera-cli/src/commands/agent.rs
@@ -266,7 +266,11 @@ pub fn run(
             json_output,
         ),
         AgentCommand::Remove => remove(client, scope, json_output),
-        AgentCommand::Sync => sync(json_output),
+        AgentCommand::Sync => sync(
+            client.unwrap_or(AgentClient::All),
+            scope.unwrap_or(AgentScope::All),
+            json_output,
+        ),
     }
 }
 
@@ -920,17 +924,68 @@ fn skill_path_for(
     Ok(base.join(VERA_SKILL_NAME))
 }
 
-fn sync(json_output: bool) -> anyhow::Result<()> {
-    sync_with_options(json_output, true, false)
+fn sync(client: AgentClient, scope: AgentScope, json_output: bool) -> anyhow::Result<()> {
+    sync_with_options(client, scope, json_output, true, false)
 }
 
 /// Automatic staleness sync: refresh skill installs only, without touching
 /// project markdown or writing over the user's command output.
 pub(crate) fn sync_skills_only() -> anyhow::Result<()> {
-    sync_with_options(false, false, true)
+    sync_with_options(AgentClient::All, AgentScope::All, false, false, true)
+}
+
+#[derive(Debug)]
+struct SyncOutcome {
+    updated: Vec<PathBuf>,
+    refreshed_snippets: Vec<PathBuf>,
+}
+
+fn sync_to_roots(
+    client: AgentClient,
+    scope: AgentScope,
+    project_cwd: Option<&Path>,
+    home: &Path,
+    refresh_project_snippets: bool,
+) -> anyhow::Result<SyncOutcome> {
+    let scan_scope = match (scope, project_cwd) {
+        (AgentScope::Project, None) => {
+            bail!("--scope project needs a readable current directory")
+        }
+        (AgentScope::All, None) => AgentScope::Global,
+        (scope, _) => scope,
+    };
+    let cwd = project_cwd.unwrap_or(home);
+    let statuses: Vec<ClientInstallStatus> =
+        collect_client_install_statuses(scan_scope, cwd, home)?
+            .into_iter()
+            .filter(|status| client == AgentClient::All || status.client == client)
+            .collect();
+
+    let mut updated = Vec::new();
+    for location in stale_locations_from_statuses(&statuses, cwd, home)? {
+        install_skill_to(&location.path)?;
+        updated.push(location.path);
+    }
+
+    // Refresh managed markdown snippets whenever a project directory is
+    // available, regardless of which skill installs were stale. They live in
+    // the project directory, so a global-scoped sync must leave them alone.
+    let refreshed_snippets = match project_cwd {
+        Some(cwd) if refresh_project_snippets && scan_scope != AgentScope::Global => {
+            refresh_existing_vera_snippets(&find_agent_configs(cwd))?
+        }
+        _ => Vec::new(),
+    };
+
+    Ok(SyncOutcome {
+        updated,
+        refreshed_snippets,
+    })
 }
 
 fn sync_with_options(
+    client: AgentClient,
+    scope: AgentScope,
     json_output: bool,
     refresh_project_snippets: bool,
     quiet: bool,
@@ -938,32 +993,16 @@ fn sync_with_options(
     let home = state::user_home_dir()?;
     let project_cwd = std::env::current_dir().ok();
     let current_version = env!("CARGO_PKG_VERSION");
-    let scan_scope = if project_cwd.is_some() {
-        AgentScope::All
-    } else {
-        AgentScope::Global
-    };
-    let cwd = project_cwd.clone().unwrap_or_else(|| home.clone());
-    let statuses = collect_client_install_statuses(scan_scope, &cwd, &home)?;
-    let stale_locations = stale_locations_from_statuses(&statuses, &cwd, &home)?;
-
-    let mut updated = Vec::new();
-    for location in &stale_locations {
-        install_skill_to(&location.path)?;
-        updated.push(location.path.clone());
-    }
-
-    let refreshed_snippets = if refresh_project_snippets {
-        // Refresh managed markdown snippets whenever a project directory is
-        // available, regardless of which skill installs were stale.
-        project_cwd
-            .as_deref()
-            .map(|cwd| refresh_existing_vera_snippets(&find_agent_configs(cwd)))
-            .transpose()?
-            .unwrap_or_default()
-    } else {
-        Vec::new()
-    };
+    let SyncOutcome {
+        updated,
+        refreshed_snippets,
+    } = sync_to_roots(
+        client,
+        scope,
+        project_cwd.as_deref(),
+        &home,
+        refresh_project_snippets,
+    )?;
 
     if quiet {
         return Ok(());
@@ -1664,5 +1703,89 @@ mod tests {
         assert_eq!(stale_locations.len(), 1);
         assert_eq!(stale_locations[0].client, AgentClient::Claude);
         assert_eq!(stale_locations[0].scope, AgentScope::Global);
+    }
+
+    const SCOPED_SYNC_FIXTURE: &[(AgentClient, AgentScope)] = &[
+        (AgentClient::Claude, AgentScope::Global),
+        (AgentClient::Claude, AgentScope::Project),
+        (AgentClient::Gemini, AgentScope::Global),
+        (AgentClient::Gemini, AgentScope::Project),
+    ];
+
+    #[test]
+    fn sync_to_roots_only_writes_the_requested_client_and_scope() {
+        let temp = tempdir().unwrap();
+        let home = temp.path().join("home");
+        let cwd = temp.path().join("project");
+        fs::create_dir_all(&home).unwrap();
+        fs::create_dir_all(&cwd).unwrap();
+
+        for &(client, scope) in SCOPED_SYNC_FIXTURE {
+            let path = skill_path_for(client, scope, &cwd, &home).unwrap();
+            fs::create_dir_all(&path).unwrap();
+            fs::write(path.join("SKILL.md"), "stale").unwrap();
+            fs::write(path.join(".version"), "0.0.0").unwrap();
+        }
+
+        let outcome = sync_to_roots(
+            AgentClient::Claude,
+            AgentScope::Project,
+            Some(cwd.as_path()),
+            &home,
+            true,
+        )
+        .unwrap();
+
+        let target = skill_path_for(AgentClient::Claude, AgentScope::Project, &cwd, &home).unwrap();
+        assert_eq!(outcome.updated, vec![target.clone()]);
+
+        for &(client, scope) in SCOPED_SYNC_FIXTURE {
+            let path = skill_path_for(client, scope, &cwd, &home).unwrap();
+            let version = fs::read_to_string(path.join(".version")).unwrap();
+            let expected = if path == target {
+                env!("CARGO_PKG_VERSION")
+            } else {
+                "0.0.0"
+            };
+            assert_eq!(
+                version,
+                expected,
+                "{client:?}/{scope:?} at {} was rewritten by a sync scoped to claude/project",
+                path.display()
+            );
+        }
+    }
+
+    #[test]
+    fn sync_to_roots_leaves_project_markdown_alone_when_scoped_global() {
+        let temp = tempdir().unwrap();
+        let home = temp.path().join("home");
+        let cwd = temp.path().join("project");
+        fs::create_dir_all(&home).unwrap();
+        fs::create_dir_all(&cwd).unwrap();
+
+        let stale = skill_path_for(AgentClient::Claude, AgentScope::Global, &cwd, &home).unwrap();
+        fs::create_dir_all(&stale).unwrap();
+        fs::write(stale.join("SKILL.md"), "stale").unwrap();
+        fs::write(stale.join(".version"), "0.0.0").unwrap();
+
+        let claude_md = cwd.join("CLAUDE.md");
+        let managed = format!(
+            "# Project\n\n## Code Search\n\n{VERA_SNIPPET_BEGIN_MARKER}\n\nOld generated content.\n{VERA_SNIPPET_END_MARKER}\n"
+        );
+        fs::write(&claude_md, &managed).unwrap();
+
+        let outcome = sync_to_roots(
+            AgentClient::All,
+            AgentScope::Global,
+            Some(cwd.as_path()),
+            &home,
+            true,
+        )
+        .unwrap();
+
+        assert_eq!(outcome.updated, vec![stale]);
+        assert!(outcome.refreshed_snippets.is_empty());
+        assert_eq!(fs::read_to_string(&claude_md).unwrap(), managed);
     }
 }


### PR DESCRIPTION
## The bug

`vera agent sync` declares `--client` and `--scope` (they live on the `Agent` variant in `cli.rs:151-156`, so clap attaches them to all four subcommands) and then ignores both. Three subcommands consume them, `Sync` did not:

```
AgentCommand::Install => install(client, scope, json_output),
AgentCommand::Status  => status(client, scope, ...),
AgentCommand::Sync    => sync(json_output),
```

`sync_with_options` recomputed its own scope from cwd (`All` when a cwd exists, otherwise `Global`) and always iterated `AgentClient::all_concrete()`. The flags were parsed, validated, and dropped, with no warning and exit 0.

## Why the blast radius matters

`vera agent sync` is not a read-only refresh. It writes skill files under `~/.claude`, `~/.codex`, `~/.cursor`, `~/.gemini` and the other 27 client roots, and it rewrites the managed snippet inside `CLAUDE.md` / `AGENTS.md` in the current directory.

So the two flags a user reaches for specifically to limit what gets overwritten were exactly the two that did nothing:

- `--client claude` refreshed every other client's install as well.
- `--scope global` still rewrote project markdown, which is the opposite of what it reads as.
- `--scope project` still rewrote global installs the user had scoped out.

## The change

`crates/vera-cli/src/commands/agent.rs`:

- Dispatch passes the flags through: `client.unwrap_or(AgentClient::All)`, `scope.unwrap_or(AgentScope::All)`. That default reproduces the old unflagged behaviour exactly, and it is the same default `status` already uses.
- The selection work moves into `sync_to_roots(client, scope, project_cwd, home, refresh_project_snippets)`, which takes its roots as arguments instead of reading the environment, so it is testable against a temp directory. `sync_with_options` keeps the env lookup and the printing.
- The client filter is the same predicate `status` uses: `client == AgentClient::All || status.client == client`. No new semantics were invented for sync.
- The project markdown refresh is now gated on the scope including project. Which config files get refreshed is unchanged and still not client-specific: `install` also refreshes every detected config through `refresh_existing_vera_snippets`, and only the *creation* target is chosen per client via `preferred_config_filename`. Matching install there rather than diverging.
- `--scope project` with an unreadable cwd now errors instead of silently syncing globals.
- `--scope all` with an unreadable cwd warns on stderr and syncs the global half. Erroring there would abort before any install runs, so a user with an unsearchable cwd would get no skill updates at all, and the global half is legitimate work they asked for. `--scope project` still bails, because there the unavailable scope is the whole request. The warning stays behind the `quiet` guard so the implicit staleness sync does not write over another command's output, and goes to stderr so `--json` stays parseable.

### The implicit path is unchanged

`update_check::check_skill_staleness` auto-syncs on a version mismatch, but it goes through `sync_skills_only()`, not `run(AgentCommand::Sync, ...)`. That helper now passes `AgentClient::All, AgentScope::All` explicitly, so it keeps its whole-world behaviour, and it still passes `refresh_project_snippets: false`, so it still does not touch project markdown.

### Relationship to #36

#36 is about sync overwriting hand-edited agent docs at all. This change is narrower: it only makes the existing flags mean what they say, and it leaves #36 open. A user who runs an unflagged `vera agent sync` still gets the same document rewriting they get today.

## Verification

Four regression tests in `crates/vera-cli/src/commands/agent.rs`, all against `tempfile::tempdir()`:

- `sync_to_roots_only_writes_the_requested_client_and_scope` seeds stale installs for claude/global, claude/project, gemini/global and gemini/project, runs a sync scoped to claude/project, and asserts the other three still carry `0.0.0` on disk.
- `sync_to_roots_leaves_project_markdown_alone_when_scoped_global` seeds a stale global install plus a `CLAUDE.md` holding a managed `vera:begin`/`vera:end` region, runs a global-scoped sync, and asserts the file is byte-identical afterwards.
- `sync_to_roots_rejects_a_project_scope_it_cannot_search` runs `--scope project` against a cwd at mode 000 and asserts it errors.
- `sync_to_roots_flags_a_project_scope_all_could_not_search` runs `--scope all` against the same cwd twice, once searchable and once not, and asserts the flag tracks the degrade in both directions while the global half still runs.

The last two are unix-gated, carry a `Drop` guard that restores mode 755 on unwind so a failure cannot leave `TempDir` unable to clean up, and return early when `stat` still succeeds at mode 000 (root, or a filesystem that ignores mode bits).

The first two were confirmed to catch the bug by reinjecting it (dropping the client filter and recomputing the scope from cwd, as on master):

```
running 2 tests
test commands::agent::tests::sync_to_roots_leaves_project_markdown_alone_when_scoped_global ... FAILED
test commands::agent::tests::sync_to_roots_only_writes_the_requested_client_and_scope ... FAILED

---- sync_to_roots_leaves_project_markdown_alone_when_scoped_global ----
assertion failed: outcome.refreshed_snippets.is_empty()

---- sync_to_roots_only_writes_the_requested_client_and_scope ----
assertion `left == right` failed
  left: [".../project/.agents/skills/vera", ".../project/.agents/skills/vera",
         ".../home/.claude/skills/vera", ".../project/.claude/skills/vera",
         ... 12 entries ...
         ".../home/.gemini/skills/vera", ...]
 right: [".../project/.claude/skills/vera"]
```

That left-hand list is the bug: a sync asked for claude/project wrote twelve locations, including both global installs.

The third was confirmed by dropping the `project_root_is_searchable` filter, which is master's behaviour on Linux:

```
---- sync_to_roots_rejects_a_project_scope_it_cannot_search ----
an unsearchable project directory must not report success:
SyncOutcome { updated: [], refreshed_snippets: [], project_scope_skipped: false }
```

The fourth was confirmed in both directions, by pinning `project_scope_skipped` to each constant:

```
---- pinned to false (the pre-existing silence) ----
--scope all silently degraded to global for an unsearchable project directory

---- pinned to true ----
a searchable project directory must not report a skipped scope
```

### The `--scope all` silence predates the searchability filter

Worth recording, because it decides whether the filter introduced this or relocated it. Measured on both sides of that commit with one fixture (stale installs at claude/global, claude/project, gemini/global, gemini/project, a managed `CLAUDE.md`, cwd at mode 000), `sync_to_roots(All, All, Some(cwd), home, true)` returns byte-identical results:

```
scope=all -> Ok
  updated            = [".../home/.claude/skills/vera", ".../home/.gemini/skills/vera"]
  refreshed_snippets = []
```

Before the filter, the two project probes each returned `false` because `Path::exists()` cannot stat through an unsearchable directory, and `find_agent_configs` returned nothing for the same reason on `is_file()`. After it, the same outcome is reached by taking the `(AgentScope::All, None)` arm. Same result, different route: the silence moved, it did not start there. The warning is what actually closes it.

Suite:

- `cargo fmt --check` clean
- `cargo test -p vera-cli --bin vera` 101 passed, 0 failed
- `cargo test -p vera-core --lib` 793 passed, 0 failed
- `cargo clippy -p vera-core --lib` 5 warnings, all pre-existing and unrelated
- `cargo clippy -p vera-cli --bin vera` no new warnings

No control run against the released binary: reproducing this one by execution means running `vera agent sync`, which overwrites real skill installs and real project markdown on the machine doing the reproducing. The reinjection above stands in for it.

Fixes #98

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Honors `--client` and `--scope` in `vera agent sync` to prevent unintended writes across other clients and project markdown. Previously, sync ignored both flags and recomputed scope from cwd; now flags control which clients and scopes are synced, with unflagged behavior unchanged.

- Thread flags through dispatch; default to `All`/`All` so bare `sync` behaves as before.
- Filter installs with the same predicate as `status`; only the selected client and scope are written.
- Gate project markdown refresh on project scope; `--scope global` never touches project files.
- Reject `--scope project` when the current directory is unsearchable; `--scope all` without a searchable cwd falls back to global.
- Extract `sync_to_roots` for explicit roots and add tests for scoped sync, global-scoped markdown no-op, and unreadable project scope.
- Keep implicit auto-sync unchanged: `sync_skills_only` uses `All`/`All` and never updates project markdown.

<sup>Written for commit aebdd7515b1ed1331d2a407cd5c9473d206e7dc9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/VeraTools/Vera/pull/110?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added client and scope selection to `vera agent sync`.
  * Added scoped synchronization for applicable installations.
  * Project-scoped synchronization now checks that the project directory is accessible.
  * Project-specific snippets refresh only when relevant to the selected scope.

* **Bug Fixes**
  * Improved handling of outdated installations during synchronization.
  * Prevented global synchronization from modifying project-specific Markdown content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

