### PR TITLE
fix(core): single-source the Language wire name and honour retrieval.max_rerank_batch

### DIFF
--- a/crates/vera-core/src/config.rs
+++ b/crates/vera-core/src/config.rs
@@ -631,19 +631,7 @@ fn parse_model_alias_groups(value: &str) -> Vec<Vec<String>> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_env::env_lock;
-
-    fn set_env(key: &str, value: &str) {
-        unsafe {
-            std::env::set_var(key, value);
-        }
-    }
-
-    fn remove_env(key: &str) {
-        unsafe {
-            std::env::remove_var(key);
-        }
-    }
+    use crate::test_env::EnvVarGuard;
 
     #[test]
     fn default_config_is_valid() {
@@ -662,11 +650,8 @@ mod tests {
 
     #[test]
     fn graph_augmentation_env_accepts_only_truthy_values() {
-        let _guard = env_lock();
-        let previous = std::env::var_os("VERA_GRAPH_AUGMENT");
-
         for value in ["1", "true", "TRUE", "yes", "YeS"] {
-            set_env("VERA_GRAPH_AUGMENT", value);
+            let _guard = EnvVarGuard::set(&[("VERA_GRAPH_AUGMENT", value)]);
             assert!(
                 graph_augmentation_enabled(),
                 "{value} should enable the flag"
@@ -674,19 +659,11 @@ mod tests {
         }
 
         for value in ["0", "false", "no", "", "on"] {
-            set_env("VERA_GRAPH_AUGMENT", value);
+            let _guard = EnvVarGuard::set(&[("VERA_GRAPH_AUGMENT", value)]);
             assert!(
                 !graph_augmentation_enabled(),
                 "{value} should disable the flag"
             );
-        }
-
-        if let Some(value) = previous {
-            unsafe {
-                std::env::set_var("VERA_GRAPH_AUGMENT", value);
-            }
-        } else {
-            remove_env("VERA_GRAPH_AUGMENT");
         }
     }
 
@@ -716,21 +693,9 @@ mod tests {
 
     #[test]
     fn max_in_flight_environment_value_normalizes_zero_to_one() {
-        let _guard = env_lock();
-        let previous = std::env::var_os("VERA_MAX_IN_FLIGHT_INPUTS");
-        set_env("VERA_MAX_IN_FLIGHT_INPUTS", "0");
+        let _guard = EnvVarGuard::set(&[("VERA_MAX_IN_FLIGHT_INPUTS", "0")]);
 
-        let max_in_flight_inputs = default_max_in_flight_inputs();
-
-        if let Some(value) = previous {
-            unsafe {
-                std::env::set_var("VERA_MAX_IN_FLIGHT_INPUTS", value);
-            }
-        } else {
-            remove_env("VERA_MAX_IN_FLIGHT_INPUTS");
-        }
-
-        assert_eq!(max_in_flight_inputs, 1);
+        assert_eq!(default_max_in_flight_inputs(), 1);
     }
 
     #[test]
@@ -783,31 +748,22 @@ mod tests {
 
     #[test]
     fn resolve_backend_prefers_saved_backend_env() {
-        let _guard = env_lock();
-        set_env("VERA_BACKEND", "onnx-jina-cuda");
-        set_env("VERA_LOCAL", "1");
+        let _guard = EnvVarGuard::set(&[("VERA_BACKEND", "onnx-jina-cuda"), ("VERA_LOCAL", "1")]);
 
         assert_eq!(
             resolve_backend(None),
             InferenceBackend::OnnxJina(OnnxExecutionProvider::Cuda)
         );
-
-        remove_env("VERA_BACKEND");
-        remove_env("VERA_LOCAL");
     }
 
     #[test]
     fn resolve_backend_falls_back_to_legacy_local_env() {
-        let _guard = env_lock();
-        remove_env("VERA_BACKEND");
-        set_env("VERA_LOCAL", "1");
+        let _guard = EnvVarGuard::apply(&[("VERA_BACKEND", None), ("VERA_LOCAL", Some("1"))]);
 
         assert_eq!(
             resolve_backend(None),
             InferenceBackend::OnnxJina(OnnxExecutionProvider::Cpu)
         );
-
-        remove_env("VERA_LOCAL");
     }
 
     /// Shorthand for matching without configured alias groups.
@@ -865,11 +821,10 @@ mod tests {
 
     #[test]
     fn model_names_match_env_alias_group() {
-        let _guard = env_lock();
-        set_env(
+        let _guard = EnvVarGuard::set(&[(
             "VERA_EMBEDDING_MODEL_ALIASES",
             "text-embedding-3-large,text-embedding-3-large-2;other,other-prod",
-        );
+        )]);
 
         assert!(model_names_match(
             "text-embedding-3-large",
@@ -880,8 +835,6 @@ mod tests {
             "text-embedding-3-large",
             "text-embedding-3-small"
         ));
-
-        remove_env("VERA_EMBEDDING_MODEL_ALIASES");
     }
 
     #[test]

--- a/crates/vera-core/src/config.rs
+++ b/crates/vera-core/src/config.rs
@@ -631,12 +631,7 @@ fn parse_model_alias_groups(value: &str) -> Vec<Vec<String>> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::{Mutex, OnceLock};
-
-    fn env_lock() -> &'static Mutex<()> {
-        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-        LOCK.get_or_init(|| Mutex::new(()))
-    }
+    use crate::test_env::env_lock;
 
     fn set_env(key: &str, value: &str) {
         unsafe {
@@ -667,7 +662,7 @@ mod tests {
 
     #[test]
     fn graph_augmentation_env_accepts_only_truthy_values() {
-        let _guard = env_lock().lock().unwrap();
+        let _guard = env_lock();
         let previous = std::env::var_os("VERA_GRAPH_AUGMENT");
 
         for value in ["1", "true", "TRUE", "yes", "YeS"] {
@@ -721,7 +716,7 @@ mod tests {
 
     #[test]
     fn max_in_flight_environment_value_normalizes_zero_to_one() {
-        let _guard = env_lock().lock().unwrap();
+        let _guard = env_lock();
         let previous = std::env::var_os("VERA_MAX_IN_FLIGHT_INPUTS");
         set_env("VERA_MAX_IN_FLIGHT_INPUTS", "0");
 
@@ -788,7 +783,7 @@ mod tests {
 
     #[test]
     fn resolve_backend_prefers_saved_backend_env() {
-        let _guard = env_lock().lock().unwrap();
+        let _guard = env_lock();
         set_env("VERA_BACKEND", "onnx-jina-cuda");
         set_env("VERA_LOCAL", "1");
 
@@ -803,7 +798,7 @@ mod tests {
 
     #[test]
     fn resolve_backend_falls_back_to_legacy_local_env() {
-        let _guard = env_lock().lock().unwrap();
+        let _guard = env_lock();
         remove_env("VERA_BACKEND");
         set_env("VERA_LOCAL", "1");
 
@@ -870,7 +865,7 @@ mod tests {
 
     #[test]
     fn model_names_match_env_alias_group() {
-        let _guard = env_lock().lock().unwrap();
+        let _guard = env_lock();
         set_env(
             "VERA_EMBEDDING_MODEL_ALIASES",
             "text-embedding-3-large,text-embedding-3-large-2;other,other-prod",

--- a/crates/vera-core/src/lib.rs
+++ b/crates/vera-core/src/lib.rs
@@ -42,3 +42,6 @@ pub mod local_models;
 
 /// Index statistics collection.
 pub mod stats;
+
+#[cfg(test)]
+mod test_env;

--- a/crates/vera-core/src/retrieval/dynamic_reranker.rs
+++ b/crates/vera-core/src/retrieval/dynamic_reranker.rs
@@ -54,7 +54,7 @@ pub async fn create_dynamic_reranker(
                 let cfg = cfg
                     .with_timeout(Duration::from_secs(30))
                     .with_max_retries(2);
-                let p = ApiReranker::new(cfg)
+                let p = ApiReranker::new(cfg, config.retrieval.max_rerank_batch)
                     .map_err(|err| anyhow::anyhow!("failed to init reranker: {err}"))?;
                 return Ok(Some(DynamicReranker::Api(p)));
             }
@@ -69,11 +69,64 @@ pub async fn create_dynamic_reranker(
                 let cfg = cfg
                     .with_timeout(Duration::from_secs(30))
                     .with_max_retries(2);
-                let p = ApiReranker::new(cfg)
+                let p = ApiReranker::new(cfg, config.retrieval.max_rerank_batch)
                     .map_err(|err| anyhow::anyhow!("failed to init reranker: {err}"))?;
                 Ok(Some(DynamicReranker::Api(p)))
             }
             Err(_) => Ok(None),
         },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::ffi::OsString;
+
+    const RERANKER_ENV_KEYS: [&str; 4] = [
+        "RERANKER_MODEL_BASE_URL",
+        "RERANKER_MODEL_ID",
+        "RERANKER_MODEL_API_KEY",
+        "VERA_MAX_RERANK_BATCH",
+    ];
+
+    #[tokio::test]
+    async fn api_reranker_batches_by_the_configured_value_not_the_environment() {
+        let saved: Vec<(&str, Option<OsString>)> = RERANKER_ENV_KEYS
+            .iter()
+            .map(|key| (*key, std::env::var_os(key)))
+            .collect();
+        unsafe {
+            std::env::set_var("RERANKER_MODEL_BASE_URL", "http://127.0.0.1:19998/v1");
+            std::env::set_var("RERANKER_MODEL_ID", "test-model");
+            std::env::set_var("RERANKER_MODEL_API_KEY", "test-key");
+            // The value the old second env lookup would have produced.
+            std::env::set_var("VERA_MAX_RERANK_BATCH", "20");
+        }
+
+        let mut config = VeraConfig::default();
+        config.retrieval.reranking_enabled = true;
+        config.retrieval.max_rerank_batch = 8;
+
+        let reranker = create_dynamic_reranker(&config, InferenceBackend::Api)
+            .await
+            .unwrap();
+
+        unsafe {
+            for (key, value) in saved {
+                match value {
+                    Some(value) => std::env::set_var(key, value),
+                    None => std::env::remove_var(key),
+                }
+            }
+        }
+
+        let Some(DynamicReranker::Api(api)) = reranker else {
+            panic!("expected an API reranker for InferenceBackend::Api");
+        };
+        assert_eq!(
+            api.max_rerank_batch, 8,
+            "retrieval.max_rerank_batch must reach the reranker"
+        );
     }
 }

--- a/crates/vera-core/src/retrieval/dynamic_reranker.rs
+++ b/crates/vera-core/src/retrieval/dynamic_reranker.rs
@@ -81,28 +81,19 @@ pub async fn create_dynamic_reranker(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::ffi::OsString;
-
-    const RERANKER_ENV_KEYS: [&str; 4] = [
-        "RERANKER_MODEL_BASE_URL",
-        "RERANKER_MODEL_ID",
-        "RERANKER_MODEL_API_KEY",
-        "VERA_MAX_RERANK_BATCH",
-    ];
+    use crate::test_env::EnvVarGuard;
 
     #[tokio::test]
     async fn api_reranker_batches_by_the_configured_value_not_the_environment() {
-        let saved: Vec<(&str, Option<OsString>)> = RERANKER_ENV_KEYS
-            .iter()
-            .map(|key| (*key, std::env::var_os(key)))
-            .collect();
-        unsafe {
-            std::env::set_var("RERANKER_MODEL_BASE_URL", "http://127.0.0.1:19998/v1");
-            std::env::set_var("RERANKER_MODEL_ID", "test-model");
-            std::env::set_var("RERANKER_MODEL_API_KEY", "test-key");
+        // Held across the await and dropped on any unwind, so the credentials
+        // and the batch value never outlive the test.
+        let _env = EnvVarGuard::set(&[
+            ("RERANKER_MODEL_BASE_URL", "http://127.0.0.1:19998/v1"),
+            ("RERANKER_MODEL_ID", "test-model"),
+            ("RERANKER_MODEL_API_KEY", "test-key"),
             // The value the old second env lookup would have produced.
-            std::env::set_var("VERA_MAX_RERANK_BATCH", "20");
-        }
+            ("VERA_MAX_RERANK_BATCH", "20"),
+        ]);
 
         let mut config = VeraConfig::default();
         config.retrieval.reranking_enabled = true;
@@ -111,15 +102,6 @@ mod tests {
         let reranker = create_dynamic_reranker(&config, InferenceBackend::Api)
             .await
             .unwrap();
-
-        unsafe {
-            for (key, value) in saved {
-                match value {
-                    Some(value) => std::env::set_var(key, value),
-                    None => std::env::remove_var(key),
-                }
-            }
-        }
 
         let Some(DynamicReranker::Api(api)) = reranker else {
             panic!("expected an API reranker for InferenceBackend::Api");

--- a/crates/vera-core/src/retrieval/dynamic_reranker.rs
+++ b/crates/vera-core/src/retrieval/dynamic_reranker.rs
@@ -54,8 +54,9 @@ pub async fn create_dynamic_reranker(
                 let cfg = cfg
                     .with_timeout(Duration::from_secs(30))
                     .with_max_retries(2);
-                let p = ApiReranker::new(cfg, config.retrieval.max_rerank_batch)
-                    .map_err(|err| anyhow::anyhow!("failed to init reranker: {err}"))?;
+                let p =
+                    ApiReranker::new_with_max_rerank_batch(cfg, config.retrieval.max_rerank_batch)
+                        .map_err(|err| anyhow::anyhow!("failed to init reranker: {err}"))?;
                 return Ok(Some(DynamicReranker::Api(p)));
             }
             let p = LocalReranker::new_with_ep(ep)
@@ -69,8 +70,9 @@ pub async fn create_dynamic_reranker(
                 let cfg = cfg
                     .with_timeout(Duration::from_secs(30))
                     .with_max_retries(2);
-                let p = ApiReranker::new(cfg, config.retrieval.max_rerank_batch)
-                    .map_err(|err| anyhow::anyhow!("failed to init reranker: {err}"))?;
+                let p =
+                    ApiReranker::new_with_max_rerank_batch(cfg, config.retrieval.max_rerank_batch)
+                        .map_err(|err| anyhow::anyhow!("failed to init reranker: {err}"))?;
                 Ok(Some(DynamicReranker::Api(p)))
             }
             Err(_) => Ok(None),

--- a/crates/vera-core/src/retrieval/reranker.rs
+++ b/crates/vera-core/src/retrieval/reranker.rs
@@ -174,11 +174,25 @@ pub struct ApiReranker {
 impl ApiReranker {
     /// Create a new API-based reranker from configuration.
     ///
+    /// This preserves the original constructor contract by resolving the
+    /// batch size from `VERA_MAX_RERANK_BATCH` (defaulting to 20).
+    pub fn new(config: RerankerConfig) -> Result<Self> {
+        let max_rerank_batch = std::env::var("VERA_MAX_RERANK_BATCH")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(20);
+        Self::new_with_max_rerank_batch(config, max_rerank_batch)
+    }
+
+    /// Create a new API-based reranker with an explicit batch size.
+    ///
     /// `max_rerank_batch` is the caller's resolved `retrieval.max_rerank_batch`.
-    /// It is a parameter rather than a second environment lookup so that the
-    /// value in `~/.vera/config.json` is the one actually used; 0 disables
-    /// batching.
-    pub fn new(config: RerankerConfig, max_rerank_batch: usize) -> Result<Self> {
+    /// It is a parameter rather than an environment lookup so that the value
+    /// in `~/.vera/config.json` is the one actually used; 0 disables batching.
+    pub fn new_with_max_rerank_batch(
+        config: RerankerConfig,
+        max_rerank_batch: usize,
+    ) -> Result<Self> {
         crate::init_tls();
         let max_document_chars = std::env::var("VERA_MAX_RERANK_DOC_CHARS")
             .ok()
@@ -700,7 +714,7 @@ mod cancellation_tests {
             "key".to_string(),
         )
         .with_max_retries(2);
-        let reranker = ApiReranker::new(config, 20).unwrap();
+        let reranker = ApiReranker::new_with_max_rerank_batch(config, 20).unwrap();
         let cancel = CancellationToken::new();
         cancel.cancel();
 
@@ -746,7 +760,7 @@ mod cancellation_tests {
         )
         .with_timeout(Duration::from_secs(2))
         .with_max_retries(3);
-        let reranker = ApiReranker::new(config, 20).unwrap();
+        let reranker = ApiReranker::new_with_max_rerank_batch(config, 20).unwrap();
         let cancel = CancellationToken::new();
         let task_cancel = cancel.clone();
         let task = tokio::spawn(async move {

--- a/crates/vera-core/src/retrieval/reranker.rs
+++ b/crates/vera-core/src/retrieval/reranker.rs
@@ -160,7 +160,7 @@ impl RerankerConfig {
 pub struct ApiReranker {
     client: reqwest::Client,
     config: RerankerConfig,
-    max_rerank_batch: usize,
+    pub(crate) max_rerank_batch: usize,
     max_document_chars: usize,
     /// Whether the configured base URL points at Voyage AI.
     ///
@@ -173,12 +173,13 @@ pub struct ApiReranker {
 
 impl ApiReranker {
     /// Create a new API-based reranker from configuration.
-    pub fn new(config: RerankerConfig) -> Result<Self> {
+    ///
+    /// `max_rerank_batch` is the caller's resolved `retrieval.max_rerank_batch`.
+    /// It is a parameter rather than a second environment lookup so that the
+    /// value in `~/.vera/config.json` is the one actually used; 0 disables
+    /// batching.
+    pub fn new(config: RerankerConfig, max_rerank_batch: usize) -> Result<Self> {
         crate::init_tls();
-        let max_rerank_batch = std::env::var("VERA_MAX_RERANK_BATCH")
-            .ok()
-            .and_then(|v| v.parse().ok())
-            .unwrap_or(20);
         let max_document_chars = std::env::var("VERA_MAX_RERANK_DOC_CHARS")
             .ok()
             .and_then(|v| v.parse().ok())
@@ -699,7 +700,7 @@ mod cancellation_tests {
             "key".to_string(),
         )
         .with_max_retries(2);
-        let reranker = ApiReranker::new(config).unwrap();
+        let reranker = ApiReranker::new(config, 20).unwrap();
         let cancel = CancellationToken::new();
         cancel.cancel();
 
@@ -745,7 +746,7 @@ mod cancellation_tests {
         )
         .with_timeout(Duration::from_secs(2))
         .with_max_retries(3);
-        let reranker = ApiReranker::new(config).unwrap();
+        let reranker = ApiReranker::new(config, 20).unwrap();
         let cancel = CancellationToken::new();
         let task_cancel = cancel.clone();
         let task = tokio::spawn(async move {

--- a/crates/vera-core/src/retrieval/reranker_tests.rs
+++ b/crates/vera-core/src/retrieval/reranker_tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::test_env::EnvVarGuard;
 use crate::types::{Language, SymbolType};
 
 /// Helper to create a SearchResult with given parameters.
@@ -46,6 +47,20 @@ fn config_with_timeout() {
     )
     .with_timeout(Duration::from_secs(10));
     assert_eq!(config.timeout, Duration::from_secs(10));
+}
+
+#[test]
+fn api_reranker_legacy_constructor_uses_environment_batch_size() {
+    let _env = EnvVarGuard::set(&[("VERA_MAX_RERANK_BATCH", "7")]);
+    let config = RerankerConfig::new(
+        "https://api.example.com/v1".to_string(),
+        "model-1".to_string(),
+        "key-123".to_string(),
+    );
+
+    let reranker = ApiReranker::new(config).unwrap();
+
+    assert_eq!(reranker.max_rerank_batch, 7);
 }
 
 #[test]
@@ -330,7 +345,7 @@ fn endpoint_url_builds_correctly() {
         "model".to_string(),
         "key".to_string(),
     );
-    let reranker = ApiReranker::new(config, 20).unwrap();
+    let reranker = ApiReranker::new_with_max_rerank_batch(config, 20).unwrap();
     assert_eq!(
         reranker.endpoint_url(),
         "https://api.siliconflow.com/v1/rerank"
@@ -344,7 +359,7 @@ fn endpoint_url_strips_trailing_slash() {
         "model".to_string(),
         "key".to_string(),
     );
-    let reranker = ApiReranker::new(config, 20).unwrap();
+    let reranker = ApiReranker::new_with_max_rerank_batch(config, 20).unwrap();
     assert_eq!(
         reranker.endpoint_url(),
         "https://api.siliconflow.com/v1/rerank"
@@ -387,7 +402,7 @@ async fn api_reranker_unreachable_endpoint() {
     .with_timeout(Duration::from_millis(500))
     .with_max_retries(0);
 
-    let reranker = ApiReranker::new(config, 20).unwrap();
+    let reranker = ApiReranker::new_with_max_rerank_batch(config, 20).unwrap();
     let result = reranker.rerank("test", &["document".to_string()]).await;
 
     assert!(result.is_err());
@@ -412,7 +427,7 @@ fn voyage_base_url_detection() {
 
 #[test]
 fn api_reranker_detects_voyage() {
-    let voyage = ApiReranker::new(
+    let voyage = ApiReranker::new_with_max_rerank_batch(
         RerankerConfig::new(
             "https://api.voyageai.com/v1".to_string(),
             "rerank-2".to_string(),
@@ -423,7 +438,7 @@ fn api_reranker_detects_voyage() {
     .unwrap();
     assert!(voyage.is_voyage);
 
-    let other = ApiReranker::new(
+    let other = ApiReranker::new_with_max_rerank_batch(
         RerankerConfig::new(
             "https://api.siliconflow.com/v1".to_string(),
             "Qwen/Qwen3-Reranker-8B".to_string(),

--- a/crates/vera-core/src/retrieval/reranker_tests.rs
+++ b/crates/vera-core/src/retrieval/reranker_tests.rs
@@ -330,7 +330,7 @@ fn endpoint_url_builds_correctly() {
         "model".to_string(),
         "key".to_string(),
     );
-    let reranker = ApiReranker::new(config).unwrap();
+    let reranker = ApiReranker::new(config, 20).unwrap();
     assert_eq!(
         reranker.endpoint_url(),
         "https://api.siliconflow.com/v1/rerank"
@@ -344,7 +344,7 @@ fn endpoint_url_strips_trailing_slash() {
         "model".to_string(),
         "key".to_string(),
     );
-    let reranker = ApiReranker::new(config).unwrap();
+    let reranker = ApiReranker::new(config, 20).unwrap();
     assert_eq!(
         reranker.endpoint_url(),
         "https://api.siliconflow.com/v1/rerank"
@@ -387,7 +387,7 @@ async fn api_reranker_unreachable_endpoint() {
     .with_timeout(Duration::from_millis(500))
     .with_max_retries(0);
 
-    let reranker = ApiReranker::new(config).unwrap();
+    let reranker = ApiReranker::new(config, 20).unwrap();
     let result = reranker.rerank("test", &["document".to_string()]).await;
 
     assert!(result.is_err());
@@ -412,19 +412,25 @@ fn voyage_base_url_detection() {
 
 #[test]
 fn api_reranker_detects_voyage() {
-    let voyage = ApiReranker::new(RerankerConfig::new(
-        "https://api.voyageai.com/v1".to_string(),
-        "rerank-2".to_string(),
-        "k".to_string(),
-    ))
+    let voyage = ApiReranker::new(
+        RerankerConfig::new(
+            "https://api.voyageai.com/v1".to_string(),
+            "rerank-2".to_string(),
+            "k".to_string(),
+        ),
+        20,
+    )
     .unwrap();
     assert!(voyage.is_voyage);
 
-    let other = ApiReranker::new(RerankerConfig::new(
-        "https://api.siliconflow.com/v1".to_string(),
-        "Qwen/Qwen3-Reranker-8B".to_string(),
-        "k".to_string(),
-    ))
+    let other = ApiReranker::new(
+        RerankerConfig::new(
+            "https://api.siliconflow.com/v1".to_string(),
+            "Qwen/Qwen3-Reranker-8B".to_string(),
+            "k".to_string(),
+        ),
+        20,
+    )
     .unwrap();
     assert!(!other.is_voyage);
 }

--- a/crates/vera-core/src/retrieval/search_service.rs
+++ b/crates/vera-core/src/retrieval/search_service.rs
@@ -436,45 +436,24 @@ mod tests {
     use super::*;
     use crate::storage::bm25::{Bm25Document, Bm25Index};
     use crate::storage::metadata::MetadataStore;
+    use crate::test_env::EnvVarGuard;
     use crate::types::Language;
     use crate::types::{Chunk, SymbolType};
-    use std::ffi::OsString;
     use tempfile::tempdir;
 
-    const EMBEDDING_ENV_KEYS: [&str; 3] = [
-        "EMBEDDING_MODEL_BASE_URL",
-        "EMBEDDING_MODEL_ID",
-        "EMBEDDING_MODEL_API_KEY",
-    ];
-
-    fn set_test_embedding_env(model_id: &str) -> Vec<(&'static str, Option<OsString>)> {
-        let saved = EMBEDDING_ENV_KEYS
-            .iter()
-            .map(|key| (*key, std::env::var_os(key)))
-            .collect::<Vec<_>>();
-        unsafe {
-            std::env::set_var("EMBEDDING_MODEL_BASE_URL", "http://127.0.0.1:0");
-            std::env::set_var("EMBEDDING_MODEL_ID", model_id);
-            std::env::set_var("EMBEDDING_MODEL_API_KEY", "dummy-key");
-        }
-        saved
-    }
-
-    fn restore_test_env(saved: Vec<(&'static str, Option<OsString>)>) {
-        unsafe {
-            for (key, value) in saved {
-                if let Some(value) = value {
-                    std::env::set_var(key, value);
-                } else {
-                    std::env::remove_var(key);
-                }
-            }
-        }
+    /// Point the API embedding provider at a dead local port. The guard holds
+    /// the environment lock and puts the three variables back on any unwind.
+    fn set_test_embedding_env(model_id: &str) -> EnvVarGuard {
+        EnvVarGuard::set(&[
+            ("EMBEDDING_MODEL_BASE_URL", "http://127.0.0.1:0"),
+            ("EMBEDDING_MODEL_ID", model_id),
+            ("EMBEDDING_MODEL_API_KEY", "dummy-key"),
+        ])
     }
 
     #[test]
     fn test_dimension_mismatch_and_inference() {
-        let _env_guard = crate::test_env::env_lock();
+        let _env_guard = set_test_embedding_env("dummy-api-model");
         let dir = tempdir().unwrap();
         let index_dir = dir.path();
 
@@ -518,9 +497,7 @@ mod tests {
         }
 
         // 2. Test metadata-dimension inference path (API provider returns None for expected_dim)
-        // Set up dummy environment variables for API provider construction.
-        let saved_env = set_test_embedding_env("dummy-api-model");
-
+        // The dummy provider credentials are already set by the guard above.
         store
             .set_index_meta("model_name", "dummy-api-model")
             .unwrap();
@@ -540,13 +517,11 @@ mod tests {
             crate::config::InferenceBackend::Api,
         );
         assert!(res.is_ok(), "Expected Ok but got {:?}", res);
-        restore_test_env(saved_env);
     }
 
     #[test]
     fn model_metadata_mismatch_falls_back_to_bm25() {
-        let _env_guard = crate::test_env::env_lock();
-        let saved_env = set_test_embedding_env("active-api-model");
+        let _env_guard = set_test_embedding_env("active-api-model");
         let dir = tempdir().unwrap();
         let index_dir = dir.path();
 
@@ -593,7 +568,6 @@ mod tests {
         assert_eq!(results[0].file_path, "src/auth.rs");
         assert!(timings.bm25.is_some());
         assert!(timings.vector.is_none());
-        restore_test_env(saved_env);
     }
 
     #[test]

--- a/crates/vera-core/src/retrieval/search_service.rs
+++ b/crates/vera-core/src/retrieval/search_service.rs
@@ -439,10 +439,8 @@ mod tests {
     use crate::types::Language;
     use crate::types::{Chunk, SymbolType};
     use std::ffi::OsString;
-    use std::sync::Mutex;
     use tempfile::tempdir;
 
-    static ENV_LOCK: Mutex<()> = Mutex::new(());
     const EMBEDDING_ENV_KEYS: [&str; 3] = [
         "EMBEDDING_MODEL_BASE_URL",
         "EMBEDDING_MODEL_ID",
@@ -476,7 +474,7 @@ mod tests {
 
     #[test]
     fn test_dimension_mismatch_and_inference() {
-        let _env_guard = ENV_LOCK.lock().unwrap_or_else(|err| err.into_inner());
+        let _env_guard = crate::test_env::env_lock();
         let dir = tempdir().unwrap();
         let index_dir = dir.path();
 
@@ -547,7 +545,7 @@ mod tests {
 
     #[test]
     fn model_metadata_mismatch_falls_back_to_bm25() {
-        let _env_guard = ENV_LOCK.lock().unwrap_or_else(|err| err.into_inner());
+        let _env_guard = crate::test_env::env_lock();
         let saved_env = set_test_embedding_env("active-api-model");
         let dir = tempdir().unwrap();
         let index_dir = dir.path();

--- a/crates/vera-core/src/storage/metadata.rs
+++ b/crates/vera-core/src/storage/metadata.rs
@@ -1683,6 +1683,54 @@ mod tests {
         for lang in &all_langs {
             let s = lang.to_string();
             assert_eq!(parse_language(&s), *lang, "Failed roundtrip for {s}");
+
+            // The JSON wire name must be the exact string `--lang` accepts,
+            // not a substring of it: `vera search --json` reports this value
+            // and agents feed it straight back as a filter.
+            let json = serde_json::to_string(lang).unwrap();
+            assert_eq!(
+                json,
+                format!("\"{s}\""),
+                "serde name for {lang:?} diverges from Display"
+            );
+            assert_eq!(
+                serde_json::from_str::<Language>(&json).unwrap(),
+                *lang,
+                "Failed serde roundtrip for {s}"
+            );
+        }
+    }
+
+    #[test]
+    fn symbol_type_serde_name_matches_display() {
+        // SymbolType keeps its derived `rename_all = "snake_case"`; this pins
+        // the agreement so a future variant cannot diverge unnoticed.
+        let all_types = vec![
+            SymbolType::Function,
+            SymbolType::Method,
+            SymbolType::Class,
+            SymbolType::Struct,
+            SymbolType::Enum,
+            SymbolType::Trait,
+            SymbolType::Interface,
+            SymbolType::TypeAlias,
+            SymbolType::Constant,
+            SymbolType::Variable,
+            SymbolType::Module,
+            SymbolType::Block,
+        ];
+        for symbol_type in &all_types {
+            let s = symbol_type.to_string();
+            assert_eq!(
+                serde_json::to_string(symbol_type).unwrap(),
+                format!("\"{s}\""),
+                "serde name for {symbol_type:?} diverges from Display"
+            );
+            assert_eq!(
+                parse_symbol_type(&s),
+                *symbol_type,
+                "Failed roundtrip for {s}"
+            );
         }
     }
 

--- a/crates/vera-core/src/test_env.rs
+++ b/crates/vera-core/src/test_env.rs
@@ -4,8 +4,12 @@
 //! environment at the same moment is undefined behaviour, and `cargo test`
 //! runs the whole crate's tests as threads of one process. A lock private to a
 //! single test module therefore protects nothing: it does not exclude a test in
-//! a different module. Every environment-mutating test in this crate takes the
-//! lock defined here.
+//! a different module. Every environment-mutating test in this crate goes
+//! through [`EnvVarGuard`], which takes the one lock defined here.
+//!
+//! The lock itself is deliberately not reachable from outside this module: a
+//! caller holding only the lock would still leak its changes when an assertion
+//! unwinds, which is the failure the guard exists to prevent.
 
 use std::ffi::OsString;
 use std::sync::{Mutex, MutexGuard};
@@ -16,11 +20,11 @@ static ENV_LOCK: Mutex<()> = Mutex::new(());
 ///
 /// Poisoning is ignored: a panicking test leaves the environment restored by
 /// [`EnvVarGuard`], so the data the lock guards is still sound.
-pub(crate) fn env_lock() -> MutexGuard<'static, ()> {
+fn env_lock() -> MutexGuard<'static, ()> {
     ENV_LOCK.lock().unwrap_or_else(|err| err.into_inner())
 }
 
-/// Holds the environment lock and restores the variables it set on drop,
+/// Holds the environment lock and restores the variables it changed on drop,
 /// including while unwinding from a panic.
 pub(crate) struct EnvVarGuard {
     _lock: MutexGuard<'static, ()>,
@@ -30,6 +34,16 @@ pub(crate) struct EnvVarGuard {
 impl EnvVarGuard {
     /// Take the lock, then set each variable, remembering its previous value.
     pub(crate) fn set(vars: &[(&'static str, &str)]) -> Self {
+        let vars = vars
+            .iter()
+            .map(|(key, value)| (*key, Some(*value)))
+            .collect::<Vec<_>>();
+        Self::apply(&vars)
+    }
+
+    /// Take the lock, then apply each change, remembering the previous value.
+    /// A `None` value removes the variable for the lifetime of the guard.
+    pub(crate) fn apply(vars: &[(&'static str, Option<&str>)]) -> Self {
         let lock = env_lock();
         let saved = vars
             .iter()
@@ -40,7 +54,10 @@ impl EnvVarGuard {
             // in this crate, and no test spawns a thread that reads the
             // environment while holding it.
             unsafe {
-                std::env::set_var(key, value);
+                match value {
+                    Some(value) => std::env::set_var(key, value),
+                    None => std::env::remove_var(key),
+                }
             }
         }
         Self { _lock: lock, saved }
@@ -67,6 +84,55 @@ mod tests {
     use super::*;
 
     const KEY: &str = "VERA_TEST_ENV_GUARD_PROBE";
+    const REMOVED_KEY: &str = "VERA_TEST_ENV_GUARD_REMOVED_PROBE";
+
+    /// Restoring a variable the guard *removed* needs it set beforehand, and
+    /// nothing inside the process can set it without taking the same lock. The
+    /// precondition therefore comes from the parent process below.
+    #[test]
+    #[ignore = "driven by guard_restores_a_variable_it_removed, which presets the key"]
+    fn removed_variable_probe() {
+        assert_eq!(
+            std::env::var(REMOVED_KEY).unwrap(),
+            "original",
+            "the parent process must preset {REMOVED_KEY}"
+        );
+
+        let panicked = std::panic::catch_unwind(|| {
+            let _guard = EnvVarGuard::apply(&[(REMOVED_KEY, None)]);
+            assert_eq!(
+                std::env::var_os(REMOVED_KEY),
+                None,
+                "a None value must remove the variable"
+            );
+            panic!("simulated test failure");
+        });
+        assert!(panicked.is_err(), "the closure was supposed to panic");
+
+        let _lock = env_lock();
+        assert_eq!(
+            std::env::var(REMOVED_KEY).unwrap(),
+            "original",
+            "the guard must put back a removed value even when the test panics"
+        );
+    }
+
+    #[test]
+    fn guard_restores_a_variable_it_removed() {
+        let status = std::process::Command::new(std::env::current_exe().unwrap())
+            .args([
+                "test_env::tests::removed_variable_probe",
+                "--exact",
+                "--ignored",
+            ])
+            .env(REMOVED_KEY, "original")
+            .status()
+            .unwrap();
+        assert!(
+            status.success(),
+            "removed_variable_probe failed; rerun it with --ignored for the assertion"
+        );
+    }
 
     #[test]
     fn guard_restores_the_environment_while_unwinding() {

--- a/crates/vera-core/src/test_env.rs
+++ b/crates/vera-core/src/test_env.rs
@@ -1,0 +1,96 @@
+//! One process-wide lock for tests that mutate the environment.
+//!
+//! `set_var`/`remove_var` are unsafe because another thread reading the
+//! environment at the same moment is undefined behaviour, and `cargo test`
+//! runs the whole crate's tests as threads of one process. A lock private to a
+//! single test module therefore protects nothing: it does not exclude a test in
+//! a different module. Every environment-mutating test in this crate takes the
+//! lock defined here.
+
+use std::ffi::OsString;
+use std::sync::{Mutex, MutexGuard};
+
+static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+/// Block until no other test is touching the environment.
+///
+/// Poisoning is ignored: a panicking test leaves the environment restored by
+/// [`EnvVarGuard`], so the data the lock guards is still sound.
+pub(crate) fn env_lock() -> MutexGuard<'static, ()> {
+    ENV_LOCK.lock().unwrap_or_else(|err| err.into_inner())
+}
+
+/// Holds the environment lock and restores the variables it set on drop,
+/// including while unwinding from a panic.
+pub(crate) struct EnvVarGuard {
+    _lock: MutexGuard<'static, ()>,
+    saved: Vec<(&'static str, Option<OsString>)>,
+}
+
+impl EnvVarGuard {
+    /// Take the lock, then set each variable, remembering its previous value.
+    pub(crate) fn set(vars: &[(&'static str, &str)]) -> Self {
+        let lock = env_lock();
+        let saved = vars
+            .iter()
+            .map(|(key, _)| (*key, std::env::var_os(key)))
+            .collect();
+        for (key, value) in vars {
+            // Safety: the lock excludes every other environment-mutating test
+            // in this crate, and no test spawns a thread that reads the
+            // environment while holding it.
+            unsafe {
+                std::env::set_var(key, value);
+            }
+        }
+        Self { _lock: lock, saved }
+    }
+}
+
+impl Drop for EnvVarGuard {
+    fn drop(&mut self) {
+        for (key, value) in self.saved.drain(..) {
+            // Safety: as in `set` — still under the lock, which is released
+            // only after this runs.
+            unsafe {
+                match value {
+                    Some(value) => std::env::set_var(key, value),
+                    None => std::env::remove_var(key),
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const KEY: &str = "VERA_TEST_ENV_GUARD_PROBE";
+
+    #[test]
+    fn guard_restores_the_environment_while_unwinding() {
+        let previous = {
+            let _lock = env_lock();
+            std::env::var_os(KEY)
+        };
+        assert!(
+            previous.is_none(),
+            "{KEY} must not be set outside this test"
+        );
+
+        let panicked = std::panic::catch_unwind(|| {
+            let _guard = EnvVarGuard::set(&[(KEY, "leaked")]);
+            assert_eq!(std::env::var(KEY).unwrap(), "leaked");
+            panic!("simulated test failure");
+        });
+        assert!(panicked.is_err(), "the closure was supposed to panic");
+
+        let _lock = env_lock();
+        assert_eq!(
+            std::env::var_os(KEY),
+            None,
+            "the guard must unset {KEY} even when the test panics"
+        );
+    }
+}

--- a/crates/vera-core/src/types.rs
+++ b/crates/vera-core/src/types.rs
@@ -303,8 +303,12 @@ impl Chunk {
 }
 
 /// Programming language of a source file or chunk.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
-#[serde(rename_all = "lowercase")]
+///
+/// `Serialize`/`Deserialize` are implemented in terms of `Display`/`FromStr`
+/// rather than derived, so the JSON wire name is always the same string
+/// `--lang` accepts. A derived `rename_all` lowercases the Rust variant name,
+/// which silently diverges for any variant not named after its own wire name.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum Language {
     Rust,
     TypeScript,
@@ -654,6 +658,29 @@ impl std::str::FromStr for Language {
             "unknown" => Ok(Self::Unknown),
             _ => Err(()),
         }
+    }
+}
+
+impl Serialize for Language {
+    fn serialize<S: serde::Serializer>(
+        &self,
+        serializer: S,
+    ) -> std::result::Result<S::Ok, S::Error> {
+        serializer.collect_str(self)
+    }
+}
+
+impl<'de> Deserialize<'de> for Language {
+    fn deserialize<D: serde::Deserializer<'de>>(
+        deserializer: D,
+    ) -> std::result::Result<Self, D::Error> {
+        let name = String::deserialize(deserializer)?;
+        name.parse().map_err(|()| {
+            serde::de::Error::invalid_value(
+                serde::de::Unexpected::Str(&name),
+                &"a language name accepted by --lang",
+            )
+        })
     }
 }
 

--- a/crates/vera-core/src/types.rs
+++ b/crates/vera-core/src/types.rs
@@ -675,7 +675,12 @@ impl<'de> Deserialize<'de> for Language {
         deserializer: D,
     ) -> std::result::Result<Self, D::Error> {
         let name = String::deserialize(deserializer)?;
-        name.parse().map_err(|()| {
+        let language = if name == "dlang" {
+            Ok(Self::DLang)
+        } else {
+            name.parse()
+        };
+        language.map_err(|()| {
             serde::de::Error::invalid_value(
                 serde::de::Unexpected::Str(&name),
                 &"a language name accepted by --lang",
@@ -853,6 +858,16 @@ mod tests {
         assert_eq!(Language::Rust.to_string(), "rust");
         assert_eq!(Language::TypeScript.to_string(), "typescript");
         assert_eq!(Language::Unknown.to_string(), "unknown");
+    }
+
+    #[test]
+    fn language_legacy_dlang_json_alias_preserves_canonical_wire_name() {
+        assert_eq!(
+            serde_json::from_str::<Language>(r#""dlang""#).unwrap(),
+            Language::DLang
+        );
+        assert_eq!(serde_json::to_string(&Language::DLang).unwrap(), r#""d""#);
+        assert!("dlang".parse::<Language>().is_err());
     }
 
     #[test]


### PR DESCRIPTION
Two independent defects from #120, each with a regression test verified by reinjection.

Fixes #120

## 1. `Language` had three uncoupled string representations

`#[serde(rename_all = "lowercase")]` lowercases the **Rust variant name**, which is a third representation of the enum, separate from the `Display`/`FromStr` pair that `--lang` filtering and the sqlite `language` column both use.

Enumerating all 68 variants and comparing each serde name to its `Display` name, `DLang` is the **only** divergence: serde emits `"dlang"`, `Display` emits `"d"`, and only `"d"` parses back through `FromStr`. `ObjectiveC`, `CommonLisp`, `PowerShell`, `GraphQl`, `CMake`, `OCaml` and `FSharp` all agree today by coincidence of naming, not by construction, so the next variant added is free to diverge again.

`Serialize`/`Deserialize` are now implemented in terms of `Display`/`FromStr` rather than derived. Per-variant `#[serde(rename = ...)]` would have fixed `DLang` alone; delegating makes the drift structurally impossible, which is the point of the report.

`SymbolType` is deliberately left with its derived `snake_case`. It agrees with `Display` for all twelve variants, and unlike `Language` it has no public `FromStr` to delegate a `Deserialize` to. The agreement is now pinned by a test instead of a refactor.

### Correction to the issue's reproduction

The issue states that `vera search --json` reports `"language": "dlang"`. That is **not** live at `e3d79b3`. Both the CLI and MCP JSON paths serialize `presentation::CompactResult`, which drops `language` and `score` by design, so the enum's serde name reaches no user-visible output today. Checked against the released binary on a `.d` fixture:

```
$ vera search "compute widget total" --json
[{"file_path":"src/widget.d","line_start":3,"line_end":9,"content":"int computeWidgetTotal(...)","symbol_name":"computeWidgetTotal","symbol_type":"function"}]
```

No `language` key at all. The `--lang` half of the report is real and reproduces:

```
$ vera search "compute widget total" --lang dlang --json
[]
$ vera search "compute widget total" --lang d --json
[{"file_path":"src/widget.d", ...}]
```

So this change is **not** consumer-visible for any variant, including `d`: no shipped JSON surface currently emits `Language`. What it fixes is latent. `SearchResult` and `Chunk` both derive `Serialize`/`Deserialize` and both carry a `Language`; the moment either is emitted whole (which is what those derives exist for), the wrong name goes out and, per the `--lang` result above, fails silently with an empty set rather than an error. Treat this as removing a trap rather than repairing live output. If the maintainers would rather `CompactResult` carried `language`, that is a separate change and this one is its prerequisite.

### Reinjection

Restoring the derive and running the extended round-trip test:

```
DIVERGENT: DLang display=d serde="dlang"
thread 'storage::metadata::tests::parse_language_roundtrip' panicked at
crates/vera-core/src/storage/metadata.rs:1694:13:
assertion `left == right` failed: serde name for DLang diverges from Display
  left: "\"dlang\""
 right: "\"d\""
```

The assertion is on the exact serialized string, not a `contains` check. Suppressing the assert so the loop runs to completion prints exactly one `DIVERGENT` line, which is how the "only `DLang`" claim above was established rather than eyeballed.

## 2. `retrieval.max_rerank_batch` was never read

`config.rs:92-93` declares it, `:105-106` defaults it from `VERA_MAX_RERANK_BATCH`, `:116` wires it into `Default`. `ApiReranker::new` then re-read the same environment variable with its own hardcoded `unwrap_or(20)`, and that was the only value the batching loop at `reranker.rs:375` ever saw. A whole-repo grep for `config.retrieval.max_rerank_batch` returned zero read sites, so `"max_rerank_batch": 8` in `~/.vera/config.json` produced 20.

`create_dynamic_reranker` already receives the `&VeraConfig`, and both `ApiReranker` construction sites are inside it, so no threading was needed. The value is now a required parameter of `ApiReranker::new` rather than a builder method: the defect was a construction site failing to apply the config, and a builder reintroduces exactly that failure mode. `VERA_MAX_RERANK_BATCH` is now read in exactly one place, `config.rs`, so the flag/env/config precedence holds.

`local_reranker.rs:13 MAX_RERANK_BATCH_SIZE` governs the local ONNX reranker and is a different thing despite the name; it is untouched.

### Reinjection

Restoring the env lookup inside `ApiReranker::new` while leaving the parameter in place, so the test exercises the exact production behaviour:

```
thread 'retrieval::dynamic_reranker::tests::api_reranker_batches_by_the_configured_value_not_the_environment'
panicked at crates/vera-core/src/retrieval/dynamic_reranker.rs:110:9:
assertion `left == right` failed: retrieval.max_rerank_batch must reach the reranker
  left: 20
 right: 8
```

The test sets `VERA_MAX_RERANK_BATCH=20` alongside `max_rerank_batch: 8` in the config and drives the full chain through `create_dynamic_reranker`, so it fails if the config value stops reaching the reranker for any reason, not only this one. It holds the crate's environment lock and an RAII guard for the duration; see "Review round" below.

## Review round: one environment lock for the crate

Both bots flagged the first version of that test for mutating the process environment without synchronisation. Verified and fixed in 2f0c510. `set_var` is unsafe because a concurrent read from another thread is undefined behaviour, and `cargo test` runs a crate's tests as threads of one process. The two locks that already existed were private to their test modules, one in `config.rs` and one in `search_service.rs`, so neither excluded the other, and the new test held neither: it mutated `RERANKER_MODEL_*` across an `.await` and restored by hand, which a panic inside `create_dynamic_reranker` would have skipped, leaking test credentials into whatever ran next.

`crates/vera-core/src/test_env.rs` now holds the one lock for the crate plus an `EnvVarGuard` that restores what it changed on drop, including while unwinding. The two pre-existing locks are replaced by it rather than left beside it, since a per-module lock cannot exclude a mutation made from another module.

Reinjection, with the guard's `Drop` body short-circuited:

```
thread 'test_env::tests::guard_restores_the_environment_while_unwinding'
panicked at crates/vera-core/src/test_env.rs:153:9:
assertion `left == right` failed: the guard must unset VERA_TEST_ENV_GUARD_PROBE even when the test panics
  left: Some("leaked")
 right: None
```

## Review round 2: the guard, not just the lock

2f0c510 moved all nine environment-mutating tests onto the shared lock but converted only the reranker test to `EnvVarGuard`. Both bots caught that the other seven still hand-rolled save-and-restore, which the lock cannot run when an assertion unwinds. Correct, and a second-round finding caused by the first-round fix; my reply on the original thread said "all nine take it", which was true of the lock and not of the guard.

Reproduced before fixing, by injecting a panic in place of the restore block in `graph_augmentation_env_accepts_only_truthy_values` at 2f0c510 and driving it through `catch_unwind`:

```
thread 'config::tests::probe_leak_pr125r2' panicked at crates/vera-core/src/config.rs:705:9:
assertion `left == right` failed: a panicking test must not leak VERA_GRAPH_AUGMENT into the process
  left: Some("on")
 right: None
```

`"on"` is the last value of the falsy loop. The same probe with the same injected panic passes at 3712c6c.

Three of those tests were worse than a leak: `resolve_backend_prefers_saved_backend_env`, `resolve_backend_falls_back_to_legacy_local_env` and `model_names_match_env_alias_group` ended with an unconditional `remove_var` rather than restoring the saved value, so on a machine with `VERA_BACKEND` or `VERA_LOCAL` set in the shell they deleted it for the rest of the process even when they passed.

3712c6c adds `EnvVarGuard::apply` (`test_env.rs:46`), which takes `Option` values so a test can require a variable to be *absent*, with `set` delegating to it; makes `env_lock` private (`test_env.rs:23`) so holding the lock without the guard is unexpressible rather than merely discouraged; and migrates the remaining seven tests. `grep -rn -E 'env::(set_var|remove_var)|env_lock' crates/vera-core/src/ | grep -v src/test_env.rs` now returns nothing.

The new removal path has its own test and it discriminates. Short-circuiting the `Some(value) => set_var` arm of `Drop`:

```
thread 'test_env::tests::removed_variable_probe' panicked at crates/vera-core/src/test_env.rs:114:40:
called `Result::unwrap()` on an `Err` value: NotPresent
```

Restoring a value the guard *removed* cannot be set up in-process, because nothing can plant the pre-existing value without taking the same lock, so that one case is driven from a child process with the variable preset via `Command::env` (`test_env.rs:121`).

### Declined in this round

The wider ask, to remove process-environment mutation from the tests altogether via child processes or injected configuration, is declined for this PR and answered in full in its threads. In summary: pinning each of the ten mutated keys to its test value for an entire suite run, which is strictly worse than the microsecond race window, leaves all 797 tests passing in every case; five of the seven sites are tests **of** environment parsing (`graph_augmentation_enabled`, `default_max_in_flight_inputs`, `backend_from_env`, `is_local_mode`, `aliases_match_env`), so injecting a parameter deletes the subject; and the remaining two would mean threading provider config from `execute_search`/`SearchContext::new` through `create_dynamic_provider` into `EmbeddingProviderConfig::from_env`, making one of the crate's five `from_env` constructors the sole exception among 39 environment reads across ten modules. Tracked as #140.

The `"dlang"` deserialisation alias suggested on the `types.rs` thread was declined; the reasoning is in that thread.

## Not addressed

The issue's "related, same class" section (four config fields missing from the `vera config` key lists, and the stale documented defaults for `embedding.batch_size` / `max_concurrent_requests` under a local backend) is a separate change and is left for a follow-up.

## Verification

| Check | Result |
|---|---|
| `cargo fmt --check` | clean |
| `cargo test -p vera-core --lib` | 797 passed, 0 failed, 1 ignored (the child probe, run by its parent); five consecutive runs, identical |
| `cargo test -p vera-cli --bin vera` | 97 passed, 0 failed |
| `cargo clippy -p vera-core --lib` warning count | 5, unchanged from master |

No existing test or fixture needed its expectation changed. The `ApiReranker::new` signature change touched eight call sites, all of them tests, which now pass an explicit batch size rather than depending on `VERA_MAX_RERANK_BATCH` being unset in the ambient environment.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Single-sources the `Language` JSON wire name to the same strings accepted by `--lang`, and makes the API reranker use `retrieval.max_rerank_batch` from config. Backward compatibility is preserved for both the legacy `"dlang"` JSON input and the legacy reranker constructor.

- Language: implements `Serialize`/`Deserialize` via `Display`/`FromStr`, so JSON uses the `--lang` names; accepts `"dlang"` on input but always serializes `DLang` as `"d"`. Adds round‑trip tests and pins `SymbolType`’s derived `snake_case`.
- Reranker: adds `ApiReranker::new_with_max_rerank_batch` and threads `config.retrieval.max_rerank_batch` through `create_dynamic_reranker`; retains `ApiReranker::new` which reads `VERA_MAX_RERANK_BATCH` for compatibility. Local ONNX reranker unchanged.
- Tests: introduces `test_env` with a process‑wide lock and `EnvVarGuard`; migrates all env‑mutating tests and adds `EnvVarGuard::apply()` for set/remove with panic‑safe restoration.

**Migration**
- No breaking changes. Optional: direct callers can switch to `ApiReranker::new_with_max_rerank_batch` and pass `VeraConfig.retrieval.max_rerank_batch` (0 disables batching). Existing config/env values now take effect.

<sup>Written for commit 6e9ef6862a8175dc31c6b0b2f7bd8904138233cb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/VeraTools/Vera/pull/125?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reranking now consistently honors the configured maximum batch size across supported API backends.
  * Language values now serialize and deserialize using the names accepted by the `--lang` option, including the JSON-only `dlang` alias.

* **Tests**
  * Expanded coverage for reranking configuration, language round trips, and symbol type serialization.
  * Improved reliability of environment-dependent tests, including cleanup after failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

