### PR TITLE
fix(parsing): advance chunk coverage monotonically past nested symbols

### DIFF
--- a/crates/vera-core/src/parsing/chunker.rs
+++ b/crates/vera-core/src/parsing/chunker.rs
@@ -93,7 +93,12 @@ pub fn chunks_from_symbols(
             chunk_index += 1;
         }
 
-        covered_end_row = sym_end + 1;
+        // Extractors emit a parent (impl, class, namespace) alongside its
+        // children, and symbols are sorted by start byte, so the parent is
+        // seen first. Advancing monotonically stops a child from rewinding
+        // coverage back inside the parent, which would make every span
+        // between children look like an uncovered gap.
+        covered_end_row = covered_end_row.max(sym_end + 1);
     }
 
     // Trailing gap after last symbol
@@ -584,6 +589,103 @@ mod tests {
         // First chunk should be the gap (imports)
         assert_eq!(chunks[0].symbol_type, Some(SymbolType::Block));
         assert!(chunks[0].content.contains("use std::io"));
+    }
+
+    #[test]
+    fn nested_children_emit_no_gap_chunks() {
+        // Extractors push the `impl` and each of its methods, sorted by start
+        // byte. The span between two methods and the impl's closing brace are
+        // already inside the parent chunk and must not be emitted again.
+        let source = "impl Token {\n    /// Create a token.\n    fn new() -> Self {\n        Self\n    }\n\n    /// Cancel the token.\n    fn cancel(&self) {}\n}\n";
+        let symbols = vec![
+            RawSymbol {
+                name: Some("Token".to_string()),
+                symbol_type: SymbolType::Block,
+                start_byte: 0,
+                end_byte: source.len(),
+                start_row: 0,
+                end_row: 8,
+            },
+            RawSymbol {
+                name: Some("new".to_string()),
+                symbol_type: SymbolType::Method,
+                start_byte: 40,
+                end_byte: 80,
+                start_row: 2,
+                end_row: 4,
+            },
+            RawSymbol {
+                name: Some("cancel".to_string()),
+                symbol_type: SymbolType::Method,
+                start_byte: 110,
+                end_byte: 130,
+                start_row: 7,
+                end_row: 7,
+            },
+        ];
+        let chunks = chunks_from_symbols(
+            &symbols,
+            source,
+            "token.rs",
+            Language::Rust,
+            &default_config(),
+        );
+
+        let names: Vec<_> = chunks.iter().map(|c| c.symbol_name.clone()).collect();
+        assert_eq!(
+            names,
+            vec![
+                Some("Token".to_string()),
+                Some("new".to_string()),
+                Some("cancel".to_string()),
+            ],
+            "only the parent and its two children should be chunked, got {chunks:?}"
+        );
+        assert!(
+            !chunks.iter().any(|c| c.content.trim() == "}"),
+            "the parent's closing brace must not become its own chunk"
+        );
+    }
+
+    #[test]
+    fn gap_after_nested_parent_still_captured() {
+        // Monotonic coverage must not swallow real code that follows the
+        // parent, only the spans the parent already covers.
+        let source = "impl Token {\n    fn new() -> Self {\n        Self\n    }\n}\n\nstatic REGISTRY: &str = \"tokens\";\n";
+        let symbols = vec![
+            RawSymbol {
+                name: Some("Token".to_string()),
+                symbol_type: SymbolType::Block,
+                start_byte: 0,
+                end_byte: 60,
+                start_row: 0,
+                end_row: 4,
+            },
+            RawSymbol {
+                name: Some("new".to_string()),
+                symbol_type: SymbolType::Method,
+                start_byte: 17,
+                end_byte: 55,
+                start_row: 1,
+                end_row: 3,
+            },
+        ];
+        let chunks = chunks_from_symbols(
+            &symbols,
+            source,
+            "token.rs",
+            Language::Rust,
+            &default_config(),
+        );
+
+        let trailing = chunks
+            .iter()
+            .find(|c| c.symbol_name.is_none())
+            .expect("trailing top-level code should still produce a gap chunk");
+        assert_eq!(trailing.symbol_type, Some(SymbolType::Block));
+        assert_eq!(trailing.line_start, 6);
+        assert_eq!(trailing.line_end, 7);
+        assert!(trailing.content.contains("static REGISTRY"));
     }
 
     #[test]

--- a/crates/vera-core/src/parsing/chunker.rs
+++ b/crates/vera-core/src/parsing/chunker.rs
@@ -678,6 +678,13 @@ mod tests {
             &default_config(),
         );
 
+        let names: Vec<_> = chunks.iter().map(|c| c.symbol_name.clone()).collect();
+        assert_eq!(
+            names,
+            vec![Some("Token".to_string()), Some("new".to_string()), None],
+            "the parent and its child must still be chunked before the trailing gap, got {chunks:?}"
+        );
+
         let trailing = chunks
             .iter()
             .find(|c| c.symbol_name.is_none())

--- a/crates/vera-core/src/parsing/tests.rs
+++ b/crates/vera-core/src/parsing/tests.rs
@@ -65,6 +65,31 @@ impl Point {
 }
 
 #[test]
+fn rust_impl_methods_emit_no_gap_chunks() {
+    let source = r#"impl CancellationToken {
+    /// Create a token.
+    fn new() -> Self {
+        Self
+    }
+
+    /// Cancel the token.
+    fn cancel(&self) {}
+}
+"#;
+    let chunks = parse(source, "cancellation.rs", Language::Rust);
+
+    let unnamed: Vec<_> = chunks.iter().filter(|c| c.symbol_name.is_none()).collect();
+    assert!(
+        unnamed.is_empty(),
+        "spans inside the impl are already covered by its chunk: {unnamed:?}"
+    );
+    assert!(
+        !chunks.iter().any(|c| c.content.trim() == "}"),
+        "the impl's closing brace must not become its own chunk: {chunks:?}"
+    );
+}
+
+#[test]
 fn rust_enum_and_trait() {
     let source = r#"enum Color {
     Red,

--- a/crates/vera-core/src/parsing/tests.rs
+++ b/crates/vera-core/src/parsing/tests.rs
@@ -78,6 +78,21 @@ fn rust_impl_methods_emit_no_gap_chunks() {
 "#;
     let chunks = parse(source, "cancellation.rs", Language::Rust);
 
+    let impl_block = find_chunk(&chunks, "impl CancellationToken");
+    assert_eq!(impl_block.symbol_type, Some(SymbolType::Block));
+    assert!(
+        impl_block.content.contains("fn cancel"),
+        "impl chunk should cover the whole body: {impl_block:?}"
+    );
+    for method in ["new", "cancel"] {
+        let chunk = find_chunk(&chunks, method);
+        assert_eq!(
+            chunk.symbol_type,
+            Some(SymbolType::Method),
+            "`{method}` should be chunked as a method: {chunk:?}"
+        );
+    }
+
     let unnamed: Vec<_> = chunks.iter().filter(|c| c.symbol_name.is_none()).collect();
     assert!(
         unnamed.is_empty(),


### PR DESCRIPTION
Fixes #107

## Mechanism

`chunks_from_symbols` tracked coverage with a single `covered_end_row` and reset it
unconditionally at the end of every symbol iteration:

`crates/vera-core/src/parsing/chunker.rs:96` (before) — `covered_end_row = sym_end + 1;`

Extractors deliberately push a parent **and** its children:

- `parsing/extractor/special_forms.rs:286` Rust `impl`, `:318` Python `class`
- `parsing/extractor/mod.rs:329` C# namespace, `:303` ObjC class, `:355` protobuf service, `:235` Elixir defmodule

`extract_symbols` sorts by `start_byte` (`parsing/extractor/mod.rs:62`), so the parent is
processed first and `covered_end_row` jumps to the parent's end row. Each child then pulled
it back to the child's own end. Every span between two children therefore satisfied
`sym_start > covered_end_row` at `chunker.rs:53` and was emitted as a standalone unnamed
`Block` chunk over lines the parent chunk already covered. The trailing-gap branch at
`chunker.rs:100` fired the same way on the parent's own closing brace, producing chunks whose
entire content is `}`.

The parent/child duplication is intentional and is left alone. The gap chunks over the same
lines are not.

The fix takes the max, so a child cannot rewind coverage back inside its parent.

Gaps between top-level symbols are unaffected. Because symbols are sorted by start byte, a
symbol whose end row precedes `covered_end_row` is by definition contained in a span that has
already been chunked, so the only spans monotonic advance suppresses are ones the parent chunk
already carries. `gap_after_nested_parent_still_captured` pins that: real top-level code
following an `impl` still produces its gap chunk, now starting after the parent's closing brace
rather than at it.

## Measured

Control is the released `vera 1.0.0` binary; a second control was built from this branch's own
tree with the one-line change reverted, and the two agree exactly. Fixture is
`crates/vera-core/src` plus `crates/vera-cli/src` copied into a scratch tree, 99 Rust files,
indexed with `--potion-code` into a throwaway `.vera/`.

| measure | released 1.0.0 | reverted-line control | branch |
|---|---|---|---|
| chunks created | 3081 | 3081 | **2947** |
| chunks with 3 or fewer characters of content | 38 | 38 | **0** |
| chunks containing no alphanumeric character | 38 | 38 | **0** |
| unnamed `block` chunks | 1072 | 1072 | **938** |
| unnamed chunks whose content is entirely comment | 886 | 886 | 835 |

179 chunks present before are absent after; 45 appear that were not there before, all of them
gap chunks whose start row moved off the parent's closing brace. 36 lines lose chunk coverage
and every one of them is blank; no non-blank source line loses coverage.

The `cancellation.rs` case from the issue, released control on the left, branch on the right:

```
1   7   block   (null)                  330      1   7   block   (null)                  330
8   10  struct  CancellationToken        67      8   10  struct  CancellationToken        67
12  37  block   impl CancellationToken  708     12  37  block   impl CancellationToken  708
14  16  method  new                      56     14  16  method  new                      56
17  18  block   (null)                   59     19  21  method  cancel                   61
19  21  method  cancel                   61     24  26  method  is_cancelled             80
22  23  block   (null)                   75     29  31  method  as_async_token           94
24  26  method  is_cancelled             80     33  36  method  check                   145
27  28  block   (null)                   59
29  31  method  as_async_token           94
33  36  method  check                   145
37  37  block   (null)                    1
```

## Re-index consequence

This changes chunk boundaries, so an existing index must be rebuilt to benefit.

Nothing notices. `model_identity` (`local_models/mod.rs:279`) covers only the embedding model's
identity, and freshness is decided purely by per-file content hashes
(`indexing/update.rs:137` `content_hash`, consumed by `indexing/freshness.rs`). There is no
index schema or chunker version stamp anywhere in the tree. An index built by an earlier binary
will therefore keep its old chunk shapes for every file that has not changed on disk, and mix
them with new-shape chunks for files that have. Users who want the effect need a full
`vera index`, not `vera update`.

## The other half, left undone

Attaching leading doc comments to the symbol that follows them is the change that would actually
move retrieval, and it is not in this PR. On the fixture, 285 unnamed chunks still begin with
`///`, and 3 of 1386 `function`/`method` chunks contain a `///` at all, essentially unchanged
from the 351/3 before. Those orphans come from the gap branch firing between *top-level*
symbols, which is legitimate gap handling and not the rewind bug. Fixing it means moving symbol
start rows back over preceding comment lines, which changes every language's chunk boundaries
rather than only nested ones, so it belongs on its own PR.

## Tests

Each test pins the chunks that must be present before it asserts that nothing spurious was
emitted, so a broken extractor cannot satisfy it by returning nothing.

- `parsing::chunker::tests::nested_children_emit_no_gap_chunks`: a parent with two children
  separated by a doc comment; asserts the chunk list is exactly parent, child, child and that no
  chunk is the bare closing brace.
- `parsing::chunker::tests::gap_after_nested_parent_still_captured`: asserts the parent and its
  child are chunked and then that real top-level code after the parent still gets its gap chunk,
  at the corrected start row.
- `parsing::tests::rust_impl_methods_emit_no_gap_chunks`: the same shape through the real
  tree-sitter extractor rather than hand-built symbols; asserts the `impl CancellationToken`
  block chunk and the `new` and `cancel` method chunks by name via `find_chunk`, which names the
  missing chunk instead of panicking on an index, then asserts no unnamed chunk and no
  brace-only chunk.

Reverting the one-line change fails all three with the production symptom:

```
---- parsing::tests::rust_impl_methods_emit_no_gap_chunks stdout ----
spans inside the impl are already covered by its chunk: [
  Chunk { line_start: 6, line_end: 7, content: "\n    /// Cancel the token.", symbol_type: Some(Block), symbol_name: None },
  Chunk { line_start: 9, line_end: 9, content: "}", symbol_type: Some(Block), symbol_name: None }
]

---- parsing::chunker::tests::nested_children_emit_no_gap_chunks stdout ----
  left: [Some("Token"), Some("new"), None, Some("cancel"), None]
 right: [Some("Token"), Some("new"), Some("cancel")]

---- parsing::chunker::tests::gap_after_nested_parent_still_captured stdout ----
  left: 5
 right: 6
```

Breaking chunk emission instead, so the list is parent-only, fails all three as well:

```
---- parsing::tests::rust_impl_methods_emit_no_gap_chunks stdout ----
should find chunk named 'new'

---- parsing::chunker::tests::nested_children_emit_no_gap_chunks stdout ----
  left: [Some("Token")]
 right: [Some("Token"), Some("new"), Some("cancel")]

---- parsing::chunker::tests::gap_after_nested_parent_still_captured stdout ----
  left: [Some("Token"), None]
 right: [Some("Token"), Some("new"), None]
```

And with the list empty:

```
---- parsing::tests::rust_impl_methods_emit_no_gap_chunks stdout ----
should find chunk named 'impl CancellationToken'

---- parsing::chunker::tests::nested_children_emit_no_gap_chunks stdout ----
  left: []
 right: [Some("Token"), Some("new"), Some("cancel")]

---- parsing::chunker::tests::gap_after_nested_parent_still_captured stdout ----
  left: []
 right: [Some("Token"), Some("new"), None]
```

No existing test asserted the presence of these chunks. The nested-fixture tests in
`parsing/tests.rs` use `>=` bounds (`rust_struct_and_impl:35`,
`python_function_and_class_methods:129`, `javascript_extracts_like_typescript:806`), and the
exact-count ones cover single-symbol or whole-file cases, so none needed changing.

## Verification

```
cargo fmt --check                                        clean
cargo test -p vera-core --lib                            796 passed, 0 failed
cargo test -p vera-cli --bin vera                         97 passed, 0 failed
cargo clippy -p vera-core --lib | grep -cE "^warning: "    5 (unchanged, all pre-existing)
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops emitting gap chunks inside a parent symbol by advancing coverage monotonically. Previously each child rewound coverage, creating duplicate unnamed block chunks and brace-only chunks; now coverage takes the max, and gaps between top-level symbols are unchanged.

- Replaces coverage advance with covered_end_row = covered_end_row.max(sym_end + 1); verify no gap chunks appear between nested children and that top-level gaps still emit after the parent’s closing brace.
- Reduces unnamed block chunks and eliminates brace-only chunks across Rust/Python/C#/ObjC/protobuf/Elixir parents; no non-blank line loses coverage.
- Tests: add cases for nested children and trailing top-level gap; strengthen existing tests to assert required chunks before checking for gaps.
- Migration: run a full re-index with `vera index` to pick up new chunk shapes.

<sup>Written for commit dac7deca4842b829fa5fde403391681837f74278. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/VeraTools/Vera/pull/115?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved code parsing for nested symbols to prevent duplicate or incorrect gap sections.
  - Preserved trailing gaps correctly after top-level symbols.
  - Fixed parsing of documented methods within implementation blocks, avoiding unnamed gaps and stray closing braces.

- **Tests**
  - Added coverage for nested symbols, trailing gaps, and documented implementation methods.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
