### PR TITLE
fix(parsing): Rust inline mod swallows every symbol inside it

### DIFF
--- a/crates/vera-core/src/parsing/extractor/mod.rs
+++ b/crates/vera-core/src/parsing/extractor/mod.rs
@@ -290,11 +290,19 @@ fn collect_symbols(
         // module, then keep walking so the items declared inside it are
         // extracted as symbols of their own instead of being swallowed by the
         // module's span. `mod name;` has no body and simply yields nothing more.
+        //
+        // Descend into the `declaration_list` rather than the `mod_item`, the
+        // way `extract_rust_block_methods` does: recursing from the `mod_item`
+        // spends one depth level on the module and a second on its body list,
+        // so three levels of nesting would exhaust the shared budget before
+        // reaching the items inside.
         if lang == Language::Rust && kind == "mod_item" {
             let name = extract_name(&node, source);
             symbols.push(RawSymbol::at(&node, name, sym_type));
-            let mut cursor = node.walk();
-            collect_symbols_cursor(&mut cursor, source, lang, symbols, depth + 1);
+            if let Some(body) = node.child_by_field_name("body") {
+                let mut cursor = body.walk();
+                collect_symbols_cursor(&mut cursor, source, lang, symbols, depth + 1);
+            }
             return;
         }
 

--- a/crates/vera-core/src/parsing/extractor/mod.rs
+++ b/crates/vera-core/src/parsing/extractor/mod.rs
@@ -279,9 +279,22 @@ fn collect_symbols(
             }
         }
 
-        // For Rust impl blocks, extract methods inside but also keep the whole block
-        if lang == Language::Rust && kind == "impl_item" {
-            extract_impl_methods(node, source, lang, symbols);
+        // For Rust impl and trait blocks, extract methods inside but also keep
+        // the whole block
+        if lang == Language::Rust && (kind == "impl_item" || kind == "trait_item") {
+            extract_rust_block_methods(node, source, lang, symbols, sym_type);
+            return;
+        }
+
+        // A Rust `mod name { ... }` is a container, not a leaf. Record the
+        // module, then keep walking so the items declared inside it are
+        // extracted as symbols of their own instead of being swallowed by the
+        // module's span. `mod name;` has no body and simply yields nothing more.
+        if lang == Language::Rust && kind == "mod_item" {
+            let name = extract_name(&node, source);
+            symbols.push(RawSymbol::at(&node, name, sym_type));
+            let mut cursor = node.walk();
+            collect_symbols_cursor(&mut cursor, source, lang, symbols, depth + 1);
             return;
         }
 

--- a/crates/vera-core/src/parsing/extractor/special_forms.rs
+++ b/crates/vera-core/src/parsing/extractor/special_forms.rs
@@ -275,19 +275,21 @@ pub(super) fn refine_go_type_spec(node: &tree_sitter::Node<'_>, source: &[u8]) -
     }
 }
 
-/// Extract individual methods from a Rust `impl` block as separate symbols.
-pub(super) fn extract_impl_methods(
-    impl_node: tree_sitter::Node<'_>,
+/// Extract individual methods from a Rust `impl` or `trait` block as separate
+/// symbols, keeping the block itself indexable as `container_type`.
+pub(super) fn extract_rust_block_methods(
+    block_node: tree_sitter::Node<'_>,
     source: &[u8],
     lang: Language,
     symbols: &mut Vec<RawSymbol>,
+    container_type: SymbolType,
 ) {
-    let name = extract_name(&impl_node, source);
-    symbols.push(RawSymbol::at(&impl_node, name, SymbolType::Block));
+    let name = extract_name(&block_node, source);
+    symbols.push(RawSymbol::at(&block_node, name, container_type));
 
-    let mut cursor = impl_node.walk();
+    let mut cursor = block_node.walk();
 
-    for child in impl_node.children(&mut cursor) {
+    for child in block_node.children(&mut cursor) {
         if child.kind() == "declaration_list" {
             let mut inner_cursor = child.walk();
             for item in child.children(&mut inner_cursor) {

--- a/crates/vera-core/src/parsing/extractor/tests.rs
+++ b/crates/vera-core/src/parsing/extractor/tests.rs
@@ -1869,3 +1869,45 @@ enum Role {
         "Prisma should extract models as structs"
     );
 }
+
+/// Three levels of inline `mod` around a single function. Each nesting level
+/// costs the shared depth budget, so the innermost item is the one at risk.
+const NESTED_INLINE_MOD_SOURCE: &str = r#"
+mod outer {
+    mod middle {
+        mod inner {
+            fn buried() -> i32 {
+                1
+            }
+        }
+    }
+}
+"#;
+
+#[test]
+fn rust_nested_inline_mods_reach_the_innermost_item() {
+    let symbols = parse_and_extract(NESTED_INLINE_MOD_SOURCE, Language::Rust);
+    let named: Vec<(&str, SymbolType)> = symbols
+        .iter()
+        .filter_map(|s| s.name.as_deref().map(|n| (n, s.symbol_type)))
+        .collect();
+
+    // Presence first: the enclosing modules must be there, or an extractor that
+    // returned nothing would satisfy the assertion below by accident.
+    assert!(
+        named.contains(&("outer", SymbolType::Module)),
+        "expected the outermost module, got {named:?}"
+    );
+    assert!(
+        named.contains(&("middle", SymbolType::Module)),
+        "expected the second-level module, got {named:?}"
+    );
+    assert!(
+        named.contains(&("inner", SymbolType::Module)),
+        "expected the third-level module, got {named:?}"
+    );
+    assert!(
+        named.contains(&("buried", SymbolType::Function)),
+        "expected the function inside three levels of inline mod, got {named:?}"
+    );
+}

--- a/crates/vera-core/src/parsing/extractor/tests.rs
+++ b/crates/vera-core/src/parsing/extractor/tests.rs
@@ -98,6 +98,137 @@ trait Drawable {
     assert_eq!(symbols[0].name.as_deref(), Some("Drawable"));
 }
 
+/// A `#[cfg(test)] mod tests { ... }` block holding the shapes that used to be
+/// swallowed by the module symbol: a free function, a struct, and an impl.
+const INLINE_MOD_SOURCE: &str = r#"
+fn helper() -> i32 {
+    1
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fixture() -> i32 {
+        helper()
+    }
+
+    struct Case {
+        value: i32,
+    }
+
+    impl Case {
+        fn run(&self) -> i32 {
+            fixture()
+        }
+    }
+}
+"#;
+
+#[test]
+fn rust_inline_mod_does_not_swallow_inner_symbols() {
+    let symbols = parse_and_extract(INLINE_MOD_SOURCE, Language::Rust);
+    let named: Vec<(&str, SymbolType)> = symbols
+        .iter()
+        .filter_map(|s| s.name.as_deref().map(|n| (n, s.symbol_type)))
+        .collect();
+
+    // Presence first: an extractor that returned nothing must not pass this.
+    assert!(
+        named.contains(&("helper", SymbolType::Function)),
+        "expected the top-level function, got {named:?}"
+    );
+    assert!(
+        named.contains(&("fixture", SymbolType::Function)),
+        "expected the function inside the inline mod, got {named:?}"
+    );
+    assert!(
+        named.contains(&("Case", SymbolType::Struct)),
+        "expected the struct inside the inline mod, got {named:?}"
+    );
+    assert!(
+        named.contains(&("run", SymbolType::Method)),
+        "expected the impl method inside the inline mod, got {named:?}"
+    );
+    // The module itself stays indexable, as `impl` blocks do.
+    assert!(
+        named.contains(&("tests", SymbolType::Module)),
+        "expected the module symbol itself, got {named:?}"
+    );
+
+    // Only then: the module no longer spans the inner symbols on its own.
+    let module = symbols
+        .iter()
+        .find(|s| s.symbol_type == SymbolType::Module)
+        .expect("module symbol");
+    let fixture = symbols
+        .iter()
+        .find(|s| s.name.as_deref() == Some("fixture"))
+        .expect("fixture symbol");
+    assert!(
+        fixture.start_byte > module.start_byte && fixture.end_byte < module.end_byte,
+        "fixture should be nested strictly inside the module span"
+    );
+}
+
+#[test]
+fn rust_inline_mod_attributes_calls_to_the_calling_function() {
+    let grammar = tree_sitter_grammar(Language::Rust).unwrap();
+    let mut parser = tree_sitter::Parser::new();
+    parser.set_language(&grammar).unwrap();
+    let tree = parser.parse(INLINE_MOD_SOURCE, None).unwrap();
+    let refs = crate::parsing::references::extract_references(
+        &tree,
+        INLINE_MOD_SOURCE.as_bytes(),
+        Language::Rust,
+    );
+
+    let callers = |callee: &str| -> Vec<Option<String>> {
+        refs.iter()
+            .filter(|r| r.callee == callee)
+            .map(|r| r.caller.clone())
+            .collect()
+    };
+
+    // Presence first: the calls have to be seen at all.
+    assert_eq!(
+        callers("helper"),
+        vec![Some("fixture".to_string())],
+        "call to helper should be attributed to the calling function, not the module"
+    );
+    assert_eq!(
+        callers("fixture"),
+        vec![Some("run".to_string())],
+        "call to fixture should be attributed to the calling method, not the module"
+    );
+}
+
+#[test]
+fn rust_trait_extracts_default_methods() {
+    let source = r#"
+trait Greeter {
+    fn name(&self) -> String;
+
+    fn greet(&self) -> String {
+        format!("hi {}", self.name())
+    }
+}
+"#;
+    let symbols = parse_and_extract(source, Language::Rust);
+    let named: Vec<(&str, SymbolType)> = symbols
+        .iter()
+        .filter_map(|s| s.name.as_deref().map(|n| (n, s.symbol_type)))
+        .collect();
+    assert!(
+        named.contains(&("Greeter", SymbolType::Trait)),
+        "expected the trait symbol, got {named:?}"
+    );
+    assert!(
+        named.contains(&("greet", SymbolType::Method)),
+        "expected the default method body, got {named:?}"
+    );
+}
+
 #[test]
 fn python_extracts_functions_and_class_methods() {
     let source = r#"

--- a/crates/vera-core/src/parsing/tests.rs
+++ b/crates/vera-core/src/parsing/tests.rs
@@ -105,6 +105,27 @@ fn rust_impl_methods_emit_no_gap_chunks() {
 }
 
 #[test]
+fn rust_inline_module_children_preserve_only_the_trailing_gap() {
+    let source = r#"mod nested {
+    fn first() {}
+
+    // Covered by the module chunk, not a separate gap.
+    fn second() {}
+}
+
+use std::fmt;
+"#;
+    let chunks = parse(source, "nested.rs", Language::Rust);
+    let names: Vec<_> = chunks
+        .iter()
+        .map(|chunk| chunk.symbol_name.as_deref())
+        .collect();
+
+    assert_eq!(names, [Some("nested"), Some("first"), Some("second"), None]);
+    assert_eq!(chunks.last().unwrap().content.trim(), "use std::fmt;");
+}
+
+#[test]
 fn rust_enum_and_trait() {
     let source = r#"enum Color {
     Red,


### PR DESCRIPTION
Fixes #106

## What was wrong

`classify.rs` maps `mod_item` to `SymbolType::Module`, and `collect_symbols` treats a classified node as a leaf unless it has an explicit recursion case. `impl_item`, Python `class_definition` and C# `namespace_declaration` have one; `mod_item` did not. So `mod name { ... }` was pushed as a single symbol spanning the whole block and extraction returned without descending.

Two things follow from that. Nothing declared inside an inline module reaches the symbol table, so those functions are absent from the call graph. And `find_enclosing_symbol` picks the smallest symbol containing the call site, which for any call inside the module was the module itself, so callers were reported as `tests`.

`#[cfg(test)] mod tests { ... }` is the standard idiom, so this affects most Rust files in most Rust repos, including this one.

## The change

`crates/vera-core/src/parsing/extractor/mod.rs:299` records the module, then calls `collect_symbols_cursor` with `depth + 1` on the module's `body` field. That is the shape `namespace_declaration` already uses at `:346`, except for entering at the body rather than the container. The `mod_item` and its `declaration_list` would otherwise each spend a level of the shared `depth > 6` budget, which put the contents of a third-level inline module out of reach; `extract_rust_block_methods` enters at the `declaration_list` for the same reason. `mod name;` has no body, so the `if let` yields nothing more.

`trait_item` had the same defect for default-bodied methods, so it now shares the `impl_item` path at `:284`. `extract_impl_methods` became `extract_rust_block_methods` with a container-type parameter, because `impl` records as `Block` and `trait` as `Trait`. Signature-only trait methods are `function_signature_item`, which `RUST_KINDS` does not classify, so a signature-only trait is unchanged.

## Measured, released 1.0.0 against this branch

Fixture: `parsing/chunker.rs`, `parsing/references.rs`, `parsing/signatures.rs` copied into a scratch tree and indexed separately with each binary. Same files, same queries.

Symbol counts by type, from `chunks` in `metadata.db`:

| symbol_type | 1.0.0 | branch |
|---|---|---|
| block | 30 | 59 |
| function | 23 | 53 |
| module | 4 | 4 |
| constant | 3 | 3 |
| struct | 1 | 1 |
| **chunks total** | **61** | **120** |

The 30 functions and 29 impl blocks that appear are the ones that were inside `mod tests`. Module count is unchanged, which is the point: the module is still recorded, it just no longer stands in for its contents.

Caller attribution, from `references`:

| | 1.0.0 | branch |
|---|---|---|
| references attributed to `tests` | 163 | 0 |
| distinct callers | 22 | 51 |

The two commands from the issue.

Before, released 1.0.0:

````
$ vera references tier0_line_chunks
```src/chunker.rs:644-648 module:tests (part 1)

$ vera references tier0_fallback_produces_chunks --callees
No callees found for 'tier0_fallback_produces_chunks'.
````

After, this branch:

````
$ vera references tier0_line_chunks
```src/chunker.rs:644-648 function:tier0_fallback_produces_chunks

$ vera references tier0_fallback_produces_chunks --callees
Symbols called by 'tier0_fallback_produces_chunks' (12 results):
  src/chunker.rs:646 → tier0_line_chunks
````

## This forces a re-index, and nothing notices

Extraction output changes, so an index built before this commit keeps the old attribution. No staleness guard catches it. Freshness is a per-file content hash and the files have not changed, and `index_metadata` holds only `embedding_dim`, `index_refreshed_at_unix_ms`, `indexing_config` and `model_name`, so `model_identity` does not cover the extractor.

Confirmed by running this branch's binary against an index built by 1.0.0:

```
$ vera update .
  Files unchanged: 3
  Index is up to date — no changes detected.

$ vera references tier0_fallback_produces_chunks --callees
No callees found for 'tier0_fallback_produces_chunks'.
```

Users need `vera index .` to pick this up. If you want that to be automatic, the extractor would have to contribute to a stored identity the same way the embedding model does. Happy to add that here or separately, whichever you prefer.

## Tests

Four added in `crates/vera-core/src/parsing/extractor/tests.rs`. Three run over one fixture with a function, a struct and an `impl` inside `#[cfg(test)] mod tests`; the fourth uses a separate three-deep nesting fixture.

- `rust_inline_mod_does_not_swallow_inner_symbols` asserts the inner function, struct and method are present and correctly typed, and that the module symbol is still there, before asserting the nesting relationship. Presence first, so an extractor returning nothing fails it.
- `rust_inline_mod_attributes_calls_to_the_calling_function` asserts the call to `helper` is attributed to `fixture` and the call to `fixture` to `run`, not to `tests`.
- `rust_trait_extracts_default_methods` covers the `trait_item` half.

Both directions of reinjection checked. Reverting just the `mod_item` case:

```
expected the function inside the inline mod, got [("helper", Function), ("tests", Module)]
  left: [Some("tests")]
 right: [Some("fixture")]
```

That is the production symptom verbatim. And making `extract_symbols` return an empty list:

```
expected the top-level function, got []
  left: [None]
 right: [Some("fixture")]
```

- `rust_nested_inline_mods_reach_the_innermost_item` wraps a function in three inline modules and asserts all three modules and the function are extracted. Before the depth fix it failed with `expected the function inside three levels of inline mod, got [("outer", Module), ("middle", Module), ("inner", Module)]`, which is the depth guard dropping the innermost item.

No existing test asserted the old behaviour, so nothing needed updating. `rust_extracts_traits` still passes unchanged because its trait has only signatures.

`cargo fmt --check` clean. `cargo test -p vera-core --lib` 797 passed. `cargo test -p vera-cli --bin vera` 97 passed. `cargo clippy -p vera-core --lib` still 5 warnings, the pre-existing ones.

## The same defect exists in other languages

Per the note in the issue, I enumerated every container kind that is classified as a symbol without a recursion case, and checked each by parsing a snippet with a nested definition rather than reading the table. Result, symbols extracted from a container holding one method:

| language | container kind | extracted |
|---|---|---|
| Ruby | `class`, `module` | container only |
| Kotlin | `class_declaration`, `object_declaration` | container only |
| Swift | `class_declaration` | container only |
| Scala | `class_definition`, `trait_definition`, `object_definition` | container only |
| C++ | `namespace_definition`, `class_specifier` | container only |
| Groovy | `class_definition` | container only |
| PowerShell | `class_statement` | container only |
| MATLAB | `class_definition` | container only |
| D | `class_declaration` | container only |
| OCaml | `module_definition` | container only |
| F# | `module_defn` | container only |
| Julia | `module_definition` | container only |
| Fortran | `module` | container only |

Every one of those is the same defect and will report the same wrong callers. I left them out of this PR because the issue is Rust and each needs its own fixture, and a diff touching thirteen languages' extraction is not reviewable alongside the fix. Say the word and I will send them, either as one PR or split by language.

Two things that look like the same shape and are not. Perl `package_statement` and Erlang `module_attribute`, Elm `module_declaration`, Clojure `ns` and Common Lisp `defpackage` are header nodes that do not span the body, so they swallow nothing: Perl already extracts `[Module, Function:f]`. And the markup and config containers, CSS `rule_set`, HTML and XML `element`, INI `section`, GraphQL type definitions, Nix `let_expression`, are deliberately whole-unit chunks with no callables inside, so recursion would only fragment them.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Rust parsing so inline modules and trait blocks no longer swallow inner items. Before, `mod name { ... }` and default-bodied trait methods hid inner symbols and attributed calls to the module (often `tests`); now we index the container and descend into its body so inner symbols are visible and caller attribution is correct.

- Rust: `mod_item` now records the module and descends into its `body` to avoid depth-budget drop; `mod name;` (no body) yields nothing.
- Rust: `trait_item` shares the `impl` extraction path via `extract_rust_block_methods`, preserving the container type (`Block` for `impl`, `Trait` for trait).
- Tests cover symbol presence, caller attribution in `#[cfg(test)] mod tests { ... }`, three-level nested inline modules, and chunking: children inside an inline module preserve only the trailing gap.

**Rollout**
- Re-index required. Run: `vera index .`; `vera update` will not detect this change.

<sup>Written for commit e85f17465dd42a6f50594ce9afde6ed3cd7505c2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/VeraTools/Vera/pull/126?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved Rust code analysis to recognize implementation blocks, trait blocks, and module declarations.
  - Nested functions, structs, methods, and other declarations within modules are now extracted more accurately.
  - Inline and deeply nested modules are traversed correctly.
  - Modules without bodies are still recorded correctly.

- **Bug Fixes**
  - Improved attribution of nested references to their containing symbols.
  - Corrected symbol classification for methods defined in implementation and trait blocks.
  - Improved parsing of code chunks within inline modules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
