### PR TITLE
fix(retrieval): time query embedding and vector search separately

### DIFF
--- a/crates/vera-core/src/retrieval/hybrid.rs
+++ b/crates/vera-core/src/retrieval/hybrid.rs
@@ -22,7 +22,7 @@ use crate::retrieval::query_classifier::{QueryType, classify_query, params_for_q
 use crate::retrieval::query_utils::result_key;
 use crate::retrieval::ranking::is_path_weighted_query;
 use crate::retrieval::reranker::{Reranker, rerank_results};
-use crate::retrieval::vector::{VectorSearchError, search_vector_with_stores};
+use crate::retrieval::vector::{VectorSearchError, search_vector_with_stores_timed};
 use crate::storage::bm25::Bm25Index;
 use crate::storage::metadata::MetadataStore;
 use crate::storage::vector::VectorStore;
@@ -134,14 +134,14 @@ pub async fn search_hybrid(
     } else {
         vector_candidates.saturating_mul(4).max(200)
     };
-    let embed_start = Instant::now();
-    let vector_results = match VectorStore::open(&index_dir.join("vectors.db"), stored_dim) {
+    let vector_start = Instant::now();
+    let vector_outcome = match VectorStore::open(&index_dir.join("vectors.db"), stored_dim) {
         Ok(vector_store) => {
             let vector_store_result =
                 MetadataStore::open(&vector_metadata_path).context("failed to open metadata store");
             match vector_store_result {
                 Ok(vector_metadata) => {
-                    match search_vector_with_stores(
+                    match search_vector_with_stores_timed(
                         &vector_store,
                         &vector_metadata,
                         provider,
@@ -150,11 +150,11 @@ pub async fn search_hybrid(
                     )
                     .await
                     {
-                        Ok(mut results) => {
+                        Ok((mut results, embed_elapsed)) => {
                             if !filters.is_empty() {
                                 results.retain(|result| filters.matches(result));
                             }
-                            Ok(results)
+                            Ok((results, embed_elapsed))
                         }
                         Err(err) => Err(err),
                     }
@@ -166,9 +166,19 @@ pub async fn search_hybrid(
             err.context("failed to open vector store"),
         )),
     };
-    let vector_elapsed = embed_start.elapsed();
-    timings.embedding = Some(vector_elapsed);
-    timings.vector = Some(vector_elapsed);
+    // The embedding runs inside the vector search, so the two stages share one
+    // wall-clock span. Report query embedding (model cost) on its own and charge
+    // the remainder to `vector` (storage cost): opening both stores, the KNN
+    // query and metadata hydration. A vector search that failed has no embedding
+    // measurement to report, so the whole span stays on `vector`.
+    let vector_span = vector_start.elapsed();
+    let embed_elapsed = vector_outcome
+        .as_ref()
+        .ok()
+        .map(|(_, embed_elapsed)| *embed_elapsed);
+    timings.embedding = embed_elapsed;
+    timings.vector = Some(vector_span.saturating_sub(embed_elapsed.unwrap_or_default()));
+    let vector_results = vector_outcome.map(|(results, _)| results);
 
     // Await the BM25 result (should already be done or nearly done).
     let (bm25_results, bm25_elapsed) = bm25_handle.await.map_err(|e| {

--- a/crates/vera-core/src/retrieval/hybrid.rs
+++ b/crates/vera-core/src/retrieval/hybrid.rs
@@ -170,9 +170,7 @@ pub async fn search_hybrid(
         .as_ref()
         .ok()
         .map(|(_, embed_elapsed)| *embed_elapsed);
-    let (embedding_stage, vector_stage) = split_vector_span(vector_start.elapsed(), embed_elapsed);
-    timings.embedding = embedding_stage;
-    timings.vector = Some(vector_stage);
+    charge_vector_span(&mut timings, vector_start.elapsed(), embed_elapsed);
     let vector_results = vector_outcome.map(|(results, _)| results);
 
     // Await the BM25 result (should already be done or nearly done).
@@ -449,7 +447,7 @@ pub fn fuse_rrf_multi_weighted(
         .collect()
 }
 
-/// Cut the one wall-clock span that covers the vector arm into the two stages
+/// Charge the one wall-clock span that covers the vector arm to the two stages
 /// `--timing` reports.
 ///
 /// The query embedding runs inside the vector search, so both stages come out
@@ -460,15 +458,16 @@ pub fn fuse_rrf_multi_weighted(
 ///
 /// The two must partition the span rather than each be given all of it, which
 /// is what issue #105 was: the same value reported twice made either stage
-/// unattributable.
-fn split_vector_span(
+/// unattributable. Both fields are written here rather than at the call site so
+/// that partition is decided in one place a test can reach: a caller that only
+/// received the two values could still charge the span twice.
+fn charge_vector_span(
+    timings: &mut HybridTimings,
     vector_span: Duration,
     embed_elapsed: Option<Duration>,
-) -> (Option<Duration>, Duration) {
-    (
-        embed_elapsed,
-        vector_span.saturating_sub(embed_elapsed.unwrap_or_default()),
-    )
+) {
+    timings.embedding = embed_elapsed;
+    timings.vector = Some(vector_span.saturating_sub(embed_elapsed.unwrap_or_default()));
 }
 
 #[cfg(test)]

--- a/crates/vera-core/src/retrieval/hybrid.rs
+++ b/crates/vera-core/src/retrieval/hybrid.rs
@@ -166,18 +166,13 @@ pub async fn search_hybrid(
             err.context("failed to open vector store"),
         )),
     };
-    // The embedding runs inside the vector search, so the two stages share one
-    // wall-clock span. Report query embedding (model cost) on its own and charge
-    // the remainder to `vector` (storage cost): opening both stores, the KNN
-    // query and metadata hydration. A vector search that failed has no embedding
-    // measurement to report, so the whole span stays on `vector`.
-    let vector_span = vector_start.elapsed();
     let embed_elapsed = vector_outcome
         .as_ref()
         .ok()
         .map(|(_, embed_elapsed)| *embed_elapsed);
-    timings.embedding = embed_elapsed;
-    timings.vector = Some(vector_span.saturating_sub(embed_elapsed.unwrap_or_default()));
+    let (embedding_stage, vector_stage) = split_vector_span(vector_start.elapsed(), embed_elapsed);
+    timings.embedding = embedding_stage;
+    timings.vector = Some(vector_stage);
     let vector_results = vector_outcome.map(|(results, _)| results);
 
     // Await the BM25 result (should already be done or nearly done).
@@ -452,6 +447,28 @@ pub fn fuse_rrf_multi_weighted(
             result
         })
         .collect()
+}
+
+/// Cut the one wall-clock span that covers the vector arm into the two stages
+/// `--timing` reports.
+///
+/// The query embedding runs inside the vector search, so both stages come out
+/// of `vector_span`. `embedding` gets the model cost and `vector` gets the
+/// remainder, which is the storage cost: opening both stores, the KNN query and
+/// metadata hydration. A vector search that failed has no embedding measurement
+/// to report, so the whole span stays on `vector`.
+///
+/// The two must partition the span rather than each be given all of it, which
+/// is what issue #105 was: the same value reported twice made either stage
+/// unattributable.
+fn split_vector_span(
+    vector_span: Duration,
+    embed_elapsed: Option<Duration>,
+) -> (Option<Duration>, Duration) {
+    (
+        embed_elapsed,
+        vector_span.saturating_sub(embed_elapsed.unwrap_or_default()),
+    )
 }
 
 #[cfg(test)]

--- a/crates/vera-core/src/retrieval/hybrid_tests.rs
+++ b/crates/vera-core/src/retrieval/hybrid_tests.rs
@@ -452,6 +452,71 @@ async fn search_hybrid_keeps_intent_out_of_bm25() {
     );
 }
 
+/// An embedding provider that spends a known, dominant amount of time in
+/// `embed_batch`, so the embedding stage is separable from the storage stages
+/// by measurement rather than by inspection.
+struct SlowProvider {
+    inner: crate::embedding::test_helpers::MockProvider,
+    delay: std::time::Duration,
+}
+
+impl crate::embedding::EmbeddingProvider for SlowProvider {
+    async fn embed_batch(
+        &self,
+        texts: &[String],
+    ) -> Result<Vec<Vec<f32>>, crate::embedding::EmbeddingError> {
+        tokio::time::sleep(self.delay).await;
+        self.inner.embed_batch(texts).await
+    }
+
+    fn expected_dim(&self) -> Option<usize> {
+        self.inner.expected_dim()
+    }
+}
+
+// Regression for issue #105: `embedding` and `vector` were both assigned the
+// span that covers the embedding, the store opens, the KNN query and
+// hydration, so `--timing` printed one measurement twice.
+#[tokio::test]
+async fn search_hybrid_reports_embedding_and_vector_as_separate_spans() {
+    use crate::embedding::test_helpers::MockProvider;
+
+    let tmp = tempfile::tempdir().unwrap();
+    let (index_dir, dim) = setup_test_index(tmp.path()).await;
+
+    let delay = std::time::Duration::from_millis(300);
+    let provider = SlowProvider {
+        inner: MockProvider::new(dim),
+        delay,
+    };
+
+    let (_results, timings) = search_hybrid(
+        &index_dir,
+        &provider,
+        "authenticate",
+        "authenticate",
+        &SearchFilters::default(),
+        5,
+        60.0,
+        dim,
+        50,
+    )
+    .await
+    .unwrap();
+
+    let embedding = timings.embedding.expect("embedding stage must be reported");
+    let vector = timings.vector.expect("vector stage must be reported");
+
+    assert!(
+        embedding >= delay,
+        "embedding must carry the provider cost: {embedding:?} < {delay:?}"
+    );
+    assert!(
+        vector < delay,
+        "vector must exclude the provider cost: {vector:?} >= {delay:?}"
+    );
+}
+
 #[tokio::test]
 async fn search_hybrid_reranked_returns_reranked_results() {
     use crate::embedding::test_helpers::MockProvider;

--- a/crates/vera-core/src/retrieval/hybrid_tests.rs
+++ b/crates/vera-core/src/retrieval/hybrid_tests.rs
@@ -478,21 +478,26 @@ impl crate::embedding::EmbeddingProvider for SlowProvider {
 // span that covers the embedding, the store opens, the KNN query and
 // hydration, so `--timing` printed one measurement twice.
 //
-// Both stages are cut from one span nested inside the call, so their sum is
-// that span and can never exceed the wall time of the call itself unless a
-// cost is counted twice. Measuring that outer time in the test turns the
-// property into containment rather than a bound on how long anything takes:
-// there is no tolerance to choose, and a machine slow enough to stretch the
-// storage work stretches the outer time with it, so load widens the bound
-// instead of tightening it.
+// The split itself is asserted by `split_vector_span_partitions_the_span`
+// below, on values rather than on a clock. It has to be, because the span the
+// two stages are cut from is internal to `search_hybrid` and no measurement
+// available to this test stands in for it. The wall time of the whole call
+// does not: BM25 runs concurrently with the vector arm and is awaited after
+// it, so that wall time is the slower arm's. Guarding on the reported BM25
+// stage does not repair the substitution, because `bm25_elapsed` starts inside
+// the `spawn_blocking` closure and so measures the arm's duration, not when it
+// finished relative to the vector arm.
 //
-// Containment only decides the split while the outer time is the vector arm's.
-// BM25 runs concurrently and is awaited after it, so a BM25 arm that outlasts
-// the vector arm carries the outer time past the span the two stages are cut
-// from and leaves room for a doubled pair to fit inside it: measured, a 748 ms
-// BM25 against a 334 ms vector span lets the pre-fix code report 334 ms twice
-// and pass containment on 668 ms. The guard below rejects such a run rather
-// than deciding the split on it.
+// Nor is the storage stage small enough to be bounded by the injected model
+// cost. Measured on this fixture, `vector` is 1.6 to 2.9 ms standalone but
+// 262.7 ms inside the 794-test suite, against a 300 ms sleep: a 1.14x margin.
+// Every bound of that family, absolute or relative to a second run, sits on
+// the wrong side of that number, so this test asserts none of them.
+//
+// What is left here is machine-independent and worth keeping: the provider
+// cost reaches `embedding`, the storage cost still reaches `vector`, and the
+// two are no longer one value reported twice, which is the symptom #105 was
+// filed for.
 #[tokio::test]
 async fn search_hybrid_charges_embedding_delay_to_embedding_not_vector() {
     let tmp = tempfile::tempdir().unwrap();
@@ -504,7 +509,6 @@ async fn search_hybrid_charges_embedding_delay_to_embedding_not_vector() {
         delay,
     };
 
-    let started = std::time::Instant::now();
     let (_results, timings) = search_hybrid(
         &index_dir,
         &provider,
@@ -518,51 +522,57 @@ async fn search_hybrid_charges_embedding_delay_to_embedding_not_vector() {
     )
     .await
     .unwrap();
-    let total = started.elapsed();
 
     let embedding = timings.embedding.expect("embedding stage must be reported");
     let vector = timings.vector.expect("vector stage must be reported");
-    let bm25 = timings.bm25.expect("bm25 stage must be reported");
 
     // `sleep` never returns early, so this is a property of the provider rather
-    // than of the machine: the model cost is charged to `embedding` in full.
+    // than of the machine: the model cost reaches `embedding`.
     assert!(
         embedding >= delay,
         "embedding must carry the provider cost: {embedding:?} < {delay:?}"
     );
 
-    // Both arms start together, so a BM25 arm that fits inside the reported
-    // pair finished no later than the vector arm and the await that follows it
-    // returned immediately, leaving `total` equal to the vector arm plus setup
-    // and fusion. That is what makes the containment below a statement about
-    // the split rather than about how long BM25 took. Rejecting the run is the
-    // right outcome here: the measurement cannot decide the property, and a
-    // pass would be the vacuous one.
-    assert!(
-        bm25 <= embedding + vector,
-        "BM25 outlasted the stages it overlaps, so the {total:?} the search \
-         took is BM25's wall time and cannot decide the split: bm25 {bm25:?} > \
-         embedding {embedding:?} + vector {vector:?}"
-    );
-
-    // Together with the bounds above this pins `vector` under `total - delay`,
-    // leaving it only the cost outside the span to hide in, a few milliseconds
-    // against this fixture. So a split that misattributes a material part of
-    // the embedding fails too, not only one that charges the whole of it twice.
-    assert!(
-        embedding + vector <= total,
-        "stages must partition the search, not double-count it: \
-         embedding {embedding:?} + vector {vector:?} exceeds the {total:?} the \
-         whole search took"
-    );
-
-    // Excluding the embedding must not empty the stage: the store opens, the
-    // KNN query and hydration are still charged to `vector`. Without this, a
-    // split that assigned the whole span to `embedding` would satisfy both
-    // bounds above.
+    // Taking the embedding out must not empty the stage: the store opens, the
+    // KNN query and hydration are still charged to `vector`. This presence has
+    // to be asserted before the non-identity below, which a zeroed `vector`
+    // would otherwise satisfy.
     assert!(
         vector > std::time::Duration::ZERO,
         "vector must still carry the storage cost: {vector:?}"
+    );
+
+    // The reported symptom. Under the bug both stages were assigned the same
+    // `Duration` value, so this fails on the bug whatever the machine is doing;
+    // reaching it legitimately would need the storage cost to equal the model
+    // cost to the nanosecond.
+    assert_ne!(
+        embedding, vector,
+        "the two stages must not be one measurement printed twice"
+    );
+}
+
+// The split itself, on values. `search_hybrid` cannot expose the span it cuts,
+// so this asserts the cut where it is decidable: given a span and the embedding
+// measurement taken inside it, the two stages must partition the span. Under
+// the bug each stage got the whole span, which this rejects without a clock.
+#[test]
+fn split_vector_span_partitions_the_span() {
+    let span = std::time::Duration::from_millis(500);
+    let embed = std::time::Duration::from_millis(300);
+
+    assert_eq!(
+        split_vector_span(span, Some(embed)),
+        (Some(embed), std::time::Duration::from_millis(200)),
+        "embedding takes the model cost and vector takes the remainder"
+    );
+
+    // A vector search that failed reports no embedding, so the whole span is
+    // storage cost rather than being dropped.
+    assert_eq!(
+        split_vector_span(span, None),
+        (None, span),
+        "an unmeasured embedding leaves the whole span on vector"
     );
 }
 

--- a/crates/vera-core/src/retrieval/hybrid_tests.rs
+++ b/crates/vera-core/src/retrieval/hybrid_tests.rs
@@ -452,9 +452,10 @@ async fn search_hybrid_keeps_intent_out_of_bm25() {
     );
 }
 
-/// An embedding provider that spends a known, dominant amount of time in
-/// `embed_batch`, so the embedding stage is separable from the storage stages
-/// by measurement rather than by inspection.
+/// An embedding provider that spends a caller-chosen amount of time in
+/// `embed_batch`. A zero delay leaves the code path identical, so two runs
+/// differ only by the delay and the stage timings can be compared against each
+/// other instead of against an absolute bound.
 struct SlowProvider {
     inner: crate::embedding::test_helpers::MockProvider,
     delay: std::time::Duration,
@@ -474,24 +475,20 @@ impl crate::embedding::EmbeddingProvider for SlowProvider {
     }
 }
 
-// Regression for issue #105: `embedding` and `vector` were both assigned the
-// span that covers the embedding, the store opens, the KNN query and
-// hydration, so `--timing` printed one measurement twice.
-#[tokio::test]
-async fn search_hybrid_reports_embedding_and_vector_as_separate_spans() {
-    use crate::embedding::test_helpers::MockProvider;
-
-    let tmp = tempfile::tempdir().unwrap();
-    let (index_dir, dim) = setup_test_index(tmp.path()).await;
-
-    let delay = std::time::Duration::from_millis(300);
+/// Run one `search_hybrid` against `index_dir` with a provider that sleeps
+/// `delay`, returning `(embedding, vector)`.
+async fn timed_hybrid_search(
+    index_dir: &std::path::Path,
+    dim: usize,
+    delay: std::time::Duration,
+) -> (std::time::Duration, std::time::Duration) {
     let provider = SlowProvider {
-        inner: MockProvider::new(dim),
+        inner: crate::embedding::test_helpers::MockProvider::new(dim),
         delay,
     };
 
     let (_results, timings) = search_hybrid(
-        &index_dir,
+        index_dir,
         &provider,
         "authenticate",
         "authenticate",
@@ -504,16 +501,73 @@ async fn search_hybrid_reports_embedding_and_vector_as_separate_spans() {
     .await
     .unwrap();
 
-    let embedding = timings.embedding.expect("embedding stage must be reported");
-    let vector = timings.vector.expect("vector stage must be reported");
+    (
+        timings.embedding.expect("embedding stage must be reported"),
+        timings.vector.expect("vector stage must be reported"),
+    )
+}
 
+// Regression for issue #105: `embedding` and `vector` were both assigned the
+// span that covers the embedding, the store opens, the KNN query and
+// hydration, so `--timing` printed one measurement twice.
+//
+// The property is that the embedding cost is charged to `embedding` and
+// excluded from `vector`, which is a statement about where added cost lands,
+// not about how long anything takes. Asserting it as a difference between two
+// otherwise identical runs keeps it off the wall clock of a machine we do not
+// control.
+#[tokio::test]
+async fn search_hybrid_charges_embedding_delay_to_embedding_not_vector() {
+    let tmp = tempfile::tempdir().unwrap();
+    let (index_dir, dim) = setup_test_index(tmp.path()).await;
+
+    let delay = std::time::Duration::from_millis(300);
+
+    // Discarded: the first search on a fresh index pays cold page-cache and
+    // file-open costs that later ones do not, and those would otherwise land
+    // entirely on whichever run went first and skew the comparison.
+    timed_hybrid_search(&index_dir, dim, std::time::Duration::ZERO).await;
+
+    let (baseline_embedding, baseline_vector) =
+        timed_hybrid_search(&index_dir, dim, std::time::Duration::ZERO).await;
+    let (delayed_embedding, delayed_vector) = timed_hybrid_search(&index_dir, dim, delay).await;
+
+    // `vector` is the remainder of the span after `embedding` is subtracted, so
+    // the delay has to land on exactly one of them and both bounds are the same
+    // question asked from either side. Half the delay is the widest tolerance
+    // that still answers it: under the original bug the full delay lands on
+    // both stages, so `vector` grows by ~300 ms and has to come in under 150 ms
+    // to pass. That leaves 150 ms of headroom for scheduler and I/O jitter on
+    // storage work that takes well under a millisecond against this fixture,
+    // while still failing any split that misattributes more than half the
+    // embedding cost.
+    let tolerance = delay / 2;
+
+    let embedding_growth = delayed_embedding.saturating_sub(baseline_embedding);
     assert!(
-        embedding >= delay,
-        "embedding must carry the provider cost: {embedding:?} < {delay:?}"
+        embedding_growth >= delay - tolerance,
+        "embedding must absorb the provider delay: grew {embedding_growth:?} \
+         (baseline {baseline_embedding:?}, delayed {delayed_embedding:?}), \
+         expected at least {:?}",
+        delay - tolerance
     );
+
+    let vector_growth = delayed_vector.saturating_sub(baseline_vector);
     assert!(
-        vector < delay,
-        "vector must exclude the provider cost: {vector:?} >= {delay:?}"
+        vector_growth < tolerance,
+        "vector must exclude the provider delay: grew {vector_growth:?} \
+         (baseline {baseline_vector:?}, delayed {delayed_vector:?}), \
+         expected under {tolerance:?}"
+    );
+
+    // Excluding the embedding must not empty the stage: the store opens, the
+    // KNN query and hydration are still charged to `vector`. Without this, a
+    // split that assigned the whole span to `embedding` would satisfy both
+    // growth bounds.
+    assert!(
+        baseline_vector > std::time::Duration::ZERO && delayed_vector > std::time::Duration::ZERO,
+        "vector must still carry the storage cost: \
+         baseline {baseline_vector:?}, delayed {delayed_vector:?}"
     );
 }
 

--- a/crates/vera-core/src/retrieval/hybrid_tests.rs
+++ b/crates/vera-core/src/retrieval/hybrid_tests.rs
@@ -452,10 +452,9 @@ async fn search_hybrid_keeps_intent_out_of_bm25() {
     );
 }
 
-/// An embedding provider that spends a caller-chosen amount of time in
-/// `embed_batch`. A zero delay leaves the code path identical, so two runs
-/// differ only by the delay and the stage timings can be compared against each
-/// other instead of against an absolute bound.
+/// An embedding provider that spends a known amount of time in `embed_batch`,
+/// so the model cost dominates the span the storage stages share with it and
+/// its attribution is decidable from the reported stages alone.
 struct SlowProvider {
     inner: crate::embedding::test_helpers::MockProvider,
     delay: std::time::Duration,
@@ -475,20 +474,31 @@ impl crate::embedding::EmbeddingProvider for SlowProvider {
     }
 }
 
-/// Run one `search_hybrid` against `index_dir` with a provider that sleeps
-/// `delay`, returning `(embedding, vector)`.
-async fn timed_hybrid_search(
-    index_dir: &std::path::Path,
-    dim: usize,
-    delay: std::time::Duration,
-) -> (std::time::Duration, std::time::Duration) {
+// Regression for issue #105: `embedding` and `vector` were both assigned the
+// span that covers the embedding, the store opens, the KNN query and
+// hydration, so `--timing` printed one measurement twice.
+//
+// Both stages are cut from one span nested inside the call, so their sum is
+// that span and can never exceed the wall time of the call itself unless a
+// cost is counted twice. Measuring that outer time in the test turns the
+// property into containment rather than a bound on how long anything takes:
+// there is no tolerance to choose, and a machine slow enough to stretch the
+// storage work stretches the outer time with it, so load widens the bound
+// instead of tightening it.
+#[tokio::test]
+async fn search_hybrid_charges_embedding_delay_to_embedding_not_vector() {
+    let tmp = tempfile::tempdir().unwrap();
+    let (index_dir, dim) = setup_test_index(tmp.path()).await;
+
+    let delay = std::time::Duration::from_millis(300);
     let provider = SlowProvider {
         inner: crate::embedding::test_helpers::MockProvider::new(dim),
         delay,
     };
 
+    let started = std::time::Instant::now();
     let (_results, timings) = search_hybrid(
-        index_dir,
+        &index_dir,
         &provider,
         "authenticate",
         "authenticate",
@@ -500,74 +510,36 @@ async fn timed_hybrid_search(
     )
     .await
     .unwrap();
+    let total = started.elapsed();
 
-    (
-        timings.embedding.expect("embedding stage must be reported"),
-        timings.vector.expect("vector stage must be reported"),
-    )
-}
+    let embedding = timings.embedding.expect("embedding stage must be reported");
+    let vector = timings.vector.expect("vector stage must be reported");
 
-// Regression for issue #105: `embedding` and `vector` were both assigned the
-// span that covers the embedding, the store opens, the KNN query and
-// hydration, so `--timing` printed one measurement twice.
-//
-// The property is that the embedding cost is charged to `embedding` and
-// excluded from `vector`, which is a statement about where added cost lands,
-// not about how long anything takes. Asserting it as a difference between two
-// otherwise identical runs keeps it off the wall clock of a machine we do not
-// control.
-#[tokio::test]
-async fn search_hybrid_charges_embedding_delay_to_embedding_not_vector() {
-    let tmp = tempfile::tempdir().unwrap();
-    let (index_dir, dim) = setup_test_index(tmp.path()).await;
-
-    let delay = std::time::Duration::from_millis(300);
-
-    // Discarded: the first search on a fresh index pays cold page-cache and
-    // file-open costs that later ones do not, and those would otherwise land
-    // entirely on whichever run went first and skew the comparison.
-    timed_hybrid_search(&index_dir, dim, std::time::Duration::ZERO).await;
-
-    let (baseline_embedding, baseline_vector) =
-        timed_hybrid_search(&index_dir, dim, std::time::Duration::ZERO).await;
-    let (delayed_embedding, delayed_vector) = timed_hybrid_search(&index_dir, dim, delay).await;
-
-    // `vector` is the remainder of the span after `embedding` is subtracted, so
-    // the delay has to land on exactly one of them and both bounds are the same
-    // question asked from either side. Half the delay is the widest tolerance
-    // that still answers it: under the original bug the full delay lands on
-    // both stages, so `vector` grows by ~300 ms and has to come in under 150 ms
-    // to pass. That leaves 150 ms of headroom for scheduler and I/O jitter on
-    // storage work that takes well under a millisecond against this fixture,
-    // while still failing any split that misattributes more than half the
-    // embedding cost.
-    let tolerance = delay / 2;
-
-    let embedding_growth = delayed_embedding.saturating_sub(baseline_embedding);
+    // `sleep` never returns early, so this is a property of the provider rather
+    // than of the machine: the model cost is charged to `embedding` in full.
     assert!(
-        embedding_growth >= delay - tolerance,
-        "embedding must absorb the provider delay: grew {embedding_growth:?} \
-         (baseline {baseline_embedding:?}, delayed {delayed_embedding:?}), \
-         expected at least {:?}",
-        delay - tolerance
+        embedding >= delay,
+        "embedding must carry the provider cost: {embedding:?} < {delay:?}"
     );
 
-    let vector_growth = delayed_vector.saturating_sub(baseline_vector);
+    // Together with the bound above this pins `vector` under `total - delay`,
+    // leaving it only the cost outside the span to hide in, a few milliseconds
+    // against this fixture. So a split that misattributes a material part of
+    // the embedding fails too, not only one that charges the whole of it twice.
     assert!(
-        vector_growth < tolerance,
-        "vector must exclude the provider delay: grew {vector_growth:?} \
-         (baseline {baseline_vector:?}, delayed {delayed_vector:?}), \
-         expected under {tolerance:?}"
+        embedding + vector <= total,
+        "stages must partition the search, not double-count it: \
+         embedding {embedding:?} + vector {vector:?} exceeds the {total:?} the \
+         whole search took"
     );
 
     // Excluding the embedding must not empty the stage: the store opens, the
     // KNN query and hydration are still charged to `vector`. Without this, a
     // split that assigned the whole span to `embedding` would satisfy both
-    // growth bounds.
+    // bounds above.
     assert!(
-        baseline_vector > std::time::Duration::ZERO && delayed_vector > std::time::Duration::ZERO,
-        "vector must still carry the storage cost: \
-         baseline {baseline_vector:?}, delayed {delayed_vector:?}"
+        vector > std::time::Duration::ZERO,
+        "vector must still carry the storage cost: {vector:?}"
     );
 }
 

--- a/crates/vera-core/src/retrieval/hybrid_tests.rs
+++ b/crates/vera-core/src/retrieval/hybrid_tests.rs
@@ -478,7 +478,7 @@ impl crate::embedding::EmbeddingProvider for SlowProvider {
 // span that covers the embedding, the store opens, the KNN query and
 // hydration, so `--timing` printed one measurement twice.
 //
-// The split itself is asserted by `split_vector_span_partitions_the_span`
+// The split itself is asserted by `charge_vector_span_partitions_the_span`
 // below, on values rather than on a clock. It has to be, because the span the
 // two stages are cut from is internal to `search_hybrid` and no measurement
 // available to this test stands in for it. The wall time of the whole call
@@ -556,22 +556,36 @@ async fn search_hybrid_charges_embedding_delay_to_embedding_not_vector() {
 // so this asserts the cut where it is decidable: given a span and the embedding
 // measurement taken inside it, the two stages must partition the span. Under
 // the bug each stage got the whole span, which this rejects without a clock.
+//
+// `charge_vector_span` writes both `HybridTimings` fields rather than returning
+// two values for the caller to assign, so this test covers the assignment as
+// well as the arithmetic. That is deliberate. While the caller did the
+// assigning, a caller that kept the remainder on `vector` but charged the whole
+// span to `embedding` passed this test and the one above together, which is a
+// second way to make `embedding` unattributable. The three durations here are
+// distinct so neither field can hold the whole span by coincidence.
 #[test]
-fn split_vector_span_partitions_the_span() {
+fn charge_vector_span_partitions_the_span() {
     let span = std::time::Duration::from_millis(500);
     let embed = std::time::Duration::from_millis(300);
 
+    let mut timings = HybridTimings::default();
+    charge_vector_span(&mut timings, span, Some(embed));
+
     assert_eq!(
-        split_vector_span(span, Some(embed)),
-        (Some(embed), std::time::Duration::from_millis(200)),
+        (timings.embedding, timings.vector),
+        (Some(embed), Some(std::time::Duration::from_millis(200))),
         "embedding takes the model cost and vector takes the remainder"
     );
 
     // A vector search that failed reports no embedding, so the whole span is
     // storage cost rather than being dropped.
+    let mut failed = HybridTimings::default();
+    charge_vector_span(&mut failed, span, None);
+
     assert_eq!(
-        split_vector_span(span, None),
-        (None, span),
+        (failed.embedding, failed.vector),
+        (None, Some(span)),
         "an unmeasured embedding leaves the whole span on vector"
     );
 }

--- a/crates/vera-core/src/retrieval/hybrid_tests.rs
+++ b/crates/vera-core/src/retrieval/hybrid_tests.rs
@@ -485,6 +485,14 @@ impl crate::embedding::EmbeddingProvider for SlowProvider {
 // there is no tolerance to choose, and a machine slow enough to stretch the
 // storage work stretches the outer time with it, so load widens the bound
 // instead of tightening it.
+//
+// Containment only decides the split while the outer time is the vector arm's.
+// BM25 runs concurrently and is awaited after it, so a BM25 arm that outlasts
+// the vector arm carries the outer time past the span the two stages are cut
+// from and leaves room for a doubled pair to fit inside it: measured, a 748 ms
+// BM25 against a 334 ms vector span lets the pre-fix code report 334 ms twice
+// and pass containment on 668 ms. The guard below rejects such a run rather
+// than deciding the split on it.
 #[tokio::test]
 async fn search_hybrid_charges_embedding_delay_to_embedding_not_vector() {
     let tmp = tempfile::tempdir().unwrap();
@@ -514,6 +522,7 @@ async fn search_hybrid_charges_embedding_delay_to_embedding_not_vector() {
 
     let embedding = timings.embedding.expect("embedding stage must be reported");
     let vector = timings.vector.expect("vector stage must be reported");
+    let bm25 = timings.bm25.expect("bm25 stage must be reported");
 
     // `sleep` never returns early, so this is a property of the provider rather
     // than of the machine: the model cost is charged to `embedding` in full.
@@ -522,7 +531,21 @@ async fn search_hybrid_charges_embedding_delay_to_embedding_not_vector() {
         "embedding must carry the provider cost: {embedding:?} < {delay:?}"
     );
 
-    // Together with the bound above this pins `vector` under `total - delay`,
+    // Both arms start together, so a BM25 arm that fits inside the reported
+    // pair finished no later than the vector arm and the await that follows it
+    // returned immediately, leaving `total` equal to the vector arm plus setup
+    // and fusion. That is what makes the containment below a statement about
+    // the split rather than about how long BM25 took. Rejecting the run is the
+    // right outcome here: the measurement cannot decide the property, and a
+    // pass would be the vacuous one.
+    assert!(
+        bm25 <= embedding + vector,
+        "BM25 outlasted the stages it overlaps, so the {total:?} the search \
+         took is BM25's wall time and cannot decide the split: bm25 {bm25:?} > \
+         embedding {embedding:?} + vector {vector:?}"
+    );
+
+    // Together with the bounds above this pins `vector` under `total - delay`,
     // leaving it only the cost outside the span to hide in, a few milliseconds
     // against this fixture. So a split that misattributes a material part of
     // the embedding fails too, not only one that charges the whole of it twice.

--- a/crates/vera-core/src/retrieval/vector.rs
+++ b/crates/vera-core/src/retrieval/vector.rs
@@ -6,6 +6,8 @@
 //! metadata store. Finds semantically related code even when query terms
 //! don't appear literally in results (e.g., "memory allocation" finds `alloc`).
 
+use std::time::{Duration, Instant};
+
 use anyhow::Result;
 use tracing::{debug, warn};
 
@@ -46,12 +48,33 @@ pub async fn search_vector_with_stores(
     query: &str,
     limit: usize,
 ) -> Result<Vec<SearchResult>, VectorSearchError> {
+    search_vector_with_stores_timed(vector_store, metadata_store, provider, query, limit)
+        .await
+        .map(|(results, _)| results)
+}
+
+/// Like [`search_vector_with_stores`], but also reports how long the query
+/// embedding took.
+///
+/// The embedding call is nested inside the vector search, so a caller that
+/// reports per-stage timings cannot otherwise separate model cost from storage
+/// cost. The returned duration covers only [`generate_query_embedding`]; it is
+/// [`Duration::ZERO`] when `limit` is 0 and no embedding is generated.
+pub async fn search_vector_with_stores_timed(
+    vector_store: &VectorStore,
+    metadata_store: &MetadataStore,
+    provider: &impl EmbeddingProvider,
+    query: &str,
+    limit: usize,
+) -> Result<(Vec<SearchResult>, Duration), VectorSearchError> {
     if limit == 0 {
-        return Ok(Vec::new());
+        return Ok((Vec::new(), Duration::ZERO));
     }
 
     // 1. Generate query embedding.
+    let embed_start = Instant::now();
     let query_embedding = generate_query_embedding(provider, query, vector_store.dim()).await?;
+    let embed_elapsed = embed_start.elapsed();
 
     debug!(
         query = query,
@@ -122,7 +145,7 @@ pub async fn search_vector_with_stores(
         "vector search complete"
     );
 
-    Ok(results)
+    Ok((results, embed_elapsed))
 }
 
 /// Size the KNN request for a caller-selected pool, bounded by the backend cap.


### PR DESCRIPTION
## What was wrong

`search_hybrid` took a single `Instant` before opening the vector store and assigned the resulting span to both stages:

```rust
let vector_elapsed = embed_start.elapsed();
timings.embedding = Some(vector_elapsed);
timings.vector = Some(vector_elapsed);
```

That span covers the query embedding, both store opens, the KNN query and metadata hydration, so `--timing` printed one measurement twice.

## Why it matters

The two stages have different fixes. Query embedding is model cost. Store open, KNN and hydration are storage cost, which is where the candidate-pool and per-hit-query work sits. With one number for both, a change to either is unattributable.

## What changed

The embedding call is nested inside `search_vector_with_stores`, so the split has to start there rather than in `hybrid.rs`.

- `retrieval/vector.rs`: `search_vector_with_stores_timed` measures `generate_query_embedding` and returns the duration alongside the results. `search_vector_with_stores` keeps its existing signature and delegates, dropping the duration, so all other callers and tests are untouched.
- `retrieval/hybrid.rs`: `embedding` gets the embedding duration; `vector` gets the rest of the span. The two still sum to the same wall time as before.

Store-open cost is charged to `vector`, not given a field of its own. It is storage cost, it is small, and a third field would change the `--timing` output shape for everyone. If you would rather see it separately, say so and I will add it.

When vector search fails there is no embedding measurement, so `embedding` reports `n/a` and the whole span stays on `vector`. Previously it reported a duplicate of `vector`.

## Verification

Control, released binary `vera 1.0.0`, and the branch, same index and same query (`vera search "how are per stage timings recorded" --timing --limit 3`), both warm:

```
released 1.0.0            branch
embedding: 93ms           embedding: 39ms
bm25: 14ms                bm25: 7ms
vector: 93ms              vector: 24ms
```

### The split is asserted on values, not on a clock

Three earlier revisions of the regression test tried to decide the split by measurement, and each was unsound in a different way. Review found the third; measurement then ruled out the whole family.

The wall time of the `search_hybrid` call is not the span the two stages are cut from. BM25 runs concurrently with the vector arm and is awaited after it, so whenever BM25 is the slower arm that wall time is BM25's. Guarding on the reported BM25 stage does not repair the substitution: `bm25_elapsed` starts inside the `spawn_blocking` closure, so it measures the arm's duration and not when the arm finished relative to the vector arm. Any queue delay before the closure runs lands in the call's wall time without appearing in the guard.

The remaining family of bounds is ruled out by measurement rather than by argument. Instrumented on this fixture at 89ba35f, `vector` is 3.0 ms standalone and 62.2 ms inside the 795-test suite; an earlier run of the same fixture recorded **262.7 ms**, against the 300 ms sleep the test injects. At the loaded figure that is a 1.14x margin. An absolute bound on `vector` fails at 300 ms; a zero-delay baseline with a tolerance of half the delay fails at 150 ms of growth. Both sit on the wrong side of that number, so neither is added back.

So the split is asserted where it is decidable. `charge_vector_span` in `hybrid.rs` names the cut that was previously inline, and `charge_vector_span_partitions_the_span` pins both stages for a given span and embedding measurement, with no fixture, no clock and no tolerance. It also pins the failure case, where no embedding was measured and the whole span stays on `vector`.

`search_hybrid_charges_embedding_delay_to_embedding_not_vector` still runs `search_hybrid` once against the temp-index fixture with a provider that sleeps 300 ms in `embed_batch`, and now asserts only what does not depend on the machine:

- `embedding >= delay`, which holds anywhere because `sleep` never returns early
- `vector > 0`, so taking the embedding out does not empty the storage stage
- `embedding != vector`, the symptom #105 was filed for

The presence assertion precedes the non-identity one, since a zeroed `vector` would otherwise satisfy it.

### The assignment lives inside the tested unit, not at the call site

Review (cubic, P2) found that those two tests still passed together under a caller that kept the remainder on `vector` but charged the whole span to `embedding`. Injected on daab5a3 with the helper untouched, that caller reported `embedding=304.599291ms vector=3.084749ms` against a clean `embedding=301.853166ms vector=2.999959ms`, and both tests passed: 304.6 ms is still at or above the 300 ms delay, `vector` is still positive, and the two still differ. The extra 2.7 ms is the storage cost charged to `embedding` as well, which is #105's failure mode in a second shape.

No wall-clock assertion at the caller separates those cases, for the reason measured above: what distinguishes them is the storage cost, and on this fixture that ranges from 3.0 ms to 262.7 ms while the delay is fixed at 300 ms. A margin tight enough to catch the corruption under load is tighter than the sleep's own overshoot under load; a margin loose enough to survive it misses the corruption entirely in a standalone run. A zero-delay baseline does not help either, since the corruption adds the storage cost to `embedding` in both runs.

So the assignment moved into the tested unit rather than being tested around. `charge_vector_span(&mut timings, vector_span, embed_elapsed)` writes both `HybridTimings` fields itself, the call site is one line with no attribution decision left in it to get wrong, and the unit test asserts the two fields rather than a tuple a caller could misplace. What remains at the call site is which span it passes, and there is exactly one `Instant` covering the vector arm.

### Reinjection

The caller-side defect above, reinjected at the new site as `timings.embedding = Some(vector_span)`:

```
test retrieval::hybrid::tests::charge_vector_span_partitions_the_span ... FAILED
test retrieval::hybrid::tests::search_hybrid_charges_embedding_delay_to_embedding_not_vector ... ok

assertion `left == right` failed: embedding takes the model cost and vector takes the remainder
  left: (Some(500ms), Some(200ms))
 right: (Some(300ms), Some(200ms))
```

The integration test still passes there, which is the point: it was never going to catch that one.

The original #105 defect, both stages given the whole span, still fails both:

```
---- charge_vector_span_partitions_the_span stdout ----
assertion `left == right` failed: embedding takes the model cost and vector takes the remainder
  left: (Some(500ms), Some(500ms))
 right: (Some(300ms), Some(200ms))

---- search_hybrid_charges_embedding_delay_to_embedding_not_vector stdout ----
assertion `left != right` failed: the two stages must not be one measurement printed twice
  left: 306.490875ms
 right: 306.490875ms
```

The pure test fails without running the fixture at all, so it cannot be flaked by load.

```
cargo fmt --check                                                  clean
cargo build --workspace                                            clean
cargo test -p vera-core --lib                                      795 passed, 0 failed
cargo test -p vera-cli --bin vera                                   97 passed, 0 failed
cargo clippy -p vera-core --lib 2>&1 | grep -cE "^warning: [a-z]"     5 (unchanged from master)
```

Fixes #105

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Splits query embedding and vector search timing so `--timing` attributes model vs. storage cost correctly. Previously both stages reported the same span; now embedding is measured and vector gets the remainder (store opens, KNN, hydration). On vector failure, `embedding` is n/a and `vector` carries the full span. Output keys unchanged.

- Add `search_vector_with_stores_timed(...)-> (Vec<SearchResult>, Duration)`; keep `search_vector_with_stores` as a delegating wrapper. When `limit = 0`, return zero embedding duration.
- In `search_hybrid`, time the vector arm and call `charge_vector_span` to write `timings.embedding` and `timings.vector` as a true partition of the span, preventing double-charging at call sites.
- Tests: replace clock-based bounds with value-based assertions. Add `charge_vector_span_partitions_the_span` (pure partition test) and `search_hybrid_charges_embedding_delay_to_embedding_not_vector` (provider delay reaches `embedding`, `vector` stays > 0, and the two differ).

<sup>Written for commit 89ba35fe4b7ff71046cb8019a9afba38f79f4150. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/VeraTools/Vera/pull/113?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added separate timing metrics for query embedding and vector search processing.
  * Search timing now accurately reflects embedding delays and vector-processing duration.
  * Zero-limit searches report timing consistently.

* **Bug Fixes**
  * Improved timing accuracy for hybrid retrieval, including failed searches and storage operations.
  * Prevented embedding delays from being double-counted in vector timing.
  * Preserved existing filtering and search behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


