### PR TITLE
fix(retrieval): contain indexed file paths within the project root

### DIFF
--- a/crates/vera-core/src/lib.rs
+++ b/crates/vera-core/src/lib.rs
@@ -28,6 +28,7 @@ pub fn init_tls() {
 
 pub mod indexing;
 pub mod parsing;
+pub(crate) mod path_containment;
 pub mod presentation;
 pub mod retrieval;
 pub mod storage;

--- a/crates/vera-core/src/parsing/sphinx.rs
+++ b/crates/vera-core/src/parsing/sphinx.rs
@@ -13,6 +13,8 @@ use std::sync::OnceLock;
 use anyhow::{Context, Result};
 use regex::Regex;
 
+use crate::path_containment::{self, Containment};
+
 const MAX_INCLUDE_DEPTH: usize = 16;
 
 /// Preprocess RST text for chunking and embedding.
@@ -127,20 +129,16 @@ fn resolve_include_path(
         current_file.parent().unwrap_or(repo_root).join(include_ref)
     };
 
-    let canonical = match candidate.canonicalize() {
-        Ok(path) => path,
-        Err(_) => return Ok(None),
-    };
-
     let canonical_repo_root = repo_root
         .canonicalize()
         .with_context(|| format!("failed to canonicalize repo root: {}", repo_root.display()))?;
 
-    if !canonical.starts_with(&canonical_repo_root) {
-        return Ok(None);
-    }
-
-    Ok(Some(canonical))
+    Ok(
+        match path_containment::resolve_within(&canonical_repo_root, &candidate) {
+            Containment::Inside(path) => Some(path),
+            Containment::Escaped | Containment::Unresolved => None,
+        },
+    )
 }
 
 fn normalize_roles(text: &str) -> String {

--- a/crates/vera-core/src/path_containment.rs
+++ b/crates/vera-core/src/path_containment.rs
@@ -64,7 +64,7 @@ pub(crate) fn resolve_indexed_path(canonical_root: &Path, relative: &str) -> Opt
     let shape_ok = !relative.is_empty()
         && path
             .components()
-            .all(|component| matches!(component, Component::Normal(_)));
+            .all(|component| matches!(component, Component::Normal(_) | Component::CurDir));
 
     let containment = if shape_ok {
         resolve_within(canonical_root, &canonical_root.join(path))
@@ -117,6 +117,15 @@ mod tests {
         let f = fixture();
         let resolved = resolve_indexed_path(&f.root, "src/lib.rs").unwrap();
         assert_eq!(resolved, f.root.join("src/lib.rs"));
+    }
+
+    #[test]
+    fn cur_dir_components_in_stored_path_resolve_inside_the_root() {
+        let f = fixture();
+        for relative in ["./src/lib.rs", "src/./lib.rs"] {
+            let resolved = resolve_indexed_path(&f.root, relative).unwrap();
+            assert_eq!(resolved, f.root.join("src/lib.rs"));
+        }
     }
 
     #[test]

--- a/crates/vera-core/src/path_containment.rs
+++ b/crates/vera-core/src/path_containment.rs
@@ -1,0 +1,151 @@
+//! Containment for paths that come back out of an index.
+//!
+//! `.vera/` is an ordinary directory: it can be committed, cloned, and edited,
+//! so every `file_path` stored in `metadata.db` is untrusted input. Joining one
+//! onto the project root is only safe after it has been checked to stay inside
+//! that root, because `Path::join` replaces the base when the right-hand side
+//! is absolute, and `..` components traverse out of it.
+
+use std::path::{Component, Path, PathBuf};
+
+use anyhow::{Context, Result};
+use tracing::warn;
+
+/// Where an untrusted path resolves relative to a project root.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum Containment {
+    /// Resolves inside the root; carries the canonicalized absolute path.
+    Inside(PathBuf),
+    /// Resolves outside the root, or has a shape that cannot resolve inside it.
+    Escaped,
+    /// Does not resolve at all: missing, unreadable, or a broken symlink.
+    Unresolved,
+}
+
+/// Canonicalize the project root that `index_dir` lives in.
+///
+/// Resolve this once per query and reuse it: containment compares against a
+/// canonicalized root, so the root itself has to be canonical for files under a
+/// symlinked root to match.
+pub(crate) fn canonical_project_root(index_dir: &Path) -> Result<PathBuf> {
+    let root = index_dir
+        .parent()
+        .ok_or_else(|| anyhow::anyhow!("Cannot determine project root from index dir"))?;
+    root.canonicalize()
+        .with_context(|| format!("failed to canonicalize project root: {}", root.display()))
+}
+
+/// Resolve `candidate` and report where it lands relative to `canonical_root`.
+pub(crate) fn resolve_within(canonical_root: &Path, candidate: &Path) -> Containment {
+    let Ok(canonical) = candidate.canonicalize() else {
+        return Containment::Unresolved;
+    };
+    if canonical.starts_with(canonical_root) {
+        Containment::Inside(canonical)
+    } else {
+        Containment::Escaped
+    }
+}
+
+/// Resolve a path stored in the index against the canonicalized project root.
+///
+/// Returns `None` for anything that must not be read. An escape is logged:
+/// a stored path that leaves the project root means the index disagrees with
+/// the repository it sits in, and a silent skip would hide that.
+pub(crate) fn resolve_indexed_path(canonical_root: &Path, relative: &str) -> Option<PathBuf> {
+    let path = Path::new(relative);
+    let shape_ok = !relative.is_empty()
+        && path
+            .components()
+            .all(|component| matches!(component, Component::Normal(_)));
+
+    let containment = if shape_ok {
+        resolve_within(canonical_root, &canonical_root.join(path))
+    } else {
+        Containment::Escaped
+    };
+
+    match containment {
+        Containment::Inside(path) => Some(path),
+        Containment::Escaped => {
+            warn!(
+                file = %relative,
+                root = %canonical_root.display(),
+                "skipping indexed path that escapes the project root"
+            );
+            None
+        }
+        Containment::Unresolved => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct Fixture {
+        _temp: tempfile::TempDir,
+        root: PathBuf,
+        canary: PathBuf,
+    }
+
+    /// A project root with a canary file next to it, outside the root.
+    fn fixture() -> Fixture {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path().join("repo");
+        std::fs::create_dir_all(root.join("src")).unwrap();
+        std::fs::write(root.join("src/lib.rs"), "fn inside() {}\n").unwrap();
+        let canary = temp.path().join("canary.txt");
+        std::fs::write(&canary, "CANARY-SECRET\n").unwrap();
+        let root = root.canonicalize().unwrap();
+        Fixture {
+            _temp: temp,
+            root,
+            canary,
+        }
+    }
+
+    #[test]
+    fn relative_path_inside_the_root_resolves() {
+        let f = fixture();
+        let resolved = resolve_indexed_path(&f.root, "src/lib.rs").unwrap();
+        assert_eq!(resolved, f.root.join("src/lib.rs"));
+    }
+
+    #[test]
+    fn absolute_stored_path_is_rejected() {
+        let f = fixture();
+        let absolute = f.canary.to_str().unwrap();
+        assert!(Path::new(absolute).is_absolute());
+        assert_eq!(resolve_indexed_path(&f.root, absolute), None);
+    }
+
+    #[test]
+    fn parent_traversal_stored_path_is_rejected() {
+        let f = fixture();
+        assert_eq!(resolve_indexed_path(&f.root, "../canary.txt"), None);
+        assert_eq!(resolve_indexed_path(&f.root, "src/../../canary.txt"), None);
+    }
+
+    #[test]
+    fn missing_file_is_unresolved_not_escaped() {
+        let f = fixture();
+        assert_eq!(
+            resolve_within(&f.root, &f.root.join("src/gone.rs")),
+            Containment::Unresolved
+        );
+    }
+
+    #[test]
+    fn resolve_within_reports_a_path_outside_the_root() {
+        let f = fixture();
+        assert_eq!(resolve_within(&f.root, &f.canary), Containment::Escaped);
+    }
+
+    #[test]
+    fn canonical_project_root_is_the_index_dir_parent() {
+        let f = fixture();
+        let root = canonical_project_root(&f.root.join(".vera")).unwrap();
+        assert_eq!(root, f.root);
+    }
+}

--- a/crates/vera-core/src/path_containment.rs
+++ b/crates/vera-core/src/path_containment.rs
@@ -28,9 +28,16 @@ pub(crate) enum Containment {
 /// canonicalized root, so the root itself has to be canonical for files under a
 /// symlinked root to match.
 pub(crate) fn canonical_project_root(index_dir: &Path) -> Result<PathBuf> {
-    let root = index_dir
+    let parent = index_dir
         .parent()
         .ok_or_else(|| anyhow::anyhow!("Cannot determine project root from index dir"))?;
+    // A relative index dir such as `.vera` has an empty parent, which names the
+    // current directory rather than nothing.
+    let root = if parent.as_os_str().is_empty() {
+        Path::new(".")
+    } else {
+        parent
+    };
     root.canonicalize()
         .with_context(|| format!("failed to canonicalize project root: {}", root.display()))
 }
@@ -147,5 +154,23 @@ mod tests {
         let f = fixture();
         let root = canonical_project_root(&f.root.join(".vera")).unwrap();
         assert_eq!(root, f.root);
+    }
+
+    #[test]
+    fn relative_index_dir_takes_the_current_directory_as_the_root() {
+        // `Path::new(".vera").parent()` is `""`, not `None`, and a trailing
+        // slash is normalized away before the parent is taken, so both spellings
+        // have to land on the current directory.
+        let cwd = std::env::current_dir().unwrap().canonicalize().unwrap();
+        assert_eq!(canonical_project_root(Path::new(".vera")).unwrap(), cwd);
+        assert_eq!(canonical_project_root(Path::new(".vera/")).unwrap(), cwd);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn symlink_out_of_the_root_is_rejected_before_it_is_read() {
+        let f = fixture();
+        std::os::unix::fs::symlink(&f.canary, f.root.join("src/leak.rs")).unwrap();
+        assert_eq!(resolve_indexed_path(&f.root, "src/leak.rs"), None);
     }
 }

--- a/crates/vera-core/src/retrieval/references.rs
+++ b/crates/vera-core/src/retrieval/references.rs
@@ -6,6 +6,7 @@ use std::path::Path;
 use anyhow::Result;
 
 use crate::corpus::{ContentClass, classify_content};
+use crate::path_containment::{canonical_project_root, resolve_indexed_path};
 use crate::retrieval::file_scan::{
     allows_class, language_for_path, line_context_snippet, symbol_for_line,
 };
@@ -25,9 +26,7 @@ pub fn search_callers(
 
     let metadata_path = index_dir.join("metadata.db");
     let store = MetadataStore::open(&metadata_path)?;
-    let repo_root = index_dir
-        .parent()
-        .ok_or_else(|| anyhow::anyhow!("Cannot determine project root from index dir"))?;
+    let repo_root = canonical_project_root(index_dir)?;
     let callers = store.find_callers(symbol)?;
     let mut results = Vec::new();
     let mut seen = HashSet::new();
@@ -42,7 +41,9 @@ pub fn search_callers(
             continue;
         }
 
-        let file_abs = repo_root.join(&caller.file_path);
+        let Some(file_abs) = resolve_indexed_path(&repo_root, &caller.file_path) else {
+            continue;
+        };
         let content = match crate::discovery::read_source_lossy(&file_abs) {
             Ok(content) => content,
             Err(_) => continue,

--- a/crates/vera-core/src/retrieval/regex_search.rs
+++ b/crates/vera-core/src/retrieval/regex_search.rs
@@ -11,6 +11,7 @@ use anyhow::Result;
 use regex::RegexBuilder;
 
 use crate::corpus::{ContentClass, classify_content};
+use crate::path_containment::{canonical_project_root, resolve_indexed_path};
 use crate::retrieval::file_scan::{
     allows_class, bounded_byte_snippet, language_for_path, sort_files_by_scan_priority,
     symbol_for_line,
@@ -43,9 +44,7 @@ pub fn search_regex(
     sort_files_by_scan_priority(&mut files, filters);
 
     // Resolve the project root (index_dir is .vera/, parent is project root).
-    let project_root = index_dir
-        .parent()
-        .ok_or_else(|| anyhow::anyhow!("Cannot determine project root from index dir"))?;
+    let project_root = canonical_project_root(index_dir)?;
 
     let mut results = Vec::new();
 
@@ -72,7 +71,9 @@ pub fn search_regex(
             None
         };
 
-        let file_abs = project_root.join(file_rel);
+        let Some(file_abs) = resolve_indexed_path(&project_root, file_rel) else {
+            continue;
+        };
         let content = match crate::discovery::read_source_lossy(&file_abs) {
             Ok(c) => c,
             Err(_) => continue,
@@ -474,5 +475,84 @@ mod tests {
                 .all(|result| result.symbol_name.as_deref() == Some("build_token"))
         );
         assert_eq!(results[0].file_path, "src/lib.rs");
+    }
+
+    #[test]
+    fn stored_paths_outside_the_project_root_are_not_read() {
+        let tmp = tempfile::tempdir().unwrap();
+        // The canary sits next to the project root, so both escape shapes reach
+        // it without the test touching anything outside the temp dir.
+        let canary = tmp.path().join("canary.txt");
+        std::fs::write(&canary, "CANARY_SECRET lives outside the repository\n").unwrap();
+
+        let repo_root = tmp.path().join("repo");
+        let index_dir = repo_root.join(".vera");
+        std::fs::create_dir_all(repo_root.join("src")).unwrap();
+        std::fs::create_dir_all(&index_dir).unwrap();
+        std::fs::write(
+            repo_root.join("src/lib.rs"),
+            "fn read() { CANARY_SECRET; }\n",
+        )
+        .unwrap();
+
+        let store = MetadataStore::open(&index_dir.join("metadata.db")).unwrap();
+        store
+            .insert_chunks(&[
+                Chunk {
+                    id: "inside:0".to_string(),
+                    file_path: "src/lib.rs".to_string(),
+                    line_start: 1,
+                    line_end: 1,
+                    content: "fn read() { CANARY_SECRET; }".to_string(),
+                    language: Language::Rust,
+                    symbol_type: None,
+                    symbol_name: None,
+                },
+                Chunk {
+                    id: "absolute:0".to_string(),
+                    file_path: canary.to_str().unwrap().to_string(),
+                    line_start: 1,
+                    line_end: 1,
+                    content: String::new(),
+                    language: Language::Unknown,
+                    symbol_type: None,
+                    symbol_name: None,
+                },
+                Chunk {
+                    id: "traversal:0".to_string(),
+                    file_path: "../canary.txt".to_string(),
+                    line_start: 1,
+                    line_end: 1,
+                    content: String::new(),
+                    language: Language::Unknown,
+                    symbol_type: None,
+                    symbol_name: None,
+                },
+            ])
+            .unwrap();
+
+        let results = search_regex(
+            &index_dir,
+            "CANARY_SECRET",
+            10,
+            false,
+            0,
+            &SearchFilters::default(),
+        )
+        .unwrap();
+
+        assert!(
+            results
+                .iter()
+                .all(|result| !result.content.contains("outside the repository")),
+            "a stored path escaped the project root: {results:?}"
+        );
+        assert_eq!(
+            results
+                .iter()
+                .map(|result| result.file_path.as_str())
+                .collect::<Vec<_>>(),
+            vec!["src/lib.rs"]
+        );
     }
 }

--- a/crates/vera-core/src/retrieval/structural.rs
+++ b/crates/vera-core/src/retrieval/structural.rs
@@ -10,6 +10,7 @@ use tree_sitter::Parser;
 
 use crate::corpus::{ContentClass, classify_content};
 use crate::parsing::languages;
+use crate::path_containment::{canonical_project_root, resolve_indexed_path};
 use crate::retrieval::apply_filters;
 use crate::retrieval::file_scan::{
     allows_class, bounded_byte_snippet, language_for_path, smallest_symbol_chunk_for_line,
@@ -56,9 +57,7 @@ pub fn search_structural(
 
     let metadata_path = index_dir.join("metadata.db");
     let store = MetadataStore::open(&metadata_path)?;
-    let repo_root = index_dir
-        .parent()
-        .ok_or_else(|| anyhow::anyhow!("Cannot determine project root from index dir"))?;
+    let repo_root = canonical_project_root(index_dir)?;
     let filters = structural_filters(filters);
 
     match kind {
@@ -67,12 +66,12 @@ pub fn search_structural(
             search_definitions(&store, symbol, limit, &filters)
         }
         StructuralSearchKind::EnvReads => {
-            search_env_reads(repo_root, &store, query, limit, &filters)
+            search_env_reads(&repo_root, &store, query, limit, &filters)
         }
         StructuralSearchKind::RouteHandlers => {
-            search_route_handlers(repo_root, &store, limit, &filters)
+            search_route_handlers(&repo_root, &store, limit, &filters)
         }
-        StructuralSearchKind::SqlQueries => search_sql_queries(repo_root, &store, limit, &filters),
+        StructuralSearchKind::SqlQueries => search_sql_queries(&repo_root, &store, limit, &filters),
         StructuralSearchKind::Implementations => {
             let target = required_query(kind, query)?;
             search_implementations(index_dir, target, limit, &filters)
@@ -263,7 +262,9 @@ where
             continue;
         }
 
-        let file_abs = repo_root.join(&file_rel);
+        let Some(file_abs) = resolve_indexed_path(repo_root, &file_rel) else {
+            continue;
+        };
         let content = match crate::discovery::read_source_lossy(&file_abs) {
             Ok(content) => content,
             Err(e) => {

--- a/crates/vera-core/src/retrieval/type_relations.rs
+++ b/crates/vera-core/src/retrieval/type_relations.rs
@@ -7,6 +7,7 @@ use anyhow::Result;
 
 use crate::corpus::{ContentClass, classify_content};
 use crate::parsing::signatures;
+use crate::path_containment::{canonical_project_root, resolve_indexed_path};
 use crate::retrieval::file_scan::{
     allows_class, language_for_path, line_context_snippet, smallest_symbol_chunk_for_line,
     symbol_for_line,
@@ -26,9 +27,7 @@ pub fn search_explicit_implementations(
 
     let metadata_path = index_dir.join("metadata.db");
     let store = MetadataStore::open(&metadata_path)?;
-    let repo_root = index_dir
-        .parent()
-        .ok_or_else(|| anyhow::anyhow!("Cannot determine project root from index dir"))?;
+    let repo_root = canonical_project_root(index_dir)?;
     let symbol = super::structural::normalize_impl_target(symbol);
     let relations = store.find_type_relations(&symbol)?;
     let mut results = Vec::new();
@@ -44,7 +43,9 @@ pub fn search_explicit_implementations(
             continue;
         }
 
-        let file_abs = repo_root.join(&relation.file_path);
+        let Some(file_abs) = resolve_indexed_path(&repo_root, &relation.file_path) else {
+            continue;
+        };
         let content = match crate::discovery::read_source_lossy(&file_abs) {
             Ok(content) => content,
             Err(e) => {


### PR DESCRIPTION
Every join of an index-stored `file_path` onto the project root now goes through one containment helper, `path_containment::resolve_indexed_path` (`crates/vera-core/src/path_containment.rs`). It rejects an empty path and any non-`Normal` component, joins onto the canonicalized project root, canonicalizes the result, and returns it only if it is still under that root. The root is canonicalized once per query by `canonical_project_root`, which also absorbs the `index_dir.parent()` resolution the four call sites each did by hand.

Fixes #108

## Threat model

`.vera/` is an ordinary committable directory and nothing validates an index's provenance: `MetadataStore::open` opens whatever is present. So a repository can ship an index whose stored paths point outside itself, and a contributor who clones it and runs a search reads those files, supplying the search pattern themselves. The attacker needs no write access to the victim's machine at any point; the whole attack travels as committed data.

## The four sites

All four took a path from `SELECT DISTINCT file_path FROM chunks` (or from the `references` / `type_relations` tables) and joined it onto the project root with no validation. `Path::join` replaces the base when the right-hand side is absolute, so an absolute stored path escaped outright; `..` components escaped by traversal.

| file | line |
|---|---|
| `crates/vera-core/src/retrieval/regex_search.rs` | 75 |
| `crates/vera-core/src/retrieval/structural.rs` | 266 |
| `crates/vera-core/src/retrieval/references.rs` | 45 |
| `crates/vera-core/src/retrieval/type_relations.rs` | 47 |

## Shared, not duplicated

`parsing/sphinx.rs:130-143` already did this correctly for `.. include::` targets, and that inlined tail is now the shared `resolve_within`, so the security-critical comparison exists once. The Sphinx resolver keeps its own input contract (an include ref may be root-anchored with a leading `/` or relative to the including file, neither of which is a repo-relative path) and its own `Ok(None)` policy, so only the canonicalize-and-prefix core is shared. One behaviour change falls out of the reordering: a repo root that cannot be canonicalized is now an error even when the include target also does not exist, where before the missing target returned `Ok(None)` first.

Canonicalizing the root is load-bearing rather than incidental: the resolved file path is canonical, so a project reached through a symlinked path would otherwise fail its own containment check.

## Index dir shapes

`Path::new(".vera").parent()` is `Some("")`, not `None`, so a relative index dir reached `canonicalize()` with an empty path and failed with a bare `No such file or directory` naming nothing. An empty parent names the current directory, and now resolves to it. Every production caller builds the index dir from `std::env::current_dir()` (`vera-cli/src/helpers.rs:177`, `vera-mcp/src/tools.rs:437`) or from `canonicalize()` (`vera-mcp/src/watcher.rs:49`), so the broken shape was only reachable by a library caller. A trailing slash is not a separate case: `Path::components` normalizes it away before the parent is taken, so `.vera/` and `.vera` are the same path.

## What a rejected path does

A path that escapes the root is skipped and the row is dropped from the result set, not treated as fatal. A search is a bulk operation over every indexed file, and failing the whole query on one bad row turns a corrupt or hostile index into a denial of service on a tool the user is running for something else.

A silent skip would hide the attack, so each escape logs at `warn`, naming the offending stored path and the root. `tracing` is initialized at `warn` by default, so it surfaces without extra flags.

The three outcomes are kept distinct in `Containment` for exactly this reason: `Escaped` warns, `Unresolved` (deleted, unreadable, broken symlink) stays a silent skip because that is the ordinary case of a file removed since the index was built, and warning on it would bury the real signal.

## What this does not close

Tracked as #135, filed at CodeRabbit's request to cover the whole boundary rather than the retrieval half. This PR does not close it, in either direction.

Containment is decided by path, and the file is then opened by path on the next statement. An attacker who can write to the working tree *concurrently with a running query* can in principle replace a validated entry between the two. That window is not closed here, and this PR should not be read as closing it. Two things bound it:

- A symlink planted *before* the query is already rejected, because `canonicalize` resolves the link before the prefix comparison. Only the interleaving remains, and it is one statement wide at each of the four sites.
- The precondition is concurrent write access to the checkout, which already yields code execution on the next build or commit through `.git/hooks`, `build.rs` or editor config. That is strictly stronger than reading one file outside the root.

Closing it properly means descriptor-based access: `openat` per component with `O_NOFOLLOW`, or `cap-std`. `discovery::read_source_lossy` is `pub` and path-taking and is shared with the three indexing call sites, `x86_64-pc-windows-msvc` is a release target with no `O_NOFOLLOW`, and vera-core carries no `libc`/`rustix`/`cap-std` dependency today. The same finding was raised on #111 against `discovery/mod.rs` and declined there for the same reason; hardening retrieval alone would leave the indexing window, which decides what is stored in the first place, untouched. It belongs in one follow-up covering both, not split across two PRs. That follow-up is #135.

Symlink following *inside* the repository is a separate finding (#103, in `discovery/mod.rs`) and is deliberately untouched here.

## Verification

End to end, on the same poisoned index and the same query, with a canary file placed one directory above the project root:

- released `vera 1.0.0`: three hits, two of them the canary's contents, one reached by `../canary.txt` and one by its absolute path.
- this branch: one hit, the in-repo file, plus two `WARN skipping indexed path that escapes the project root` lines.

Tests cover three escape shapes at the helper level (absolute, `..` traversal, and a symlink pointing out of the root) and one at a call site (`retrieval::regex_search::tests::stored_paths_outside_the_project_root_are_not_read`, which asserts no returned result carries content from outside the root). Everything they touch lives in a `tempfile::tempdir()`; the canary is a file the test writes, never a real one.

Confirmed by reinjection. With the containment check removed and the naive join restored, the helper tests fail with the escaping path returned instead of `None` (the symlink one returning `.../repo/src/leak.rs`, which resolves to the canary), and the call-site test fails with the canary's line returned twice, once under `../canary.txt` and once under its absolute path. With the empty-parent normalization reverted, `relative_index_dir_takes_the_current_directory_as_the_root` fails with the production error, `failed to canonicalize project root: ` / `No such file or directory (os error 2)`.

- `cargo fmt --check`: clean
- `cargo test -p vera-core --lib`: 802 passed, 0 failed
- `cargo test -p vera-cli --bin vera`: 97 passed, 0 failed
- `cargo clippy -p vera-core --lib`: 5 warnings, the pre-existing set, none added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved repository path validation across search, reference, structural, and type-relation retrieval.
  * Prevented searches and lookups from accessing files outside the project directory.
  * Safely ignore missing, unresolved, absolute, or traversal-based paths.
  * Added coverage for valid paths, escaped paths, unavailable files, and external content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
