### PR TITLE
fix(indexing): write hashes and the freshness stamp after the stores are rebuilt

### DIFF
--- a/crates/vera-core/src/indexing/pipeline.rs
+++ b/crates/vera-core/src/indexing/pipeline.rs
@@ -670,9 +670,11 @@ fn store_index(
     // deleted and repopulated above; committing the hashes first would leave a
     // crash or a Ctrl-C in that window with a complete metadata store, current
     // hashes and a missing or half-built vector/BM25 store, which
-    // `detect_staleness` cannot see and `vera update` skips. Writing them last
-    // means every kill point leaves the old hashes, so the next run
-    // reprocesses. `update.rs` keeps the same order.
+    // `detect_staleness` cannot see and `vera update` skips. `metadata_store`
+    // was cleared above, hashes and index metadata included, so writing them
+    // last means a kill anywhere in this window leaves both absent, every file
+    // reads as new and the next run reprocesses. `update.rs` keeps the same
+    // order.
     metadata_store
         .set_file_hashes_batch(file_hashes)
         .context("failed to store file hashes")?;

--- a/crates/vera-core/src/indexing/pipeline.rs
+++ b/crates/vera-core/src/indexing/pipeline.rs
@@ -610,12 +610,6 @@ fn store_index(
         .insert_chunks(chunks)
         .context("failed to insert chunk metadata")?;
 
-    // Store file content hashes for incremental indexing, batched into a
-    // single transaction instead of one commit per file.
-    metadata_store
-        .set_file_hashes_batch(file_hashes)
-        .context("failed to store file hashes")?;
-
     metadata_store
         .insert_file_states(metadata.file_states)
         .context("failed to store file index states")?;
@@ -632,8 +626,6 @@ fn store_index(
     metadata_store
         .set_index_meta("embedding_dim", &dim.to_string())
         .context("failed to store embedding_dim")?;
-    super::freshness::record_index_snapshot(&metadata_store, metadata.indexing_config)
-        .context("failed to store index freshness metadata")?;
 
     debug!(chunks = chunks.len(), "metadata stored");
 
@@ -672,6 +664,20 @@ fn store_index(
         .context("failed to insert BM25 documents")?;
 
     debug!(docs = chunks.len(), "BM25 index built");
+
+    // Hashes and the freshness stamp are what certify the index current, so
+    // they are written only once every store has been rebuilt. Both stores are
+    // deleted and repopulated above; committing the hashes first would leave a
+    // crash or a Ctrl-C in that window with a complete metadata store, current
+    // hashes and a missing or half-built vector/BM25 store, which
+    // `detect_staleness` cannot see and `vera update` skips. Writing them last
+    // means every kill point leaves the old hashes, so the next run
+    // reprocesses. `update.rs` keeps the same order.
+    metadata_store
+        .set_file_hashes_batch(file_hashes)
+        .context("failed to store file hashes")?;
+    super::freshness::record_index_snapshot(&metadata_store, metadata.indexing_config)
+        .context("failed to store index freshness metadata")?;
 
     Ok(())
 }

--- a/crates/vera-core/src/indexing/pipeline.rs
+++ b/crates/vera-core/src/indexing/pipeline.rs
@@ -671,9 +671,10 @@ fn store_index(
     // crash or a Ctrl-C in that window with a complete metadata store, current
     // hashes and a missing or half-built vector/BM25 store, which
     // `detect_staleness` cannot see and `vera update` skips. `metadata_store`
-    // was cleared above, hashes and index metadata included, so writing them
-    // last means a kill anywhere in this window leaves both absent, every file
-    // reads as new and the next run reprocesses. `update.rs` keeps the same
+    // was cleared above, hashes and index metadata included, so a failure
+    // before final publication leaves both absent, every file reads as new and
+    // the next run reprocesses. A failure during the final metadata writes can
+    // happen only after both stores are complete. `update.rs` keeps the same
     // order.
     metadata_store
         .set_file_hashes_batch(file_hashes)

--- a/crates/vera-core/src/indexing/pipeline_tests.rs
+++ b/crates/vera-core/src/indexing/pipeline_tests.rs
@@ -471,3 +471,98 @@ async fn index_permission_error_continues() {
         let _ = fs::set_permissions(&unreadable, fs::Permissions::from_mode(0o644));
     }
 }
+
+/// Freshness keys, duplicated here because `freshness` keeps them private.
+const INDEXING_CONFIG_META_KEY: &str = "indexing_config";
+const INDEX_REFRESHED_AT_META_KEY: &str = "index_refreshed_at_unix_ms";
+
+fn store_index_into(idx_dir: &Path) -> Result<()> {
+    let indexing_config = crate::config::IndexingConfig::default();
+    store_index(
+        idx_dir,
+        &[],
+        &[],
+        &[("src/lib.rs".to_string(), "hash-a".to_string())],
+        &[],
+        &[],
+        IndexBuildMetadata {
+            file_states: &[],
+            indexing_config: &indexing_config,
+            model_name: "mock-model",
+        },
+    )
+}
+
+/// A failed store rebuild must not leave the index certified current.
+///
+/// Both stores are deleted and repopulated by `store_index`. The failure is
+/// injected by leaving a plain file where the store expects a directory (and a
+/// directory where it expects a file), which makes the reset step fail after
+/// the preceding stores have already been written. This proves the hashes and
+/// the freshness stamp land after both stores; it does not simulate a kill
+/// signal, and `store_index` has no seam for one.
+#[test]
+fn store_index_defers_hashes_and_freshness_until_stores_are_rebuilt() {
+    for poison in ["vector", "bm25"] {
+        let dir = TempDir::new().unwrap();
+        let idx_dir = dir.path().join(".vera");
+        fs::create_dir_all(&idx_dir).unwrap();
+        match poison {
+            // `remove_file` fails on a directory.
+            "vector" => fs::create_dir(idx_dir.join(VECTOR_DB)).unwrap(),
+            // `remove_dir_all` fails on a plain file.
+            _ => fs::write(idx_dir.join(BM25_SUBDIR), "not a directory").unwrap(),
+        }
+
+        let err = store_index_into(&idx_dir).unwrap_err();
+        let rendered = format!("{err:#}");
+        assert!(
+            rendered.contains("failed to reset"),
+            "{poison}: unexpected failure: {rendered}"
+        );
+
+        let store = MetadataStore::open(&idx_dir.join(METADATA_DB)).unwrap();
+        assert_eq!(
+            store.get_file_hash("src/lib.rs").unwrap(),
+            None,
+            "{poison}: hashes were committed before the stores were rebuilt"
+        );
+        assert_eq!(
+            store.get_index_meta(INDEX_REFRESHED_AT_META_KEY).unwrap(),
+            None,
+            "{poison}: the index was stamped fresh before the stores were rebuilt"
+        );
+        assert_eq!(
+            store.get_index_meta(INDEXING_CONFIG_META_KEY).unwrap(),
+            None,
+            "{poison}: the freshness snapshot was recorded before the stores were rebuilt"
+        );
+    }
+}
+
+/// The deferred writes still happen when the rebuild succeeds.
+#[test]
+fn store_index_records_hashes_and_freshness_on_success() {
+    let dir = TempDir::new().unwrap();
+    let idx_dir = dir.path().join(".vera");
+
+    store_index_into(&idx_dir).unwrap();
+
+    let store = MetadataStore::open(&idx_dir.join(METADATA_DB)).unwrap();
+    assert_eq!(
+        store.get_file_hash("src/lib.rs").unwrap().as_deref(),
+        Some("hash-a")
+    );
+    assert!(
+        store
+            .get_index_meta(INDEX_REFRESHED_AT_META_KEY)
+            .unwrap()
+            .is_some()
+    );
+    assert!(
+        store
+            .get_index_meta(INDEXING_CONFIG_META_KEY)
+            .unwrap()
+            .is_some()
+    );
+}


### PR DESCRIPTION
`store_index` committed the file hashes and the freshness stamp **before** it deleted and rebuilt the vector and BM25 stores. Any death in that window left an index that was permanently wrong and reported itself healthy at every level.

## The ordering

`crates/vera-core/src/indexing/pipeline.rs`, `store_index`, before this change:

| line | action |
|---|---|
| 607 | `metadata_store.clear()` |
| 610 | `insert_chunks` |
| **616** | **`set_file_hashes_batch`** |
| **635** | **`record_index_snapshot`** |
| **643** | **`std::fs::remove_file(vectors.db)`** |
| 657 | `vector_store.insert_batch` |
| **665** | **`std::fs::remove_dir_all(bm25/)`** |
| 671 | `bm25_index.insert_chunks` |

Both stores were deleted after the index had already certified itself current, in WAL-durable commits.

## The failure mode

Nothing detects the resulting state:

- `detect_staleness` reads only `file_hashes` and discovery. It never opens the vector store or the BM25 index, so all hashes match and no warning prints.
- `vera update` keys off those same hashes, so it is a no-op. The user cannot repair this with `update`.
- `Bm25Index::open` creates an empty index when the directory is missing and `VectorStore::open` creates the file, so search takes the success arm and fuses against an empty list rather than erroring. Even the BM25-only fallback warning never fires, because nothing failed.

Measured on a copy of a real index, simulating the kill at the old line 643 by removing `vectors.db`: 342 of 375 tracked files still reported unchanged.

It is not only reachable by a crash. `store_index` is fully synchronous with no `.await`, called directly from the async task, so Ctrl-C during storage prints "indexing cancelled" and exits non-zero while the rewrite is in flight. The user has no reason to re-run `vera index`.

## Contrast with `update.rs`

The sibling path already gets this right. `crates/vera-core/src/indexing/update.rs` writes vectors at `:708`, file states at `:717`, hashes at `:725` and the stamp at `:733`: hashes and stamp last, after every store. Every kill point there leaves the old hash, so the next run reprocesses and self-heals. So this was a deviation between two paths, not a house convention.

## The change

`crates/vera-core/src/indexing/pipeline.rs:668-682` moves `set_file_hashes_batch` and `record_index_snapshot` to after the BM25 insert, matching `update.rs`.

Both were safe to move. `record_index_snapshot` needs only the `MetadataStore` handle and the `IndexingConfig`, neither of which the vector or BM25 step touches. `set_file_hashes_batch` needs only the `file_hashes` slice. Nothing between the old and new positions reads `file_hashes`: `insert_file_states`, `insert_parse_artifacts_batch`, the `model_name`/`embedding_dim` writes, the vector store and the BM25 index all ignore it, and the `file_hashes` table carries no foreign keys. `IndexSummary` is unaffected: it is built from `discovery`, `all_chunks`, `embeddings` and the in-memory `file_states`, never from the store.

The comment above the moved writes records the post-crash state exactly, after both review bots caught it overstating the case. `metadata_store.clear()` (`crates/vera-core/src/storage/metadata.rs:491-497`) deletes `file_hashes` and `index_metadata` at `pipeline.rs:606`, so a kill in this window leaves them absent rather than stale. That still self-heals: `detect_staleness` counts a file with no stored hash as modified (`indexing/freshness.rs:171`), and `update.rs:403-420` builds `stored_files` from `SELECT file_path FROM file_hashes` (`metadata.rs:607`), so an empty table puts every file in the `added` arm.

`insert_file_states` was left where it is. The `file_index_state` table is diagnostic only, read by `vera stats` and never by staleness detection, so its position does not affect the invariant.

## Tests

`crates/vera-core/src/indexing/pipeline_tests.rs:475-568`, two tests.

`store_index_defers_hashes_and_freshness_until_stores_are_rebuilt` injects a failure into each store rebuild by leaving a directory where `vectors.db` belongs (so `remove_file` fails) and a plain file where `bm25/` belongs (so `remove_dir_all` fails), then asserts that after the error the stored hash, `index_refreshed_at_unix_ms` and `indexing_config` are all absent. `store_index_records_hashes_and_freshness_on_success` asserts all three are written when the rebuild succeeds, so the ordering test cannot be satisfied by simply dropping the writes.

What this proves: the hashes and the stamp are committed after both store rebuilds. What it does not prove: behaviour under an actual kill signal. `store_index` has no seam for one and deliberately has no cancellation checks inside it, since cooperative cancellation cannot tear three stores. The reset step is the reachable seam, and it sits inside the same window.

Verified by reinjection. Reverting the ordering fails the test with the production symptom, on the earliest window:

```
thread 'store_index_defers_hashes_and_freshness_until_stores_are_rebuilt' panicked at
crates/vera-core/src/indexing/pipeline_tests.rs:525:9:
assertion `left == right` failed: vector: hashes were committed before the stores were rebuilt
  left: Some("hash-a")
 right: None
```

## Verification

- `cargo fmt --check` clean
- `cargo test -p vera-core --lib` 795 passed, 0 failed
- `cargo test -p vera-cli --bin vera` 97 passed, 0 failed
- `cargo clippy -p vera-core --lib` 5 warnings, the pre-existing set, none added

## Not in this PR

The issue lists two adjacent items from the same audit that look like separate decisions and are left alone here: there is no advisory lock on `.vera/`, so two concurrent `vera index` runs delete each other's stores mid-write (including tantivy's lock file, which lives inside `bm25/`); and neither sqlite connection sets `busy_timeout`, so a second writer gets `SQLITE_BUSY` immediately rather than waiting.

Fixes #119

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Defers writing file hashes and the freshness stamp until after the vector and BM25 stores are rebuilt. Previously `store_index` wrote these first, which could certify a broken index as fresh; now failures leave them absent so the next run reprocesses everything.

- Moves `set_file_hashes_batch` and `record_index_snapshot` to after the BM25 insert in `crates/vera-core/src/indexing/pipeline.rs`; keeps `insert_file_states` in place. Aligns ordering with `update.rs`.
- Clarifies the comment: `metadata_store.clear()` removes `file_hashes` and `index_metadata` up front, so a crash leaves both absent (not stale) and triggers reindexing; narrows the publication guarantee accordingly.
- Adds tests verifying hashes/stamp are absent on rebuild failure and present on success.

<sup>Written for commit a81bd5f2a7ae9319c5e1534cae7ba094fc3efbe6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/VeraTools/Vera/pull/123?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Index freshness and file metadata are now updated only after vector and keyword index rebuilding completes successfully.
  * Failed index rebuilds no longer leave misleading freshness or file hash information behind.

* **Tests**
  * Added coverage confirming metadata behavior for both successful and failed rebuilds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
