### PR TITLE
perf(cli): let the update cache answer the install method before detecting it

### DIFF
--- a/crates/vera-cli/src/update_check.rs
+++ b/crates/vera-cli/src/update_check.rs
@@ -263,81 +263,103 @@ fn print_binary_nudge(latest: &str, status: &BinaryVersionStatus) {
 }
 
 pub fn binary_version_status(force_refresh: bool) -> BinaryVersionStatus {
-    let install_method = resolve_install_method();
-    let cache_file = match cache_path() {
-        Some(path) => path,
-        None => {
-            return BinaryVersionStatus {
-                current_version: CURRENT_VERSION,
-                latest_version: None,
-                install_method: install_method.install_method,
-                install_method_source: install_method.source,
-                detected_install_methods: install_method.detected_install_methods,
-                source: VersionCheckSource::Unavailable,
-            };
-        }
-    };
-
     let now = SystemTime::now()
         .duration_since(SystemTime::UNIX_EPOCH)
         .unwrap_or_default()
         .as_secs();
+    binary_version_status_inner(cache_path(), force_refresh, now, &resolve_install_method)
+}
+
+/// `binary_version_status` with the cache location, the clock and the install
+/// method fallback injected, so tests can drive it without touching `~/.vera`
+/// or spawning package managers.
+///
+/// `resolve` is only called when the cache cannot answer. That matters: the
+/// fallback ends in `detect_install_methods`, which spawns `npm`, `bun`, `pip`
+/// and `uv`, and `print_nudges` runs synchronously before the process exits.
+fn binary_version_status_inner(
+    cache_file: Option<PathBuf>,
+    force_refresh: bool,
+    now: u64,
+    resolve: &dyn Fn() -> InstallMethodResolution,
+) -> BinaryVersionStatus {
+    let Some(cache_file) = cache_file else {
+        return status_from(None, resolve(), VersionCheckSource::Unavailable);
+    };
+
     let cached = load_cache(&cache_file);
 
     if !force_refresh {
         if let Some(cached) = cached.as_ref() {
             if now.saturating_sub(cached.checked_at_secs) < CHECK_INTERVAL.as_secs() {
-                return BinaryVersionStatus {
-                    current_version: CURRENT_VERSION,
-                    latest_version: Some(cached.latest_version.clone()),
-                    install_method: cached
-                        .install_method
-                        .clone()
-                        .or(install_method.install_method.clone()),
-                    install_method_source: install_method.source,
-                    detected_install_methods: install_method.detected_install_methods.clone(),
-                    source: VersionCheckSource::Cache,
-                };
+                let resolution = cached_install_method(cached).unwrap_or_else(resolve);
+                return status_from(
+                    Some(cached.latest_version.clone()),
+                    resolution,
+                    VersionCheckSource::Cache,
+                );
             }
         }
     }
+
+    let resolution = resolve();
 
     if let Some(latest) = fetch_latest_version() {
         let cache = UpdateCache {
             latest_version: latest.clone(),
             checked_at_secs: now,
-            install_method: install_method.install_method.clone(),
+            install_method: resolution.install_method.clone(),
         };
         let _ = save_cache(&cache_file, &cache);
-        return BinaryVersionStatus {
-            current_version: CURRENT_VERSION,
-            latest_version: Some(latest),
-            install_method: install_method.install_method.clone(),
-            install_method_source: install_method.source,
-            detected_install_methods: install_method.detected_install_methods.clone(),
-            source: VersionCheckSource::Live,
-        };
+        return status_from(Some(latest), resolution, VersionCheckSource::Live);
     }
 
     if let Some(cached) = cached {
         return BinaryVersionStatus {
             current_version: CURRENT_VERSION,
             latest_version: Some(cached.latest_version),
-            install_method: cached.install_method.or(install_method.install_method),
-            install_method_source: install_method.source,
-            detected_install_methods: install_method.detected_install_methods,
+            install_method: cached.install_method.or(resolution.install_method),
+            install_method_source: resolution.source,
+            detected_install_methods: resolution.detected_install_methods,
             source: VersionCheckSource::Cache,
         };
     }
 
+    status_from(None, resolution, VersionCheckSource::Unavailable)
+}
+
+fn status_from(
+    latest_version: Option<String>,
+    resolution: InstallMethodResolution,
+    source: VersionCheckSource,
+) -> BinaryVersionStatus {
     BinaryVersionStatus {
         current_version: CURRENT_VERSION,
-        latest_version: None,
-        install_method: install_method.install_method,
-        install_method_source: install_method.source,
-        detected_install_methods: install_method.detected_install_methods,
-        source: VersionCheckSource::Unavailable,
+        latest_version,
+        install_method: resolution.install_method,
+        install_method_source: resolution.source,
+        detected_install_methods: resolution.detected_install_methods,
+        source,
     }
+}
+
+/// Rebuild an install method resolution from a cache entry, so a fresh cache
+/// answers without re-running detection.
+///
+/// The source is reported as `Heuristic`. `save_cache` only ever stores a
+/// method that `resolve_install_method` returned as `Some`, which narrows the
+/// original source to `Provenance` or `Heuristic`, but the cache does not
+/// record which, so this reports the weaker of the two. `can_apply_update` and
+/// `suggested_update_command` treat them identically; the only callers that
+/// surface the distinction, `vera upgrade` and `vera doctor`, pass
+/// `force_refresh = true` and never reach this branch.
+fn cached_install_method(cached: &UpdateCache) -> Option<InstallMethodResolution> {
+    let method = cached.install_method.clone()?;
+    Some(InstallMethodResolution {
+        detected_install_methods: vec![method.clone()],
+        install_method: Some(method),
+        source: InstallMethodSource::Heuristic,
+    })
 }
 
 pub fn suggested_update_command(install_method: Option<&str>) -> String {
@@ -553,6 +575,7 @@ fn save_cache(path: &Path, cache: &UpdateCache) -> Option<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::cell::Cell;
 
     #[test]
     fn is_newer_works() {
@@ -667,6 +690,91 @@ mod tests {
             source: VersionCheckSource::Live,
         };
         assert!(!status.can_apply_update());
+    }
+
+    /// A resolver that records how often it ran and reports nothing, standing in
+    /// for `resolve_install_method` without spawning any package manager.
+    fn counting_resolver(calls: &Cell<usize>) -> impl Fn() -> InstallMethodResolution + '_ {
+        || {
+            calls.set(calls.get() + 1);
+            InstallMethodResolution {
+                install_method: None,
+                detected_install_methods: Vec::new(),
+                source: InstallMethodSource::Unknown,
+            }
+        }
+    }
+
+    fn write_cache(dir: &Path, install_method: Option<&str>, checked_at_secs: u64) -> PathBuf {
+        let path = dir.join("update-check.json");
+        save_cache(
+            &path,
+            &UpdateCache {
+                latest_version: "99.0.0".to_string(),
+                checked_at_secs,
+                install_method: install_method.map(str::to_string),
+            },
+        )
+        .expect("cache written");
+        path
+    }
+
+    #[test]
+    fn fresh_cache_with_install_method_skips_detection() {
+        let dir = tempfile::tempdir().unwrap();
+        let checked_at = 1_700_000_000;
+        let cache_file = write_cache(dir.path(), Some("npm"), checked_at);
+
+        let calls = Cell::new(0);
+        let status = binary_version_status_inner(
+            Some(cache_file),
+            false,
+            checked_at + 60,
+            &counting_resolver(&calls),
+        );
+
+        assert_eq!(
+            calls.get(),
+            0,
+            "install method detection ran even though a fresh cache carried the method"
+        );
+        assert_eq!(status.source, VersionCheckSource::Cache);
+        assert_eq!(status.latest_version.as_deref(), Some("99.0.0"));
+        assert_eq!(status.install_method.as_deref(), Some("npm"));
+        assert_eq!(status.install_method_source, InstallMethodSource::Heuristic);
+        assert_eq!(status.detected_install_methods, vec!["npm".to_string()]);
+        assert!(status.can_apply_update());
+    }
+
+    #[test]
+    fn fresh_cache_without_install_method_falls_back_to_detection() {
+        let dir = tempfile::tempdir().unwrap();
+        let checked_at = 1_700_000_000;
+        let cache_file = write_cache(dir.path(), None, checked_at);
+
+        let calls = Cell::new(0);
+        let status = binary_version_status_inner(
+            Some(cache_file),
+            false,
+            checked_at + 60,
+            &counting_resolver(&calls),
+        );
+
+        assert_eq!(calls.get(), 1);
+        assert_eq!(status.source, VersionCheckSource::Cache);
+        assert_eq!(status.install_method, None);
+        assert_eq!(status.install_method_source, InstallMethodSource::Unknown);
+    }
+
+    #[test]
+    fn missing_cache_path_still_resolves_the_install_method() {
+        let calls = Cell::new(0);
+        let status =
+            binary_version_status_inner(None, false, 1_700_000_000, &counting_resolver(&calls));
+
+        assert_eq!(calls.get(), 1);
+        assert_eq!(status.source, VersionCheckSource::Unavailable);
+        assert_eq!(status.latest_version, None);
     }
 
     #[test]


### PR DESCRIPTION
Fixes #101

## Cause

`crates/vera-cli/src/update_check.rs`, `binary_version_status`, resolved the install method as its **first statement**:

```rust
pub fn binary_version_status(force_refresh: bool) -> BinaryVersionStatus {
    let install_method = resolve_install_method();   // <- before the cache is read
    let cache_file = ...
    if !force_refresh { /* cache short-circuit */ }
```

With no `install_method` in `~/.vera/install.json` or `~/.vera/config.json`, `resolve_install_method` falls through to `detect_install_methods`, which spawns `npm`, `bun`, `pip` and `uv`. The cache short-circuited only the GitHub call, never that. `print_nudges` is called synchronously from `main.rs` before `process::exit`, so it is wall clock the caller waits on.

The answer was already stored: `save_cache` writes `install_method`, and the cache branch read it back with `cached.install_method.clone().or(...)` — and then re-detected anyway.

## Change

Consult the cache first; call the resolver only when the cache cannot answer.

- `binary_version_status` now delegates to `binary_version_status_inner`, which takes the cache path, the clock and the install-method resolver as parameters. Same behaviour, but drivable from a test without `~/.vera` and without spawning anything.
- `cached_install_method` rebuilds an `InstallMethodResolution` from a fresh cache entry that carries a method.
- Everything else is unchanged: `force_refresh = true` (`vera doctor`, `vera upgrade`) still resolves and fetches exactly as before, and the stale-cache and no-cache paths still detect.

### What the cache branch reports

`install_method` is unchanged — the cache already won there.

`install_method_source` is reported as `Heuristic`. The cache does not record the source, but `save_cache` only ever stores a method that `resolve_install_method` returned as `Some`, which narrows the original to `Provenance` or `Heuristic`, so this reports the weaker of the two. `can_apply_update` and `suggested_update_command` treat them identically, and the only callers that surface the distinction (`vera upgrade`, `vera doctor`) pass `force_refresh = true` and never reach this branch.

`detected_install_methods` becomes `vec![method]`, matching what `resolve_install_method` already returns for a method read from `install.json` or `config.json` rather than from detection.

### Side effect: the cache branch is now self-consistent

Previously it paired a **cached** `install_method` with the source and detected list from a **fresh** resolution, which could disagree. Observed on `master` with a fresh cache carrying `"npm"` and nothing detectable:

```
master: hint: vera v99.0.0 is available (current: v0.4.0). Update: `vera upgrade`
branch: hint: vera v99.0.0 is available (current: v0.4.0). Update: `npm install -g @vera-ai/cli@latest && npx @vera-ai/cli install`
```

`master` knew the method was npm and still printed the generic command, because `can_apply_update()` saw `install_method_source: Unknown` from the live detection.

## Measured

Apple M4, `vera grep` in a directory with no index, isolated `HOME` so nothing touched real state, `master` at `e3d79b3` and this branch built from the same tree and run **interleaved** so both saw the same machine load. 11 runs each, sorted, median in bold.

| condition | master e3d79b3 | this branch |
|---|---|---|
| `VERA_NO_UPDATE_CHECK=1` | 4 4 4 4 4 5 5 5 6 8 17 → **5 ms** | 4 4 5 5 5 5 5 6 6 7 · → **5 ms** |
| fresh 24h cache, `install_method: "npm"` | 289 290 292 292 293 293 302 309 326 330 402 → **293 ms** | 5 5 5 5 5 5 5 5 6 6 6 → **5 ms** |
| fresh 24h cache, `install_method: null` | 288 289 292 293 293 293 294 295 299 303 304 → **293 ms** | 292 292 294 294 294 296 298 299 313 314 372 → **296 ms** |
| `config.json` records the method | 4 4 4 4 4 4 4 4 4 5 5 → **4 ms** | 4 4 4 4 4 5 5 5 5 5 5 → **5 ms** |

The npm-cached row is the fix: **293 ms → 5 ms**, and it is the row the issue is about. One 1693 ms outlier in the first row is dropped from the branch column; the machine was under concurrent `cargo build` load and it does not move the median.

Subprocess costs on this machine, 3 reps each: `npm list -g --depth=0` 481/504/537 ms, `pip show` 160/172/277 ms, `uv pip show` 13/14/16 ms, `bun pm ls -g` 10/20/23 ms. These are higher than the numbers in the issue; the totals differ but the shape is the same.

## Residual, deliberately not fixed here

Row 3 is unchanged: when the cached `install_method` is `null` the cache has nothing to answer with, so detection still runs on every command. That covers installs where detection genuinely finds nothing — cargo builds and manual installs — and installs where several package managers report vera (`Ambiguous`, which also stores `null`).

Fixing that means caching a negative detection result, which needs a new cache field and accepts a 24-hour window where a newly added package manager is not noticed by the nudge. That is a product call rather than a reordering, so it is left out. `vera upgrade` and `vera doctor` force-refresh and would be unaffected either way. Happy to add it if wanted.

## Verification

Reinjection, to confirm the test catches the real bug. Restoring the original ordering inside `binary_version_status_inner`:

```
thread 'update_check::tests::fresh_cache_with_install_method_skips_detection' panicked at
crates/vera-cli/src/update_check.rs:741:9:
assertion `left == right` failed: install method detection ran even though a fresh cache carried the method
  left: 1
 right: 0

test result: FAILED. 13 passed; 1 failed
```

The test also fails on the source, which the reinjected ordering reports as `Unknown` rather than `Heuristic`.

Checks on the branch:

- `cargo fmt --check` — clean
- `cargo test -p vera-cli --bin vera` — `100 passed; 0 failed`
- `cargo test -p vera-core --lib` — `793 passed; 0 failed`
- `cargo clippy -p vera-core --lib` — 5 warnings, all pre-existing (`pip_package_for_ep`, `CUDA_RUNTIME_LIBRARY_PREFIXES`, `parse_cuda_major_from_runtime_library_entry`, one unused import, one unused variable)
- `cargo clippy -p vera-cli --bin vera --all-targets` — no new warnings

The three new tests are hermetic: the cache path is a `tempfile::tempdir`, the clock is a parameter, and the resolver is a counting stub, so nothing reads or writes `~/.vera` and no package manager is spawned.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip install‑method detection when the update cache already stores it, so CLI nudges don’t spawn `npm`, `bun`, `pip`, or `uv` unnecessarily. Previously we resolved the install method before reading the cache; now we read the cache first and only detect if the cache can’t answer, cutting the cached `npm` case from ~293 ms to ~5 ms.

**Reviewer notes**
- Core logic moves into `binary_version_status_inner(cache_path, force_refresh, now, resolve)`; tests inject the cache path, clock, and resolver to avoid touching `~/.vera` or spawning subprocesses.
- Cache hit behavior: reconstructs a resolution via `cached_install_method`; reports `install_method_source: Heuristic` and `detected_install_methods: [method]`. This makes the cache branch self‑consistent and fixes incorrect generic upgrade hints when a cached method existed.
- Invariants: `force_refresh = true` still detects and fetches; cache miss or `install_method: null` still detects. No migration or config changes required.

<sup>Written for commit 64b1102024a2431d4f91002c299d4b259abbba91. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/VeraTools/Vera/pull/114?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved version status checks when cached installation information is available.
  * Added fallback handling when cached information is missing or unavailable.
  * Prevented unnecessary installation detection during fresh-cache checks.

* **Tests**
  * Expanded coverage for version resolution and cached status behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->