### PR TITLE
fix(indexing): do not follow symlinks out of the repository

### DIFF
--- a/crates/vera-core/src/discovery/mod.rs
+++ b/crates/vera-core/src/discovery/mod.rs
@@ -385,21 +385,27 @@ pub fn explain_path(root: &Path, path: &Path, config: &IndexingConfig) -> Result
     // enumerated; reject the whole path before reading metadata, ignore rules
     // or content through the link. The scan runs on the path as written, since
     // collapsing `..` first erases the very links the kernel would traverse.
-    if let Some(link) = symlinked_ancestor(&root, root_relative)? {
-        return Ok(path_excluded(
-            display_input,
-            absolute_display,
-            relative_path,
-            IgnoreMatchExplanation {
-                reason: PathReason::NonRegularFile,
-                source: Some("discovery".to_string()),
-                pattern: None,
-                details: Some(format!(
-                    "the ancestor {} is a symbolic link, and symbolic links are not followed during indexing",
-                    link.display()
-                )),
-            },
-        ));
+    match scan_ancestors(&root, root_relative)? {
+        AncestorScan::Symlink(link) => {
+            return Ok(path_excluded(
+                display_input,
+                absolute_display,
+                relative_path,
+                IgnoreMatchExplanation {
+                    reason: PathReason::NonRegularFile,
+                    source: Some("discovery".to_string()),
+                    pattern: None,
+                    details: Some(format!(
+                        "the ancestor {} is a symbolic link, and symbolic links are not followed during indexing",
+                        link.display()
+                    )),
+                },
+            ));
+        }
+        AncestorScan::MissingAncestor => {
+            return Ok(path_missing(display_input, absolute_display, relative_path));
+        }
+        AncestorScan::Clear => {}
     }
 
     // Inspect the link itself, not its target, so this diagnostic reports the
@@ -407,16 +413,7 @@ pub fn explain_path(root: &Path, path: &Path, config: &IndexingConfig) -> Result
     let metadata = match std::fs::symlink_metadata(&candidate) {
         Ok(metadata) => metadata,
         Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
-            return Ok(PathExplanation {
-                input_path: display_input,
-                absolute_path: absolute_display,
-                relative_path: Some(relative_path),
-                decision: PathDecision::Missing,
-                reason: PathReason::Missing,
-                source: None,
-                pattern: None,
-                details: Some("path does not exist".to_string()),
-            });
+            return Ok(path_missing(display_input, absolute_display, relative_path));
         }
         Err(err) => {
             return Err(err)
@@ -609,19 +606,30 @@ pub fn explain_path(root: &Path, path: &Path, config: &IndexingConfig) -> Result
     })
 }
 
-/// Return the first repository-relative ancestor of `relative` that is a
-/// symbolic link, ignoring the final component.
+/// What a walk of `relative`'s ancestors found, ignoring the final component.
+enum AncestorScan {
+    /// Every ancestor exists and none of them is a symbolic link.
+    Clear,
+    /// The first ancestor that is a symbolic link, repository-relative.
+    Symlink(PathBuf),
+    /// An ancestor does not exist, so the path cannot resolve at all.
+    MissingAncestor,
+}
+
+/// Walk the ancestors of `relative` under `root`, stopping at the first that is
+/// a symbolic link or does not exist.
 ///
 /// `relative` must be the path as it was written, before `..` segments are
 /// collapsed. The kernel resolves left to right, so `link/../file` traverses
 /// `link`, while collapsing the pair lexically first erases the link and leaves
-/// no ancestor to inspect. The scan therefore keeps its own lexical prefix and
+/// no ancestor to inspect. The walk therefore keeps its own lexical prefix and
 /// treats a `..` as one more component following whatever precedes it.
 ///
-/// A missing ancestor cannot hide a link behind it, because every path below it
-/// is missing too, so the scan continues and the caller still reports the path
-/// as missing rather than as a link.
-fn symlinked_ancestor(root: &Path, relative: &Path) -> Result<Option<PathBuf>> {
+/// A missing ancestor is reported separately rather than skipped, because the
+/// kernel cannot resolve through it either: `absent/../link/file` is missing, not
+/// a link, and normalizing `absent/..` away would otherwise leave the caller
+/// inspecting a path the operating system would never reach.
+fn scan_ancestors(root: &Path, relative: &Path) -> Result<AncestorScan> {
     let mut prefix = PathBuf::new();
     let mut components = relative.components().peekable();
     while let Some(component) = components.next() {
@@ -629,21 +637,23 @@ fn symlinked_ancestor(root: &Path, relative: &Path) -> Result<Option<PathBuf>> {
             Component::CurDir => continue,
             Component::ParentDir => {
                 if !prefix.pop() {
-                    return Ok(None);
+                    return Ok(AncestorScan::Clear);
                 }
                 continue;
             }
             Component::Normal(part) => prefix.push(part),
-            Component::RootDir | Component::Prefix(_) => return Ok(None),
+            Component::RootDir | Component::Prefix(_) => return Ok(AncestorScan::Clear),
         }
         if components.peek().is_none() {
             break;
         }
         let ancestor = root.join(&prefix);
         match std::fs::symlink_metadata(&ancestor) {
-            Ok(metadata) if metadata.is_symlink() => return Ok(Some(prefix)),
+            Ok(metadata) if metadata.is_symlink() => return Ok(AncestorScan::Symlink(prefix)),
             Ok(_) => {}
-            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+                return Ok(AncestorScan::MissingAncestor);
+            }
             Err(err) => {
                 return Err(err).with_context(|| {
                     format!("failed to read metadata for {}", ancestor.display())
@@ -651,7 +661,7 @@ fn symlinked_ancestor(root: &Path, relative: &Path) -> Result<Option<PathBuf>> {
             }
         }
     }
-    Ok(None)
+    Ok(AncestorScan::Clear)
 }
 
 /// Resolve `path` against `root`, returning both the root-relative path as it
@@ -931,6 +941,23 @@ fn path_excluded(
         source: explanation.source,
         pattern: explanation.pattern,
         details: explanation.details,
+    }
+}
+
+fn path_missing(
+    input_path: String,
+    absolute_path: String,
+    relative_path: String,
+) -> PathExplanation {
+    PathExplanation {
+        input_path,
+        absolute_path,
+        relative_path: Some(relative_path),
+        decision: PathDecision::Missing,
+        reason: PathReason::Missing,
+        source: None,
+        pattern: None,
+        details: Some("path does not exist".to_string()),
     }
 }
 
@@ -1748,7 +1775,7 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
-    fn explain_path_scans_past_a_missing_segment_for_a_symlinked_ancestor() {
+    fn explain_path_reports_a_missing_ancestor_as_missing() {
         let outside = TempDir::new().unwrap();
         let secrets = outside.path().join("secrets");
         fs::create_dir_all(secrets.join("nested")).unwrap();
@@ -1757,17 +1784,17 @@ mod tests {
         let dir = TempDir::new().unwrap();
         std::os::unix::fs::symlink(&secrets, dir.path().join("link")).unwrap();
 
-        // A missing segment cancels itself out lexically, so the scan has to
-        // keep going: stopping at `absent` would hand the checks below a
-        // candidate that reaches through `link` and report it as indexed.
+        // The kernel cannot resolve through `absent`, so the path is missing.
+        // Collapsing `absent/..` away instead would leave the checks below
+        // inspecting a candidate that reaches through `link`.
         let explanation = explain_path(
             dir.path(),
             Path::new("absent/../link/nested/secret.rs"),
             &default_config(),
         )
         .unwrap();
-        assert_eq!(explanation.decision, PathDecision::Excluded);
-        assert_eq!(explanation.reason, PathReason::NonRegularFile);
+        assert_eq!(explanation.decision, PathDecision::Missing);
+        assert_eq!(explanation.reason, PathReason::Missing);
     }
 
     #[test]

--- a/crates/vera-core/src/discovery/mod.rs
+++ b/crates/vera-core/src/discovery/mod.rs
@@ -383,9 +383,10 @@ pub fn explain_path(root: &Path, path: &Path, config: &IndexingConfig) -> Result
     // intermediate symlinked directory would still be traversed by every check
     // below. The walker never descends through one, so nothing beneath it is
     // enumerated; reject the whole path before reading metadata, ignore rules
-    // or content through the link. The scan runs on the path as written, since
-    // collapsing `..` first erases the very links the kernel would traverse.
-    match scan_ancestors(&root, root_relative)? {
+    // or content through the link. Which form of the path the scan walks is
+    // platform-dependent, since only POSIX resolves a `..` against the directory
+    // it has already reached.
+    match scan_ancestors(&root, ancestor_scan_path(root_relative, &relative))? {
         AncestorScan::Symlink(link) => {
             return Ok(path_excluded(
                 display_input,
@@ -617,14 +618,34 @@ enum AncestorScan {
     UnresolvableAncestor,
 }
 
-/// Walk the ancestors of `relative` under `root`, stopping at the first that is
-/// a symbolic link or that the kernel could not resolve through.
+/// Which form of the path the ancestor scan should walk: the one whose
+/// ancestors the operating system would actually visit.
 ///
-/// `relative` must be the path as it was written, before `..` segments are
-/// collapsed. The kernel resolves left to right, so `link/../file` traverses
-/// `link`, while collapsing the pair lexically first erases the link and leaves
-/// no ancestor to inspect. The walk therefore keeps its own lexical prefix and
-/// treats a `..` as one more component following whatever precedes it.
+/// POSIX resolves a path left to right and applies each `..` to the directory it
+/// has already reached, so the ancestors are the ones written down:
+/// `link/../file` traverses `link`, and `regular/../file` stops at `regular`
+/// with `ENOTDIR`. Win32 canonicalizes `..` out of an ordinary path before the
+/// file system sees it, so `link\..\file` opens `file` and `regular\..\file`
+/// succeeds; scanning the written form there would report on ancestors Windows
+/// never visits.
+///
+/// Only the placement of `..` differs, which is why this selects an input rather
+/// than gating the scan. The scan's other two outcomes hold on both platforms:
+/// Windows will not open `regular\nested\file` either, and the walker declines a
+/// reparse point exactly as it declines a symbolic link. The Windows branch is
+/// reasoned from Win32's documented path canonicalization and is not exercised
+/// by the tests below, which run only on Unix.
+fn ancestor_scan_path<'a>(as_written: &'a Path, collapsed: &'a Path) -> &'a Path {
+    if cfg!(unix) { as_written } else { collapsed }
+}
+
+/// Walk the ancestors of `relative` under `root`, stopping at the first that is
+/// a symbolic link or that the operating system could not resolve through.
+///
+/// `relative` comes from `ancestor_scan_path`, which decides whether this
+/// platform has already collapsed its `..` segments. The walk keeps its own
+/// lexical prefix so that a `..` still present counts as one more component
+/// following whatever precedes it.
 ///
 /// An unresolvable ancestor is reported separately rather than skipped, because
 /// the kernel cannot resolve through it either: `absent/../link/file` is missing,
@@ -1804,7 +1825,8 @@ mod tests {
     }
 
     // Windows collapses `..` lexically before the filesystem sees the path, so
-    // the `ENOTDIR` this pins is POSIX resolution order.
+    // the `ENOTDIR` this pins is POSIX resolution order, which is what
+    // `ancestor_scan_path` selects for.
     #[cfg(unix)]
     #[test]
     fn explain_path_reports_a_non_directory_ancestor_as_missing() {

--- a/crates/vera-core/src/discovery/mod.rs
+++ b/crates/vera-core/src/discovery/mod.rs
@@ -250,9 +250,12 @@ pub fn discover_files_with_cancellation(
             }
         };
 
-        // Skip directories — we only want files.
+        // Keep only regular files. `file_type()` reports the entry's own type,
+        // so a symlink is skipped rather than indexed through its target: the
+        // walker does not follow links, and resolving one here would pull
+        // content from outside the repository under an in-repository path.
         let path = entry.path();
-        if !path.is_file() {
+        if !entry.file_type().is_some_and(|ft| ft.is_file()) {
             continue;
         }
 
@@ -377,20 +380,29 @@ pub fn explain_path(root: &Path, path: &Path, config: &IndexingConfig) -> Result
     let relative_path = relative.to_string_lossy().to_string();
     let relative = Path::new(&relative_path);
 
-    if !candidate.exists() {
-        return Ok(PathExplanation {
-            input_path: display_input,
-            absolute_path: absolute_display,
-            relative_path: Some(relative_path),
-            decision: PathDecision::Missing,
-            reason: PathReason::Missing,
-            source: None,
-            pattern: None,
-            details: Some("path does not exist".to_string()),
-        });
-    }
+    // Inspect the link itself, not its target, so this diagnostic reports the
+    // same decision the walker makes.
+    let metadata = match std::fs::symlink_metadata(&candidate) {
+        Ok(metadata) => metadata,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+            return Ok(PathExplanation {
+                input_path: display_input,
+                absolute_path: absolute_display,
+                relative_path: Some(relative_path),
+                decision: PathDecision::Missing,
+                reason: PathReason::Missing,
+                source: None,
+                pattern: None,
+                details: Some("path does not exist".to_string()),
+            });
+        }
+        Err(err) => {
+            return Err(err)
+                .with_context(|| format!("failed to read metadata for {}", candidate.display()));
+        }
+    };
 
-    if candidate.is_dir() {
+    if metadata.is_dir() {
         return Ok(PathExplanation {
             input_path: display_input,
             absolute_path: absolute_display,
@@ -403,7 +415,7 @@ pub fn explain_path(root: &Path, path: &Path, config: &IndexingConfig) -> Result
         });
     }
 
-    if !candidate.is_file() {
+    if !metadata.is_file() {
         return Ok(path_excluded(
             display_input,
             absolute_display,
@@ -412,7 +424,11 @@ pub fn explain_path(root: &Path, path: &Path, config: &IndexingConfig) -> Result
                 reason: PathReason::NonRegularFile,
                 source: Some("discovery".to_string()),
                 pattern: None,
-                details: Some("only regular files are indexed".to_string()),
+                details: Some(if metadata.is_symlink() {
+                    "symbolic links are not followed during indexing".to_string()
+                } else {
+                    "only regular files are indexed".to_string()
+                }),
             },
         ));
     }
@@ -483,8 +499,6 @@ pub fn explain_path(root: &Path, path: &Path, config: &IndexingConfig) -> Result
         ));
     }
 
-    let metadata = std::fs::metadata(&candidate)
-        .with_context(|| format!("failed to read metadata for {}", candidate.display()))?;
     if metadata.len() > config.max_file_size_bytes {
         return Ok(path_excluded(
             display_input,
@@ -1521,6 +1535,65 @@ mod tests {
         assert_eq!(explanation.reason, PathReason::OutsideRoot);
 
         fs::remove_file(outside).unwrap();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn symlink_to_file_outside_root_is_not_discovered() {
+        let outside = TempDir::new().unwrap();
+        let canary = outside.path().join("canary.rs");
+        fs::write(&canary, "fn canary_outside_root() {}\n").unwrap();
+
+        let dir = TempDir::new().unwrap();
+        fs::write(dir.path().join("main.rs"), "fn main() {}").unwrap();
+        std::os::unix::fs::symlink(&canary, dir.path().join("linked.rs")).unwrap();
+
+        let result = discover_files(dir.path(), &default_config()).unwrap();
+        let names: Vec<&str> = result
+            .files
+            .iter()
+            .map(|f| f.relative_path.as_str())
+            .collect();
+        assert_eq!(
+            names,
+            vec!["main.rs"],
+            "a symlink to a file outside the root must not be discovered"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn symlink_to_file_inside_root_is_not_indexed_twice() {
+        let dir = TempDir::new().unwrap();
+        let real = dir.path().join("main.rs");
+        fs::write(&real, "fn main() {}").unwrap();
+        std::os::unix::fs::symlink(&real, dir.path().join("alias.rs")).unwrap();
+
+        let result = discover_files(dir.path(), &default_config()).unwrap();
+        let names: Vec<&str> = result
+            .files
+            .iter()
+            .map(|f| f.relative_path.as_str())
+            .collect();
+        assert_eq!(
+            names,
+            vec!["main.rs"],
+            "a symlink to an in-repository file must not be indexed a second time"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn explain_path_rejects_symlinks_to_regular_files() {
+        let dir = TempDir::new().unwrap();
+        let real = dir.path().join("main.rs");
+        fs::write(&real, "fn main() {}").unwrap();
+        std::os::unix::fs::symlink(&real, dir.path().join("alias.rs")).unwrap();
+
+        let explanation =
+            explain_path(dir.path(), Path::new("alias.rs"), &default_config()).unwrap();
+        assert_eq!(explanation.decision, PathDecision::Excluded);
+        assert_eq!(explanation.reason, PathReason::NonRegularFile);
     }
 
     #[cfg(unix)]

--- a/crates/vera-core/src/discovery/mod.rs
+++ b/crates/vera-core/src/discovery/mod.rs
@@ -356,7 +356,7 @@ pub fn explain_path(root: &Path, path: &Path, config: &IndexingConfig) -> Result
         .canonicalize()
         .with_context(|| format!("failed to resolve path: {}", root.display()))?;
     let display_input = path.display().to_string();
-    let Some(relative) = normalized_relative_path(&root, path) else {
+    let Some((root_relative, relative)) = normalized_relative_path(&root, path) else {
         return Ok(PathExplanation {
             input_path: display_input,
             absolute_path: if path.is_absolute() {
@@ -378,14 +378,14 @@ pub fn explain_path(root: &Path, path: &Path, config: &IndexingConfig) -> Result
     let candidate = root.join(&relative);
     let absolute_display = candidate.display().to_string();
     let relative_path = relative.to_string_lossy().to_string();
-    let relative = Path::new(&relative_path);
 
     // `symlink_metadata` refuses to follow only the final component, so an
     // intermediate symlinked directory would still be traversed by every check
     // below. The walker never descends through one, so nothing beneath it is
     // enumerated; reject the whole path before reading metadata, ignore rules
-    // or content through the link.
-    if let Some(link) = symlinked_ancestor(&root, relative)? {
+    // or content through the link. The scan runs on the path as written, since
+    // collapsing `..` first erases the very links the kernel would traverse.
+    if let Some(link) = symlinked_ancestor(&root, root_relative)? {
         return Ok(path_excluded(
             display_input,
             absolute_display,
@@ -455,7 +455,7 @@ pub fn explain_path(root: &Path, path: &Path, config: &IndexingConfig) -> Result
         ));
     }
 
-    if let Some(explanation) = explain_override_match(&root, relative, config)? {
+    if let Some(explanation) = explain_override_match(&root, &relative, config)? {
         return Ok(path_excluded(
             display_input,
             absolute_display,
@@ -469,10 +469,10 @@ pub fn explain_path(root: &Path, path: &Path, config: &IndexingConfig) -> Result
         let strategy = determine_ignore_strategy(&root, config)?;
 
         for decision in [
-            explain_custom_ignore_match(&root, relative, strategy.use_veraignore)?,
-            explain_named_ignore_match(&root, relative, ".ignore", PathReason::DotIgnore)?,
+            explain_custom_ignore_match(&root, &relative, strategy.use_veraignore)?,
+            explain_named_ignore_match(&root, &relative, ".ignore", PathReason::DotIgnore)?,
             if strategy.use_gitignore {
-                explain_named_ignore_match(&root, relative, ".gitignore", PathReason::Gitignore)?
+                explain_named_ignore_match(&root, &relative, ".gitignore", PathReason::Gitignore)?
             } else {
                 IgnoreDecision::None
             },
@@ -612,21 +612,38 @@ pub fn explain_path(root: &Path, path: &Path, config: &IndexingConfig) -> Result
 /// Return the first repository-relative ancestor of `relative` that is a
 /// symbolic link, ignoring the final component.
 ///
-/// A missing ancestor yields `None` so the caller still reports the path as
-/// missing rather than as a link.
+/// `relative` must be the path as it was written, before `..` segments are
+/// collapsed. The kernel resolves left to right, so `link/../file` traverses
+/// `link`, while collapsing the pair lexically first erases the link and leaves
+/// no ancestor to inspect. The scan therefore keeps its own lexical prefix and
+/// treats a `..` as one more component following whatever precedes it.
+///
+/// A missing ancestor cannot hide a link behind it, because every path below it
+/// is missing too, so the scan continues and the caller still reports the path
+/// as missing rather than as a link.
 fn symlinked_ancestor(root: &Path, relative: &Path) -> Result<Option<PathBuf>> {
     let mut prefix = PathBuf::new();
     let mut components = relative.components().peekable();
     while let Some(component) = components.next() {
+        match component {
+            Component::CurDir => continue,
+            Component::ParentDir => {
+                if !prefix.pop() {
+                    return Ok(None);
+                }
+                continue;
+            }
+            Component::Normal(part) => prefix.push(part),
+            Component::RootDir | Component::Prefix(_) => return Ok(None),
+        }
         if components.peek().is_none() {
             break;
         }
-        prefix.push(component);
         let ancestor = root.join(&prefix);
         match std::fs::symlink_metadata(&ancestor) {
             Ok(metadata) if metadata.is_symlink() => return Ok(Some(prefix)),
             Ok(_) => {}
-            Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
             Err(err) => {
                 return Err(err).with_context(|| {
                     format!("failed to read metadata for {}", ancestor.display())
@@ -637,13 +654,19 @@ fn symlinked_ancestor(root: &Path, relative: &Path) -> Result<Option<PathBuf>> {
     Ok(None)
 }
 
-fn normalized_relative_path(root: &Path, path: &Path) -> Option<PathBuf> {
+/// Resolve `path` against `root`, returning both the root-relative path as it
+/// was written and its lexically normalized form.
+///
+/// Callers that inspect the filesystem need the former, because normalization
+/// discards the `..` segments the kernel would resolve through; callers that
+/// match ignore rules or report the path need the latter.
+fn normalized_relative_path<'a>(root: &Path, path: &'a Path) -> Option<(&'a Path, PathBuf)> {
     let relative = if path.is_absolute() {
         path.strip_prefix(root).ok()?
     } else {
         path
     };
-    normalize_relative_path(relative)
+    Some((relative, normalize_relative_path(relative)?))
 }
 
 fn normalize_relative_path(path: &Path) -> Option<PathBuf> {
@@ -1683,6 +1706,67 @@ mod tests {
             PathDecision::Excluded,
             "explain_path must agree with discovery, which never enumerated this path"
         );
+        assert_eq!(explanation.reason, PathReason::NonRegularFile);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn explain_path_rejects_a_symlinked_ancestor_erased_by_a_parent_segment() {
+        let outside = TempDir::new().unwrap();
+        fs::create_dir(outside.path().join("vault")).unwrap();
+        fs::write(
+            outside.path().join("secret.rs"),
+            "fn outside_the_repository() {}\n",
+        )
+        .unwrap();
+
+        let dir = TempDir::new().unwrap();
+        fs::write(
+            dir.path().join("secret.rs"),
+            "fn inside_the_repository() {}\n",
+        )
+        .unwrap();
+        std::os::unix::fs::symlink(outside.path().join("vault"), dir.path().join("link")).unwrap();
+
+        // The kernel resolves left to right, so `link/../secret.rs` traverses
+        // `link` and names `<outside>/secret.rs`. Collapsing `..` lexically
+        // first rewrites it to the unrelated in-repository `secret.rs` and
+        // leaves no ancestor for the symlink check to see.
+        let explanation = explain_path(
+            dir.path(),
+            Path::new("link/../secret.rs"),
+            &default_config(),
+        )
+        .unwrap();
+        assert_eq!(
+            explanation.decision,
+            PathDecision::Excluded,
+            "a parent segment must not erase the symlinked ancestor it traverses"
+        );
+        assert_eq!(explanation.reason, PathReason::NonRegularFile);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn explain_path_scans_past_a_missing_segment_for_a_symlinked_ancestor() {
+        let outside = TempDir::new().unwrap();
+        let secrets = outside.path().join("secrets");
+        fs::create_dir_all(secrets.join("nested")).unwrap();
+        fs::write(secrets.join("nested/secret.rs"), "fn outside_secret() {}\n").unwrap();
+
+        let dir = TempDir::new().unwrap();
+        std::os::unix::fs::symlink(&secrets, dir.path().join("link")).unwrap();
+
+        // A missing segment cancels itself out lexically, so the scan has to
+        // keep going: stopping at `absent` would hand the checks below a
+        // candidate that reaches through `link` and report it as indexed.
+        let explanation = explain_path(
+            dir.path(),
+            Path::new("absent/../link/nested/secret.rs"),
+            &default_config(),
+        )
+        .unwrap();
+        assert_eq!(explanation.decision, PathDecision::Excluded);
         assert_eq!(explanation.reason, PathReason::NonRegularFile);
     }
 

--- a/crates/vera-core/src/discovery/mod.rs
+++ b/crates/vera-core/src/discovery/mod.rs
@@ -402,7 +402,7 @@ pub fn explain_path(root: &Path, path: &Path, config: &IndexingConfig) -> Result
                 },
             ));
         }
-        AncestorScan::MissingAncestor => {
+        AncestorScan::UnresolvableAncestor => {
             return Ok(path_missing(display_input, absolute_display, relative_path));
         }
         AncestorScan::Clear => {}
@@ -612,12 +612,13 @@ enum AncestorScan {
     Clear,
     /// The first ancestor that is a symbolic link, repository-relative.
     Symlink(PathBuf),
-    /// An ancestor does not exist, so the path cannot resolve at all.
-    MissingAncestor,
+    /// An ancestor is absent or is not a directory, so the path cannot resolve
+    /// at all.
+    UnresolvableAncestor,
 }
 
 /// Walk the ancestors of `relative` under `root`, stopping at the first that is
-/// a symbolic link or does not exist.
+/// a symbolic link or that the kernel could not resolve through.
 ///
 /// `relative` must be the path as it was written, before `..` segments are
 /// collapsed. The kernel resolves left to right, so `link/../file` traverses
@@ -625,10 +626,12 @@ enum AncestorScan {
 /// no ancestor to inspect. The walk therefore keeps its own lexical prefix and
 /// treats a `..` as one more component following whatever precedes it.
 ///
-/// A missing ancestor is reported separately rather than skipped, because the
-/// kernel cannot resolve through it either: `absent/../link/file` is missing, not
-/// a link, and normalizing `absent/..` away would otherwise leave the caller
-/// inspecting a path the operating system would never reach.
+/// An unresolvable ancestor is reported separately rather than skipped, because
+/// the kernel cannot resolve through it either: `absent/../link/file` is missing,
+/// not a link, and normalizing `absent/..` away would otherwise leave the caller
+/// inspecting a path the operating system would never reach. An ancestor that
+/// exists but is not a directory is the same outcome by a different errno, since
+/// `regular/../file` stops at `regular` with `ENOTDIR`.
 fn scan_ancestors(root: &Path, relative: &Path) -> Result<AncestorScan> {
     let mut prefix = PathBuf::new();
     let mut components = relative.components().peekable();
@@ -650,9 +653,12 @@ fn scan_ancestors(root: &Path, relative: &Path) -> Result<AncestorScan> {
         let ancestor = root.join(&prefix);
         match std::fs::symlink_metadata(&ancestor) {
             Ok(metadata) if metadata.is_symlink() => return Ok(AncestorScan::Symlink(prefix)),
+            Ok(metadata) if !metadata.is_dir() => {
+                return Ok(AncestorScan::UnresolvableAncestor);
+            }
             Ok(_) => {}
             Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
-                return Ok(AncestorScan::MissingAncestor);
+                return Ok(AncestorScan::UnresolvableAncestor);
             }
             Err(err) => {
                 return Err(err).with_context(|| {
@@ -1790,6 +1796,35 @@ mod tests {
         let explanation = explain_path(
             dir.path(),
             Path::new("absent/../link/nested/secret.rs"),
+            &default_config(),
+        )
+        .unwrap();
+        assert_eq!(explanation.decision, PathDecision::Missing);
+        assert_eq!(explanation.reason, PathReason::Missing);
+    }
+
+    // Windows collapses `..` lexically before the filesystem sees the path, so
+    // the `ENOTDIR` this pins is POSIX resolution order.
+    #[cfg(unix)]
+    #[test]
+    fn explain_path_reports_a_non_directory_ancestor_as_missing() {
+        let dir = TempDir::new().unwrap();
+        fs::write(dir.path().join("regular"), "not a directory\n").unwrap();
+        fs::write(dir.path().join("target.rs"), "fn target() {}\n").unwrap();
+
+        // The kernel stops at `regular` with `ENOTDIR` and never reaches
+        // `target.rs`, so the path as written cannot resolve. Collapsing
+        // `regular/..` away instead would report on the unrelated `target.rs`.
+        assert_eq!(
+            std::fs::symlink_metadata(dir.path().join("regular/../target.rs"))
+                .unwrap_err()
+                .kind(),
+            std::io::ErrorKind::NotADirectory
+        );
+
+        let explanation = explain_path(
+            dir.path(),
+            Path::new("regular/../target.rs"),
             &default_config(),
         )
         .unwrap();

--- a/crates/vera-core/src/discovery/mod.rs
+++ b/crates/vera-core/src/discovery/mod.rs
@@ -380,6 +380,28 @@ pub fn explain_path(root: &Path, path: &Path, config: &IndexingConfig) -> Result
     let relative_path = relative.to_string_lossy().to_string();
     let relative = Path::new(&relative_path);
 
+    // `symlink_metadata` refuses to follow only the final component, so an
+    // intermediate symlinked directory would still be traversed by every check
+    // below. The walker never descends through one, so nothing beneath it is
+    // enumerated; reject the whole path before reading metadata, ignore rules
+    // or content through the link.
+    if let Some(link) = symlinked_ancestor(&root, relative)? {
+        return Ok(path_excluded(
+            display_input,
+            absolute_display,
+            relative_path,
+            IgnoreMatchExplanation {
+                reason: PathReason::NonRegularFile,
+                source: Some("discovery".to_string()),
+                pattern: None,
+                details: Some(format!(
+                    "the ancestor {} is a symbolic link, and symbolic links are not followed during indexing",
+                    link.display()
+                )),
+            },
+        ));
+    }
+
     // Inspect the link itself, not its target, so this diagnostic reports the
     // same decision the walker makes.
     let metadata = match std::fs::symlink_metadata(&candidate) {
@@ -585,6 +607,34 @@ pub fn explain_path(root: &Path, path: &Path, config: &IndexingConfig) -> Result
         pattern,
         details: details.or_else(|| Some("path would be indexed".to_string())),
     })
+}
+
+/// Return the first repository-relative ancestor of `relative` that is a
+/// symbolic link, ignoring the final component.
+///
+/// A missing ancestor yields `None` so the caller still reports the path as
+/// missing rather than as a link.
+fn symlinked_ancestor(root: &Path, relative: &Path) -> Result<Option<PathBuf>> {
+    let mut prefix = PathBuf::new();
+    let mut components = relative.components().peekable();
+    while let Some(component) = components.next() {
+        if components.peek().is_none() {
+            break;
+        }
+        prefix.push(component);
+        let ancestor = root.join(&prefix);
+        match std::fs::symlink_metadata(&ancestor) {
+            Ok(metadata) if metadata.is_symlink() => return Ok(Some(prefix)),
+            Ok(_) => {}
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+            Err(err) => {
+                return Err(err).with_context(|| {
+                    format!("failed to read metadata for {}", ancestor.display())
+                });
+            }
+        }
+    }
+    Ok(None)
 }
 
 fn normalized_relative_path(root: &Path, path: &Path) -> Option<PathBuf> {
@@ -1594,6 +1644,57 @@ mod tests {
             explain_path(dir.path(), Path::new("alias.rs"), &default_config()).unwrap();
         assert_eq!(explanation.decision, PathDecision::Excluded);
         assert_eq!(explanation.reason, PathReason::NonRegularFile);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn explain_path_rejects_files_below_a_symlinked_directory() {
+        let outside = TempDir::new().unwrap();
+        let outside_dir = outside.path().join("secrets");
+        fs::create_dir_all(outside_dir.join("nested")).unwrap();
+        fs::write(
+            outside_dir.join("nested/secret.rs"),
+            "fn outside_secret() {}\n",
+        )
+        .unwrap();
+
+        let dir = TempDir::new().unwrap();
+        fs::write(dir.path().join("main.rs"), "fn main() {}").unwrap();
+        std::os::unix::fs::symlink(&outside_dir, dir.path().join("linkdir")).unwrap();
+
+        let result = discover_files(dir.path(), &default_config()).unwrap();
+        let discovered: Vec<&str> = result
+            .files
+            .iter()
+            .map(|f| f.relative_path.as_str())
+            .collect();
+        assert_eq!(discovered, vec!["main.rs"]);
+
+        // The symlink is an intermediate component, not the final one, so
+        // `symlink_metadata` on the candidate would follow it.
+        let explanation = explain_path(
+            dir.path(),
+            Path::new("linkdir/nested/secret.rs"),
+            &default_config(),
+        )
+        .unwrap();
+        assert_eq!(
+            explanation.decision,
+            PathDecision::Excluded,
+            "explain_path must agree with discovery, which never enumerated this path"
+        );
+        assert_eq!(explanation.reason, PathReason::NonRegularFile);
+    }
+
+    #[test]
+    fn explain_path_reports_a_path_that_does_not_exist_as_missing() {
+        let dir = TempDir::new().unwrap();
+        fs::create_dir(dir.path().join("src")).unwrap();
+
+        let explanation =
+            explain_path(dir.path(), Path::new("src/absent.rs"), &default_config()).unwrap();
+        assert_eq!(explanation.decision, PathDecision::Missing);
+        assert_eq!(explanation.reason, PathReason::Missing);
     }
 
     #[cfg(unix)]


### PR DESCRIPTION
## The bug

`crates/vera-core/src/discovery/mod.rs:255` filtered discovered entries with:

```
if !path.is_file() { continue; }
```

`Path::is_file()` calls `fs::metadata`, which **resolves** symlinks. The walker runs with `follow_links(false)` (the `ignore` crate default; Vera never calls `follow_links`). So a symlink whose target is a regular file passed the filter, was assigned a repository-relative path (`discovery/mod.rs:331-335`), and was read through the link at `indexing/pipeline.rs:408`. Two later sites resolved the link again: the `fs::metadata` size check at `:267`, so the 1 MB cap applied to the target, and binary detection at `:308`, which opened the target.

`explain_path` had the same hole at `:406`, which matters on its own, since `vera explain-path` exists to answer exactly this question and answered it wrongly.

Symlinked *directories* were already skipped correctly, because `is_file()` is false for them.

## Reproduction against v1.0.0

```
outside/canary.env    CANARY_TOKEN=not-a-real-secret-outside-the-repo
repo/main.rs
repo/aws.conf -> ../outside/canary.env
```

Released binary (`vera 1.0.0`), run inside `repo/`:

```
$ vera explain-path aws.conf
  Decision:  indexed
  Reason:    indexed
  path would be indexed

$ vera index . --no-progress
  Files parsed:        2
  Chunks created:      2
  Embeddings generated: 2

$ vera grep "CANARY_TOKEN"
aws.conf:1-1
CANARY_TOKEN=not-a-real-secret-outside-the-repo
```

The contents of a file outside the repository are in `.vera/`, filed under an in-repository path. With an API embedding provider the same content also leaves the host.

Same fixture on this branch:

```
$ vera explain-path aws.conf
  Decision:  excluded
  Reason:    non_regular_file
  Source:    discovery
  symbolic links are not followed during indexing

$ vera index . --no-progress
  Files parsed:        1
  Chunks created:      1
  Embeddings generated: 1

$ vera grep "CANARY_TOKEN"
(no results)
```

## Not inherited from the walker

ripgrep drives the same `ignore` crate walker and does not have this behaviour, because it filters on the entry's own file type. Control on the fixture above:

```
$ rg --files --hidden repo/
repo/main.rs
```

## The change

One behavioural change applied at both sites, plus its consequences, then four follow-up commits that close the same divergence for paths `explain_path` is asked about directly.

- `crates/vera-core/src/discovery/mod.rs:253-260`: filter on `entry.file_type()`, the walker entry's own type, rather than the link-resolving `path.is_file()`. This is what ripgrep does. `file_type()` returns `None` only for stdin, which a directory walk never yields, so `is_some_and` treats that as not-a-file.
- `crates/vera-core/src/discovery/mod.rs:412-454`: `explain_path` reads `symlink_metadata` once and derives missing / directory / non-regular / regular from it, so the diagnostic agrees with the walker. A symlink now reports `non_regular_file` with a message naming links specifically, instead of being reported through whatever its target happens to be. A metadata error other than `NotFound` surfaces with context rather than being reported as a missing path.
- `crates/vera-core/src/discovery/mod.rs:522-551`: the separate `fs::metadata` call that fed the size and empty-file checks is gone, because the `symlink_metadata` result above serves them. For a regular file the two are identical, so those checks are unchanged.

The later `fs::metadata` at `:270` and the `File::open` inside `is_binary_content` need no adjustment: once the entry is known to be a regular file rather than a symlink, both resolve to the same inode as the entry itself.

`symlink_metadata` declines to follow only the *final* component, so an intermediate symlinked directory was still traversed by every check below it. Four commits close that:

- `crates/vera-core/src/discovery/mod.rs:382-410`, `:610-619`, `:642-692`: reject a candidate whose ancestor is a symlink before any metadata, ignore or content check reads through the link, so `explain_path` cannot report a path the walker never enumerated.
- `crates/vera-core/src/discovery/mod.rs:642-692`, `:694-707`: run that scan on the root-relative path **as written**, before `..` is collapsed. Lexical normalization turned `link/../file` into `file` and left no ancestor to inspect, while POSIX resolves left to right and traverses `link` either way. The scan keeps its own lexical prefix and treats a `..` as one more component following whatever precedes it. Taking the pre-normalization path also removes the `to_string_lossy` round trip the scan and the ignore matchers were reading, so a component whose name is not valid UTF-8 is no longer stat'd as a different, non-existent path.
- `crates/vera-core/src/discovery/mod.rs:406-408`, `:610-619`, `:675-689`: an ancestor the kernel cannot resolve through stops the scan and reports the path as **missing**, rather than being scanned past or reported through the normalized tail. Two conditions reach it, by different errno: an ancestor that does not exist (`absent/../link/file` is missing, not a link) and an ancestor that exists but is not a directory (`regular/../target.rs` stops at `regular` with `ENOTDIR` and never reaches `target.rs`). Both mean the same thing to a caller, the named path cannot be resolved, and both produce the same `missing` / `path does not exist` output, so they share one `AncestorScan::UnresolvableAncestor` state rather than a fourth variant the output could not distinguish. `missing` is the right reason code here rather than `excluded`: nothing excluded the path, it cannot exist.
- `crates/vera-core/src/discovery/mod.rs:389`, `:621-640`: which of those two forms the scan is handed is chosen per platform, because only POSIX resolves a `..` against the directory it has already reached. Win32 canonicalizes `..` out of an ordinary path before the file system is consulted, so `link\..\file` opens `file` and `regular\..\file` succeeds; walking the written form there reports on ancestors Windows never visits, and answers `regular/../target.rs` with `missing` where Windows would open `target.rs`. Only the placement of `..` differs, so `ancestor_scan_path` selects an input rather than gating the scan: Windows will not open `regular\nested\file` either, and the walker declines a reparse point exactly as it declines a symbolic link, so gating the whole function would drop the symlink rejection this PR exists to add. The selection uses `cfg!` rather than `#[cfg]`, so both arms stay compiled on every host.

**The Windows arm is unverified and no test claims it.** `x86_64-pc-windows-msvc` is not installed on this machine (`cargo check --target x86_64-pc-windows-msvc` fails with `can't find crate for core`), and every test that exercises this code is `#[cfg(unix)]`. It is reasoned from Win32's documented path canonicalization, nothing more. Because the selection is `cfg!`, the Windows build compiles the same code either way, so this cannot break `release.yml`'s `x86_64-pc-windows-msvc` job, which builds that target but runs no tests. Pinning the behaviour would need a Windows test job.

## Tests

Eight, all built inside `tempfile::tempdir()` against a canary file created in that temp directory (no real file is ever linked to). All but the last are `#[cfg(unix)]`, either because they call `std::os::unix::fs::symlink` or, for the `ENOTDIR` one, because Windows collapses `..` lexically before the filesystem sees the path, which the production rule now encodes as well:

- `symlink_to_file_outside_root_is_not_discovered`
- `symlink_to_file_inside_root_is_not_indexed_twice`
- `explain_path_rejects_symlinks_to_regular_files`
- `explain_path_rejects_files_below_a_symlinked_directory`
- `explain_path_rejects_a_symlinked_ancestor_erased_by_a_parent_segment`
- `explain_path_reports_a_missing_ancestor_as_missing`
- `explain_path_reports_a_non_directory_ancestor_as_missing`
- `explain_path_reports_a_path_that_does_not_exist_as_missing`

Verified by reinjection. Restoring `path.is_file()` in the walker and `candidate.is_dir()` / `candidate.is_file()` in `explain_path` makes the first three fail with the production behaviour:

```
---- discovery::tests::symlink_to_file_outside_root_is_not_discovered stdout ----
assertion `left == right` failed: a symlink to a file outside the root must not be discovered
  left: ["linked.rs", "main.rs"]
 right: ["main.rs"]

---- discovery::tests::symlink_to_file_inside_root_is_not_indexed_twice stdout ----
assertion `left == right` failed: a symlink to an in-repository file must not be indexed a second time
  left: ["alias.rs", "main.rs"]
 right: ["main.rs"]

---- discovery::tests::explain_path_rejects_symlinks_to_regular_files stdout ----
assertion `left == right` failed
  left: Indexed
 right: Excluded
```

Handing the ancestor scan the normalized path again, one line, fails the fifth:

```
---- discovery::tests::explain_path_rejects_a_symlinked_ancestor_erased_by_a_parent_segment stdout ----
assertion `left == right` failed: a parent segment must not erase the symlinked ancestor it traverses
  left: Indexed
 right: Excluded
```

Letting the scan carry on past an ancestor that does not exist fails the sixth. The path is then reported through the link the `..` was hiding, so it comes back excluded rather than missing:

```
---- discovery::tests::explain_path_reports_a_missing_ancestor_as_missing stdout ----
assertion `left == right` failed
  left: Excluded
 right: Missing
```

Dropping the non-directory arm from the scan fails the seventh, with the behaviour the review found: the scan runs to the end, the checks below it read the normalized `target.rs`, and a path the kernel refuses with `ENOTDIR` is reported as indexed.

```
---- discovery::tests::explain_path_reports_a_non_directory_ancestor_as_missing stdout ----
assertion `left == right` failed
  left: Indexed
 right: Missing
```

The pre-existing `explain_path_rejects_non_regular_files` passes either way, since it links to `/dev/null` and the old resolving check already saw a character device there. That is why the new `explain_path` test links to a regular file instead.

## Verification

```
cargo fmt --check                   clean
cargo test -p vera-core --lib       801 passed, 0 failed
cargo test -p vera-cli --bin vera    97 passed, 0 failed
cargo clippy -p vera-core --lib       5 warnings, all pre-existing, none added
```

## Two things for you to decide

**Should following symlinks become an opt-in flag?** I have deliberately not added one, so this PR is only the fix. If you want one, the shape I would suggest is a `--follow-symlinks` flag that sets `follow_links(true)` on the walker and confines resolved targets to the repository root, so the escape-out-of-the-repo case stays impossible even when opted in. Happy to send that as a separate PR.

**The `#include .gitignore` half of #103 is not addressed here.** That half is a UX judgement (accept more spellings of the directive, or warn whenever a root `.veraignore` disables gitignore) and I did not want to guess at it. The closing keyword below will close #103 on merge, so if you would rather keep that half tracked, please split it into its own issue before merging, or drop the keyword and close #103 manually. I am glad to file the split issue if you prefer.

Fixes #103

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop indexing through symlinks and align explain-path with discovery. Previously we resolved symlinks and indexed their targets (even outside the repo); now symlinks and paths with a symlinked ancestor are excluded, and paths with a missing ancestor are reported as Missing.

- Discovery filters on the walker entry’s own type (`entry.file_type()`), so links are never resolved or indexed.
- explain-path uses `symlink_metadata` and rejects any symlinked ancestor before further checks. It scans ancestors the way the OS resolves `..`: POSIX uses the path as written; Windows uses the collapsed form.
- Missing ancestors (absent or not-a-directory) return Decision: Missing; final-component NotFound shares the same handling.
- The single `symlink_metadata` read also backs size and empty-file checks; ignore matching still uses the normalized relative path.
- Impact: files previously indexed only via symlinks are now excluded. Migration: replace symlinks with real files or index targets directly.

<sup>Written for commit c827a16c1e9bf2f405392d99e15112ccb882256c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/VeraTools/Vera/pull/111?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Symbolic links are now excluded from file discovery instead of being followed, including links to files and directories inside or outside the repository.
  * Improved path explanations distinguish missing paths, directories, symbolic links, and other unsupported file types.
  * Added clearer details when symbolic links or paths with symlinked ancestors are excluded, including paths containing `..` segments.
  * Improved handling of missing and inaccessible paths, including missing ancestors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



