### PR TITLE
fix(mcp): fuse multi-query search results instead of concatenating them

### DIFF
--- a/crates/vera-cli/src/commands/search.rs
+++ b/crates/vera-cli/src/commands/search.rs
@@ -28,7 +28,7 @@ pub fn run(
     let mut config = load_runtime_config()?;
     config.adjust_for_backend(backend);
     let result_limit = limit.unwrap_or(config.retrieval.default_limit);
-    let queries = normalize_queries(queries);
+    let queries = vera_core::retrieval::normalize_queries(queries);
 
     if queries.is_empty() {
         bail!(
@@ -120,7 +120,7 @@ impl SearchRunner<'_> {
         intent: Option<&str>,
     ) -> anyhow::Result<(Vec<SearchResult>, SearchTimings)> {
         let overall_start = Instant::now();
-        let per_query_limit = compute_per_query_limit(self.result_limit);
+        let per_query_limit = vera_core::retrieval::multi_query_candidate_limit(self.result_limit);
         let mut timings = SearchTimings::default();
         let mut weights = Vec::with_capacity(queries.len());
         let mut result_sets = Vec::with_capacity(queries.len());
@@ -153,30 +153,6 @@ impl SearchRunner<'_> {
         timings.total = Some(overall_start.elapsed());
         Ok((fused, timings))
     }
-}
-
-fn normalize_queries(queries: &[String]) -> Vec<String> {
-    let mut normalized = Vec::with_capacity(queries.len());
-    let mut seen = std::collections::HashSet::new();
-
-    for query in queries {
-        let collapsed = query.split_whitespace().collect::<Vec<_>>().join(" ");
-        if collapsed.is_empty() {
-            continue;
-        }
-        if seen.insert(collapsed.to_ascii_lowercase()) {
-            normalized.push(collapsed);
-        }
-    }
-
-    normalized
-}
-
-fn compute_per_query_limit(result_limit: usize) -> usize {
-    result_limit
-        .saturating_mul(2)
-        .max(result_limit.saturating_add(10))
-        .max(20)
 }
 
 fn merge_timings(target: &mut SearchTimings, incoming: &SearchTimings) {

--- a/crates/vera-cli/src/commands/search.rs
+++ b/crates/vera-cli/src/commands/search.rs
@@ -122,7 +122,6 @@ impl SearchRunner<'_> {
         let overall_start = Instant::now();
         let per_query_limit = vera_core::retrieval::multi_query_candidate_limit(self.result_limit);
         let mut timings = SearchTimings::default();
-        let mut weights = Vec::with_capacity(queries.len());
         let mut result_sets = Vec::with_capacity(queries.len());
 
         for query in queries {
@@ -133,21 +132,15 @@ impl SearchRunner<'_> {
             let (results, query_timings) = query_runner.execute_query(query, intent)?;
             merge_timings(&mut timings, &query_timings);
             result_sets.push(results);
-            weights.push(1.0);
         }
 
-        let slices: Vec<&[SearchResult]> = result_sets.iter().map(Vec::as_slice).collect();
-        let fused = vera_core::retrieval::fuse_rrf_multi_weighted(
-            &slices,
-            &weights,
-            self.config.retrieval.rrf_k,
-            self.result_limit,
-        );
-        let fused = vera_core::retrieval::search_service::augment_multi_query_exact_matches(
+        let fused = vera_core::retrieval::fuse_and_augment_multi_query(
             self.index_dir,
             queries,
-            fused,
+            &result_sets,
             self.filters,
+            self.config.retrieval.rrf_k,
+            self.result_limit,
             self.result_limit,
         )?;
         timings.total = Some(overall_start.elapsed());

--- a/crates/vera-core/src/retrieval/mod.rs
+++ b/crates/vera-core/src/retrieval/mod.rs
@@ -108,3 +108,32 @@ pub fn multi_query_candidate_limit(result_limit: usize) -> usize {
         .max(result_limit.saturating_add(10))
         .max(20)
 }
+
+/// Merge per-subquery result sets: equally weighted RRF, then exact-match
+/// augmentation, then the cut to `result_limit`.
+///
+/// `fuse_limit` is a parameter rather than a constant because the two callers
+/// disagree on it and are meant to. MCP passes `multi_query_candidate_limit`,
+/// so augmentation still has candidates to displace; `vera search` passes
+/// `result_limit`, truncating before augmenting, which is issue #121 and is
+/// left alone here. Collapsing them would silently change CLI results.
+pub fn fuse_and_augment_multi_query(
+    index_dir: &std::path::Path,
+    queries: &[String],
+    result_sets: &[Vec<SearchResult>],
+    filters: &SearchFilters,
+    rrf_k: f64,
+    fuse_limit: usize,
+    result_limit: usize,
+) -> anyhow::Result<Vec<SearchResult>> {
+    let slices: Vec<&[SearchResult]> = result_sets.iter().map(Vec::as_slice).collect();
+    let weights = vec![1.0; result_sets.len()];
+    let fused = fuse_rrf_multi_weighted(&slices, &weights, rrf_k, fuse_limit);
+    exact_matches::augment_multi_query_exact_matches(
+        index_dir,
+        queries,
+        fused,
+        filters,
+        result_limit,
+    )
+}

--- a/crates/vera-core/src/retrieval/mod.rs
+++ b/crates/vera-core/src/retrieval/mod.rs
@@ -75,3 +75,36 @@ pub fn apply_filters(
         .take(limit)
         .collect()
 }
+
+/// Collapse whitespace and drop empty or repeated subqueries.
+///
+/// Fusion counts every subquery, so the same query arriving twice would
+/// otherwise weigh double against the ones it was meant to complement.
+pub fn normalize_queries(queries: &[String]) -> Vec<String> {
+    let mut normalized = Vec::with_capacity(queries.len());
+    let mut seen = std::collections::HashSet::new();
+
+    for query in queries {
+        let collapsed = query.split_whitespace().collect::<Vec<_>>().join(" ");
+        if collapsed.is_empty() {
+            continue;
+        }
+        if seen.insert(collapsed.to_ascii_lowercase()) {
+            normalized.push(collapsed);
+        }
+    }
+
+    normalized
+}
+
+/// Candidate width each subquery keeps before multi-query fusion.
+///
+/// A subquery has to over-fetch relative to the caller's limit, or fusion has
+/// nothing to merge: the first subquery alone fills the final window and every
+/// later one is truncated away.
+pub fn multi_query_candidate_limit(result_limit: usize) -> usize {
+    result_limit
+        .saturating_mul(2)
+        .max(result_limit.saturating_add(10))
+        .max(20)
+}

--- a/crates/vera-core/src/retrieval/rag_fusion.rs
+++ b/crates/vera-core/src/retrieval/rag_fusion.rs
@@ -21,6 +21,7 @@ use crate::types::{SearchFilters, SearchResult};
 
 use super::completion_client::CompletionClient;
 use super::hybrid::fuse_rrf_multi_weighted;
+use super::multi_query_candidate_limit;
 use super::search_service::{SearchContext, SearchTimings};
 
 /// Execute deep search: RAG-fusion if a completion endpoint is configured,
@@ -111,7 +112,7 @@ async fn execute_rag_fusion_with_context(
         ));
     }
 
-    let per_query_limit = compute_per_query_limit(result_limit);
+    let per_query_limit = multi_query_candidate_limit(result_limit);
 
     let query_count = queries.len();
 
@@ -192,13 +193,6 @@ fn normalize_query(query: &str) -> String {
     query.split_whitespace().collect::<Vec<_>>().join(" ")
 }
 
-fn compute_per_query_limit(result_limit: usize) -> usize {
-    result_limit
-        .saturating_mul(2)
-        .max(result_limit.saturating_add(10))
-        .max(20)
-}
-
 fn merge_timings(target: &mut SearchTimings, incoming: &SearchTimings) {
     add_duration(&mut target.embedding, incoming.embedding);
     add_duration(&mut target.bm25, incoming.bm25);
@@ -277,8 +271,8 @@ mod tests {
 
     #[test]
     fn per_query_limit_overfetches() {
-        assert_eq!(compute_per_query_limit(5), 20);
-        assert_eq!(compute_per_query_limit(20), 40);
+        assert_eq!(multi_query_candidate_limit(5), 20);
+        assert_eq!(multi_query_candidate_limit(20), 40);
     }
 
     #[test]

--- a/crates/vera-core/src/retrieval/rag_fusion.rs
+++ b/crates/vera-core/src/retrieval/rag_fusion.rs
@@ -21,8 +21,8 @@ use crate::types::{SearchFilters, SearchResult};
 
 use super::completion_client::CompletionClient;
 use super::hybrid::fuse_rrf_multi_weighted;
-use super::multi_query_candidate_limit;
 use super::search_service::{SearchContext, SearchTimings};
+use super::{multi_query_candidate_limit, normalize_queries};
 
 /// Execute deep search: RAG-fusion if a completion endpoint is configured,
 /// otherwise fall back to iterative symbol-following search.
@@ -167,30 +167,10 @@ async fn execute_rag_fusion_with_context(
 }
 
 fn dedupe_queries_with_original(original: &str, alternatives: Vec<String>) -> Vec<String> {
-    let mut deduped = Vec::with_capacity(alternatives.len() + 1);
-    let mut seen = std::collections::HashSet::new();
-
-    let original = normalize_query(original);
-    if !original.is_empty() {
-        seen.insert(original.to_ascii_lowercase());
-        deduped.push(original);
-    }
-
-    for alt in alternatives {
-        let normalized = normalize_query(&alt);
-        if normalized.is_empty() {
-            continue;
-        }
-        if seen.insert(normalized.to_ascii_lowercase()) {
-            deduped.push(normalized);
-        }
-    }
-
-    deduped
-}
-
-fn normalize_query(query: &str) -> String {
-    query.split_whitespace().collect::<Vec<_>>().join(" ")
+    let mut all = Vec::with_capacity(alternatives.len() + 1);
+    all.push(original.to_string());
+    all.extend(alternatives);
+    normalize_queries(&all)
 }
 
 fn merge_timings(target: &mut SearchTimings, incoming: &SearchTimings) {

--- a/crates/vera-mcp/src/tools.rs
+++ b/crates/vera-mcp/src/tools.rs
@@ -543,9 +543,10 @@ fn handle_search_code(args: &Value) -> ToolCallResult {
             }
         }
     }
+    let queries = vera_core::retrieval::normalize_queries(&queries);
     if queries.is_empty() {
         return ToolCallResult::error(
-            "Missing required parameter: provide 'query' (string) or 'queries' (array)",
+            "Missing required parameter: provide a non-empty 'query' (string) or 'queries' (array)",
         );
     }
 
@@ -588,14 +589,16 @@ fn handle_search_code(args: &Value) -> ToolCallResult {
         Err(err) => return err,
     };
 
-    // Run each query, collect all results.
-    let mut all_results: Vec<vera_core::types::SearchResult> = Vec::new();
+    // Run each query. A multi-query search over-fetches per query so fusion has
+    // candidates to merge; a single query is already at its final width.
     let per_query_limit = if queries.len() > 1 {
-        result_limit.max(10)
+        vera_core::retrieval::multi_query_candidate_limit(result_limit)
     } else {
         result_limit
     };
 
+    let mut result_sets: Vec<Vec<vera_core::types::SearchResult>> =
+        Vec::with_capacity(queries.len());
     for query in &queries {
         // Pass the raw query plus the optional intent. Core applies the intent
         // only to the semantic (embedding/rerank) side; BM25 gets the raw query
@@ -608,15 +611,26 @@ fn handle_search_code(args: &Value) -> ToolCallResult {
             &filters,
             per_query_limit,
         )) {
-            Ok((results, _timings)) => all_results.extend(results),
+            Ok((results, _timings)) => result_sets.push(results),
             Err(e) => return ToolCallResult::error(format!("Search failed: {e}")),
         }
     }
 
-    // Deduplicate by (file_path, line_start, line_end), keeping first occurrence.
-    let mut seen = std::collections::HashSet::new();
-    all_results.retain(|r| seen.insert(format!("{}:{}:{}", r.file_path, r.line_start, r.line_end)));
-    all_results.truncate(result_limit);
+    let all_results = if result_sets.len() == 1 {
+        result_sets.remove(0)
+    } else {
+        match fuse_multi_query_results(
+            &index_dir,
+            &queries,
+            &result_sets,
+            &filters,
+            config.retrieval.rrf_k,
+            result_limit,
+        ) {
+            Ok(results) => results,
+            Err(e) => return ToolCallResult::error(format!("Search failed: {e}")),
+        }
+    };
 
     let signatures_only = args
         .get("compact")
@@ -627,6 +641,37 @@ fn handle_search_code(args: &Value) -> ToolCallResult {
         Ok(json) => ToolCallResult::success(json),
         Err(e) => ToolCallResult::error(format!("Failed to serialize results: {e}")),
     }
+}
+
+/// Merge per-query result sets the way `vera search` does.
+///
+/// Reciprocal rank fusion over the full candidate pool, then exact-match
+/// augmentation, and only then the cut to `result_limit`. Concatenating instead
+/// would hand the whole window to the first query and drop the rest.
+fn fuse_multi_query_results(
+    index_dir: &std::path::Path,
+    queries: &[String],
+    result_sets: &[Vec<vera_core::types::SearchResult>],
+    filters: &vera_core::types::SearchFilters,
+    rrf_k: f64,
+    result_limit: usize,
+) -> anyhow::Result<Vec<vera_core::types::SearchResult>> {
+    let slices: Vec<&[vera_core::types::SearchResult]> =
+        result_sets.iter().map(Vec::as_slice).collect();
+    let weights = vec![1.0; result_sets.len()];
+    let fused = vera_core::retrieval::fuse_rrf_multi_weighted(
+        &slices,
+        &weights,
+        rrf_k,
+        vera_core::retrieval::multi_query_candidate_limit(result_limit),
+    );
+    vera_core::retrieval::search_service::augment_multi_query_exact_matches(
+        index_dir,
+        queries,
+        fused,
+        filters,
+        result_limit,
+    )
 }
 
 fn ensure_index_and_watcher(cwd: &std::path::Path) -> Result<std::path::PathBuf, ToolCallResult> {
@@ -1095,6 +1140,51 @@ mod tests {
         );
         // Should fail (either auto-index fails or embedding provider fails).
         assert!(result.is_error);
+    }
+
+    fn stub_result(name: &str) -> vera_core::types::SearchResult {
+        vera_core::types::SearchResult {
+            file_path: format!("src/{name}.rs"),
+            line_start: 1,
+            line_end: 10,
+            content: format!("fn {name}() {{}}"),
+            language: vera_core::types::Language::Rust,
+            score: 1.0,
+            symbol_name: Some(name.to_string()),
+            symbol_type: None,
+        }
+    }
+
+    #[test]
+    fn multi_query_fusion_keeps_hits_the_first_query_buried() {
+        // Query 1 returns more hits than the caller's limit, so a concatenating
+        // merge fills the window before query 2 is ever read.
+        let first: Vec<_> = (1..=10).map(|i| stub_result(&format!("a{i}"))).collect();
+        // Query 2's top hit is `a8`, which query 1 ranked 8th, followed by three
+        // files query 1 never returned at all.
+        let second: Vec<_> = std::iter::once(stub_result("a8"))
+            .chain((1..=3).map(|i| stub_result(&format!("b{i}"))))
+            .collect();
+
+        let index_dir = tempfile::tempdir().unwrap();
+        let queries = vec!["alpha".to_string(), "beta".to_string()];
+        let fused = fuse_multi_query_results(
+            index_dir.path(),
+            &queries,
+            &[first, second],
+            &vera_core::types::SearchFilters::default(),
+            60.0,
+            5,
+        )
+        .unwrap();
+        let paths: Vec<&str> = fused.iter().map(|r| r.file_path.as_str()).collect();
+
+        // Ranked by both queries, so it outscores every hit only one query found.
+        assert_eq!(paths.first(), Some(&"src/a8.rs"), "fused: {paths:?}");
+        // Query 2 only: reachable solely through fusion.
+        assert!(paths.contains(&"src/b1.rs"), "fused: {paths:?}");
+        // Query 1's 5th hit: inside a concatenated window, outranked after fusion.
+        assert!(!paths.contains(&"src/a5.rs"), "fused: {paths:?}");
     }
 
     #[test]

--- a/crates/vera-mcp/src/tools.rs
+++ b/crates/vera-mcp/src/tools.rs
@@ -656,20 +656,13 @@ fn fuse_multi_query_results(
     rrf_k: f64,
     result_limit: usize,
 ) -> anyhow::Result<Vec<vera_core::types::SearchResult>> {
-    let slices: Vec<&[vera_core::types::SearchResult]> =
-        result_sets.iter().map(Vec::as_slice).collect();
-    let weights = vec![1.0; result_sets.len()];
-    let fused = vera_core::retrieval::fuse_rrf_multi_weighted(
-        &slices,
-        &weights,
-        rrf_k,
-        vera_core::retrieval::multi_query_candidate_limit(result_limit),
-    );
-    vera_core::retrieval::search_service::augment_multi_query_exact_matches(
+    vera_core::retrieval::fuse_and_augment_multi_query(
         index_dir,
         queries,
-        fused,
+        result_sets,
         filters,
+        rrf_k,
+        vera_core::retrieval::multi_query_candidate_limit(result_limit),
         result_limit,
     )
 }


### PR DESCRIPTION
The MCP `search_code` tool documents its `queries` array as *"Results are deduplicated and reranked"* and its tips tell the agent to *"Use 2-3 varied queries to capture different aspects"*. It did neither merge nor benefit from the extra queries: every result came back from query #1.

## The arithmetic

`crates/vera-mcp/src/tools.rs` ran each query, concatenated the result lists in query order, deduped by `(file_path, line_start, line_end)`, then truncated:

- `per_query_limit = result_limit.max(10)` when more than one query is given
- `limit` defaults to 5 in the schema, so `per_query_limit` is 10
- query #1 contributes up to 10 results, appended first
- `truncate(5)` keeps the first 5, all of them query #1's

Queries #2 and #3 each cost a full hybrid search plus a cross-encoder rerank pass and could not reach the output. Following the tool's own advice made results strictly worse than a single query, and nothing in the response said so: MCP output enters an agent's context as trusted repository facts.

## The CLI comparison

`crates/vera-cli/src/commands/search.rs` did the real merge, in this order:

1. per-query limit `max(2 * limit, limit + 10, 20)`, so each query keeps enough candidates to survive fusion
2. `fuse_rrf_multi_weighted(..., config.retrieval.rrf_k)`
3. `augment_multi_query_exact_matches(...)`, which re-injects exact symbol and filename hits

The MCP path called none of these, so exact-match augmentation was missing from MCP results as well.

## What changed

`handle_search_code` now performs the same merge for multi-query searches: over-fetch per query, fuse with weighted RRF, augment exact matches, and only then cut to the caller's limit. Single-query searches keep their existing path untouched. Exact-symbol hits reach MCP callers for the first time.

One deliberate difference from the CLI: the fusion step is given the full candidate width and the cut to `result_limit` happens inside augmentation, not before it. The CLI truncates the fused list *before* augmenting, so exact matches there displace fused hits inside an already-cut window. That CLI-side ordering, and the exact-match injection behaviour around it, are a separate matter tracked outside this PR (see #121); the new MCP path does not copy the ordering.

Both fusion helpers were already `pub` in `vera-core`, so no visibility change was needed for them. Three helpers now live in `vera_core::retrieval` so the CLI and MCP share one definition instead of a third copy appearing in `vera-mcp`:

- `multi_query_candidate_limit` (was `compute_per_query_limit`, duplicated in `vera-cli` and `retrieval::rag_fusion`)
- `normalize_queries` (was `vera-cli` only; `retrieval::rag_fusion` had its own second implementation of the same algorithm and now calls this one)
- `fuse_and_augment_multi_query`, the fuse-then-augment sequence itself, which was otherwise written out once in `execute_multi_query_search` and once in `fuse_multi_query_results`

The fuse width stays a parameter of that last helper rather than being derived inside it, because the two callers are meant to disagree on it: MCP passes `multi_query_candidate_limit(result_limit)`, the CLI passes `result_limit`. That is the deliberate difference described above, so collapsing the two would change CLI results.

Query normalization matters more after this change than before it. Fusion counts every subquery, so the same string arriving through both `query` and `queries` would now weigh double; deduping at the edge keeps that from silently skewing the ranking. It also turns whitespace-only queries into the existing missing-parameter error instead of a search for the empty string.

The tool description is left as it stands: after this change the `queries` array does merge, deduplicate, and return reranked results, so the text is accurate rather than aspirational.

## Test

`multi_query_fusion_keeps_hits_the_first_query_buried` in `crates/vera-mcp/src/tools.rs` pins identity, not counts. Query #1 returns 10 hits `a1..a10`, query #2 returns `a8` plus three files query #1 never returned, limit 5. The assertions are that `a8` (ranked by both queries) leads the fused list, that `b1` (query #2 only) survives, and that `a5` (query #1's 5th hit) does not.

Verified by reinjection: with the pre-fix concatenate-dedup-truncate body restored, the test fails on the real production output.

```
assertion `left == right` failed: fused: ["src/a1.rs", "src/a2.rs", "src/a3.rs", "src/a4.rs", "src/a5.rs"]
  left: Some("src/a1.rs")
 right: Some("src/a8.rs")
```

Every result from query #1, exactly as the issue describes.

## Verification

- `cargo fmt --check` clean
- `cargo test -p vera-core --lib` 793 passed, 0 failed
- `cargo test -p vera-cli --bin vera` 97 passed, 0 failed
- `cargo test -p vera-mcp` 38 passed, 0 failed
- `cargo clippy -p vera-core --lib` 5 warnings, the same 5 pre-existing ones on master; no new warnings in `vera-mcp` or `vera-cli`

## Benchmark evidence

Standing answer to the `crates/vera-core/src/retrieval/**` path instruction, so it does not have to be re-derived each round.

The Vera-side benchmark harness cannot reach the code this PR touches. `benchmarks/scripts/run_vera_benchmarks.py:138-145` builds one command shape, `vera --json search <query> --limit <n>`, with a single positional query, and `crates/vera-cli/src/commands/search.rs:56` takes the multi-query branch only when `queries.len() != 1`. The four scripts under `eval/scripts/` drive `SembleIndex`, Semble's own index, and reference the vera binary 0 times. Nothing under `benchmarks/` or `eval/` starts MCP or `serve`.

Verified by execution, not by reading: a temporary `eprintln!` at the top of `fuse_and_augment_multi_query`, release build, run against a 3-file index. The harness command shape fires the probe 0 times, the same command plus `--deep` fires it 0 times, and two positional queries fire it once.

CLI ranking is unchanged by the refactor. Same index, 8 multi-query pairs, parent `6b9f554` (pre-extraction) against `b7a73fd`: 8 identical result sets, 0 differing. Top-1 ordering varies run to run on one pair and varies identically on both binaries (10 runs each, 6/4 the same way), which is the pre-existing run-to-run non-determinism tracked in #122 rather than anything introduced here. Released v1.0.0 as a control agrees with `b7a73fd` on the same index and query.

The behaviour that does change is the MCP `search_code` path, which no benchmark in this repo measures. It is pinned instead by `multi_query_fusion_keeps_hits_the_first_query_buried`, with the reinjection output quoted above.

Fixes #116

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fuses multi-query results in MCP `search_code` instead of concatenating them, so additional queries now affect ranking. Previously MCP concatenated per-query lists, deduped, and truncated, which let only query #1 survive; now we over-fetch, fuse with weighted RRF, augment exact matches, then cut to the limit. Single-query behavior is unchanged.

- Centralizes multi-query logic in `vera_core::retrieval`: `normalize_queries`, `multi_query_candidate_limit`, and `fuse_and_augment_multi_query`. `vera-cli` and `retrieval::rag_fusion` now use these helpers, removing duplicated implementations.
- MCP fuses over the full candidate pool and trims during augmentation; the CLI still truncates before augmenting. This preserves existing CLI behavior while fixing MCP.
- Query normalization collapses whitespace, dedupes case-insensitively, and rejects empty strings, preventing double-weighting when the same query appears in both `query` and `queries`.
- Expect ordering/content changes for multi-query MCP calls and new exact-symbol/filename hits. Empty or whitespace-only input now returns a clearer validation error.

<sup>Written for commit b7a73fddbd06c2d2a213e4095c174b5fa4316fff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/VeraTools/Vera/pull/124?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Multi-query searches now combine results across all entered queries for more comprehensive matches.
  - Results are ranked across queries while preserving exact matches.
  - Search queries are automatically cleaned, deduplicated, and normalized.
  - Searches retrieve a broader set of candidates before applying the final result limit.

- **Bug Fixes**
  - Improved result coverage so relevant matches from individual queries are less likely to be overlooked.
  - Empty or whitespace-only searches now provide a clear validation error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

