### PR TITLE
fix(retrieval): break RRF ties on a stable key so results stop varying per process

### DIFF
--- a/crates/vera-core/src/retrieval/hybrid.rs
+++ b/crates/vera-core/src/retrieval/hybrid.rs
@@ -410,6 +410,9 @@ pub fn fuse_rrf_weighted(
 ///
 /// Each result set has an associated weight that scales its RRF contribution.
 /// A weight of 2.0 means that set's scores count double in the final ranking.
+///
+/// Equal scores are broken by `(file_path, line_start, line_end)` ascending, so the
+/// output is a function of the inputs alone and does not vary between processes.
 pub fn fuse_rrf_multi_weighted(
     result_sets: &[&[SearchResult]],
     weights: &[f64],
@@ -432,7 +435,23 @@ pub fn fuse_rrf_multi_weighted(
     }
 
     let mut ranked: Vec<(f64, SearchResult)> = fused.into_values().collect();
-    ranked.sort_by(|a, b| b.0.partial_cmp(&a.0).unwrap_or(std::cmp::Ordering::Equal));
+    // Ties are structural, not incidental: with equal source weights a result found only
+    // in set A at rank r and one found only in set B at rank r score bit-identically.
+    // `into_values` yields a per-process-random order, so a score-only sort would make the
+    // output depend on the HashMap seed rather than on the index. Break ties on the same
+    // (file_path, line_start, line_end) triple that keys the map, which is distinct for
+    // every surviving entry and therefore a total order.
+    ranked.sort_by(|a, b| {
+        b.0.partial_cmp(&a.0)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| {
+                (&a.1.file_path, a.1.line_start, a.1.line_end).cmp(&(
+                    &b.1.file_path,
+                    b.1.line_start,
+                    b.1.line_end,
+                ))
+            })
+    });
 
     ranked
         .into_iter()

--- a/crates/vera-core/src/retrieval/hybrid_tests.rs
+++ b/crates/vera-core/src/retrieval/hybrid_tests.rs
@@ -293,11 +293,13 @@ fn rrf_ties_break_on_file_path_then_line_range() {
         make_result("z_bm25.rs", 1, 10, 5.0, None),
         make_result("a_bm25.rs", 1, 10, 4.0, None),
         make_result("shared.rs", 200, 210, 3.0, None),
+        make_result("shared.rs", 300, 1000, 2.0, None),
     ];
     let vector = vec![
         make_result("m_vec.rs", 1, 10, 0.9, None),
         make_result("b_vec.rs", 1, 10, 0.8, None),
         make_result("shared.rs", 30, 40, 0.7, None),
+        make_result("shared.rs", 300, 305, 0.6, None),
     ];
 
     // Each call builds a fresh HashMap, and std gives every HashMap in a thread its own
@@ -305,24 +307,36 @@ fn rrf_ties_break_on_file_path_then_line_range() {
     for _ in 0..8 {
         let results = fuse_rrf(&bm25, &vector, 60.0, 10);
 
-        let order: Vec<(&str, u32)> = results
+        let order: Vec<(&str, u32, u32)> = results
             .iter()
-            .map(|result| (result.file_path.as_str(), result.line_start))
+            .map(|result| {
+                (
+                    result.file_path.as_str(),
+                    result.line_start,
+                    result.line_end,
+                )
+            })
             .collect();
 
         assert_eq!(
             order,
             vec![
                 // rank 1 tie, ascending file_path
-                ("m_vec.rs", 1),
-                ("z_bm25.rs", 1),
+                ("m_vec.rs", 1, 10),
+                ("z_bm25.rs", 1, 10),
                 // rank 2 tie, ascending file_path
-                ("a_bm25.rs", 1),
-                ("b_vec.rs", 1),
+                ("a_bm25.rs", 1, 10),
+                ("b_vec.rs", 1, 10),
                 // rank 3 tie, same file, ascending line_start numerically (a lexicographic
                 // compare of the "path:start:end" key would put 200 before 30)
-                ("shared.rs", 30),
-                ("shared.rs", 200),
+                ("shared.rs", 30, 40),
+                ("shared.rs", 200, 210),
+                // rank 4 tie, same file and same line_start, so only line_end separates
+                // them; 305 before 1000 is again the numeric order, not the lexicographic
+                // one. A comparator that stopped at (file_path, line_start) would leave
+                // this pair on the HashMap seed.
+                ("shared.rs", 300, 305),
+                ("shared.rs", 300, 1000),
             ],
             "tied RRF scores must order by (file_path, line_start, line_end)"
         );

--- a/crates/vera-core/src/retrieval/hybrid_tests.rs
+++ b/crates/vera-core/src/retrieval/hybrid_tests.rs
@@ -284,6 +284,83 @@ fn rrf_distinct_results_no_overlap() {
 }
 
 #[test]
+fn rrf_ties_break_on_file_path_then_line_range() {
+    // Equal weights make the ties bit-identical: a result found only in BM25 at rank r
+    // and one found only in the vector list at rank r both score 1/(k + r). Fusion
+    // collects into a HashMap, so without an explicit tie-break the order of each pair
+    // is the HashMap seed, which is fresh per process.
+    let bm25 = vec![
+        make_result("z_bm25.rs", 1, 10, 5.0, None),
+        make_result("a_bm25.rs", 1, 10, 4.0, None),
+        make_result("shared.rs", 200, 210, 3.0, None),
+    ];
+    let vector = vec![
+        make_result("m_vec.rs", 1, 10, 0.9, None),
+        make_result("b_vec.rs", 1, 10, 0.8, None),
+        make_result("shared.rs", 30, 40, 0.7, None),
+    ];
+
+    // Each call builds a fresh HashMap, and std gives every HashMap in a thread its own
+    // hash keys, so repeating the call samples several orders within this one process.
+    for _ in 0..8 {
+        let results = fuse_rrf(&bm25, &vector, 60.0, 10);
+
+        let order: Vec<(&str, u32)> = results
+            .iter()
+            .map(|result| (result.file_path.as_str(), result.line_start))
+            .collect();
+
+        assert_eq!(
+            order,
+            vec![
+                // rank 1 tie, ascending file_path
+                ("m_vec.rs", 1),
+                ("z_bm25.rs", 1),
+                // rank 2 tie, ascending file_path
+                ("a_bm25.rs", 1),
+                ("b_vec.rs", 1),
+                // rank 3 tie, same file, ascending line_start numerically (a lexicographic
+                // compare of the "path:start:end" key would put 200 before 30)
+                ("shared.rs", 30),
+                ("shared.rs", 200),
+            ],
+            "tied RRF scores must order by (file_path, line_start, line_end)"
+        );
+    }
+}
+
+#[test]
+fn rrf_multi_source_ties_break_on_file_path() {
+    // The multi-query path fuses more than two lists, so a single rank can carry a tie
+    // as wide as the number of sources. Six disjoint sets, one hit each at rank 1, give
+    // a six-way bit-identical tie whose order is otherwise the HashMap seed.
+    let sets: Vec<Vec<SearchResult>> = ["e.rs", "c.rs", "f.rs", "a.rs", "d.rs", "b.rs"]
+        .iter()
+        .map(|file| vec![make_result(file, 1, 10, 1.0, None)])
+        .collect();
+    let refs: Vec<&[SearchResult]> = sets.iter().map(|set| set.as_slice()).collect();
+
+    let results = fuse_rrf_multi_weighted(&refs, &[1.0; 6], 60.0, 10);
+
+    let order: Vec<&str> = results
+        .iter()
+        .map(|result| result.file_path.as_str())
+        .collect();
+
+    assert_eq!(
+        order,
+        vec!["a.rs", "b.rs", "c.rs", "d.rs", "e.rs", "f.rs"],
+        "a tie across all sources must order by file_path, not by insertion or hash order"
+    );
+    for result in &results {
+        assert!(
+            (result.score - 1.0 / 61.0).abs() < 1e-10,
+            "all six must tie"
+        );
+    }
+}
+
+#[test]
 fn rrf_different_chunks_same_file_are_separate() {
     // Two different chunks from the same file should be treated as separate.
     let bm25 = vec![


### PR DESCRIPTION
Part of #122. This covers the **determinism** half only. The trailing-period
classifier half is untouched: it changes ranking, so it needs Semble evidence of
its own and belongs in a separate PR.

## The bug

`fuse_rrf_multi_weighted` accumulates into a `HashMap<String, (f64, SearchResult)>`,
then does `fused.into_values()` followed by a **stable** `sort_by` on score alone
(`crates/vera-core/src/retrieval/hybrid.rs:434-435` before this change). A stable
sort preserves input order within a tied group, and the input order here is
`HashMap` iteration order, which `RandomState` seeds per process. Every CLI
invocation is a new process, so the same index and the same query can return a
different answer each time.

The ties are structural, not incidental. `NL_PARAMS` sets
`bm25_weight == vector_weight == 1.0`, so a document appearing only in the BM25
list at rank *r* and one appearing only in the vector list at rank *r* both score
exactly `1.0 / (k + r)` — bit-identical, not merely close. On a natural-language
query the two lists overlap only partially, so most of the pool is single-source
and ties at every rank are the normal case rather than the exception.

When such a tie straddles the truncation boundary it changes **which** results are
returned, not just their order. See the transcript below: 2 runs in 10 lost a
result entirely.

`fuse_rrf` and `fuse_rrf_weighted` are thin wrappers that both delegate to
`fuse_rrf_multi_weighted`, and the multi-query path
(`retrieval/rag_fusion.rs:157`, `vera-cli/src/commands/search.rs:140`) calls it
directly, so this is the only site holding the map and the only fix needed. All
four entry points are covered.

## The fix

Break ties on `(file_path, line_start, line_end)` ascending.

**Why that key is total.** It is the same triple that `result_key` formats into the
`HashMap` key used to dedupe the pool. Because `line_start` and `line_end` are
`u32` and render without colons, `format!("{path}:{start}:{end}")` is injective on
the triple; distinct map keys therefore imply distinct triples. Every entry that
survives to the sort has a distinct map key by construction, so no two can compare
equal, and the comparator is a total order on the collected vector.

**Why that key is stable across re-indexes.** It is derived entirely from index
content — the repository-relative path and the chunk's line span. It carries no
rowid, no insertion counter, and no timestamp, so a rebuild of `.vera/` from
unchanged sources reproduces the same key and therefore the same order. A chunk id
would have been the other candidate and was rejected for exactly this reason: it
is assignment order, so it changes on every rebuild, which would make the output
stable within one index but not across two.

The triple is compared field-wise rather than as the formatted key string, so
`line_start` orders numerically. Comparing the key strings would put line 200
before line 30.

I kept the explicit tie-break rather than swapping the `HashMap` for an ordered
map. A `BTreeMap` would make the pre-sort order deterministic and let the stable
sort inherit it, but that determinism would be implicit and silently lost if the
collection type ever changed back, and it would pay `O(log n)` on every insert in
the fusion hot path to buy an ordering that only matters for the tail. It would
also give the lexicographic line ordering noted above.

## Evidence

`.coderabbit.yaml` asks for Semble benchmark evidence on `retrieval/**`. **This
change cannot move a benchmark score, because it does not change any score.** The
RRF arithmetic is untouched; the only edit is a `.then_with(...)` appended to an
existing comparator, which is reached only when two scores are already exactly
equal. Retrieval quality metrics are computed from the returned set and its order,
and the set/order only change where the pre-fix behaviour was a coin flip. There
is no "before" number to compare against, since before this change the number was
not a function of the index.

What is measurable is the determinism itself, so that is what I measured.

**Control**: release build of the base commit `e3d79b3`.
**Treatment**: this branch.
Same index, same query, 10 invocations each, distinct orderings counted.

Query: `vera search "how are search results ranked and fused together" --limit 20`

Before (`e3d79b3`) — two distinct answers:

```
   8 runs  search.rs:77-85  search_service.rs:285-297  hybrid.rs:404-436
           regex_search.rs:27-144  ranking/score.rs:533-539
           hybrid_tests.rs:70-108  mod.rs:43-54  tools.rs:22-22
           how-it-works.md:78-103  combined_results.json:502-1002
           (10 results)

   2 runs  search.rs:77-85  search_service.rs:285-297  hybrid.rs:404-436
           regex_search.rs:27-144
           hybrid_tests.rs:70-108  mod.rs:43-54  tools.rs:22-22
           how-it-works.md:78-103  combined_results.json:502-1002
           (9 results)
```

The two orderings differ by more than a swap: `ranking/score.rs:533-539` is
present in 8 runs and absent in 2. It sat on the truncation boundary, so the coin
flip decided whether it was returned at all.

After — one answer, 10 out of 10 runs:

```
  10 runs  search.rs:77-85  search_service.rs:285-297  hybrid.rs:404-436
           regex_search.rs:27-144
           hybrid_tests.rs:70-108  mod.rs:43-54  tools.rs:22-22
           how-it-works.md:78-103  combined_results.json:502-1002
```

To be explicit about what the fix does and does not claim: it does not pick the
*better* of the two tie orders, it picks a *fixed* one. Here it settles on the
ordering that the pre-fix binary happened to produce in 2 runs out of 10.

Scores are unchanged, and that is verifiable from the diff rather than from the
output: the only executable line this PR touches in `hybrid.rs` is the comparator
passed to `sort_by`. Accumulation into the map and the `result.score = rrf_score`
assignment are byte-for-byte the same, so no score can differ.

On a query with no tie at the truncation boundary the two binaries agree exactly:

```
$ vera search "index files and store their embeddings on disk" --limit 20 --json
  (e3d79b3 vs this branch)  →  byte-identical  (23520 bytes each)
```

To be precise about what that shows: `--json` emits `file_path`, `line_start`,
`line_end`, `content`, `symbol_name` and `symbol_type`, and carries no score
field, so byte-identity is evidence about the returned set and its order, not
about the scores. The scores claim rests on the diff above.

## Tests

Two new tests in `crates/vera-core/src/retrieval/hybrid_tests.rs`, which had no
determinism coverage. Both construct the tie explicitly and assert the exact
resulting order against the expected key, so they pin the ordering rule rather
than merely asserting that two runs agree.

Defeating the per-process seeding took some care: within one process the seed is
fixed, so fusing twice and comparing proves nothing on its own.

- `rrf_ties_break_on_file_path_then_line_range` — the real two-source NL shape,
  with disjoint BM25 and vector lists producing a tie at each of ranks 1 to 4.
  Rank 3 ties two chunks of the *same* file at different `line_start`s, and rank 4
  ties two chunks of the same file at the same `line_start` differing only in
  `line_end`, so each field of the key is exercised and each is pinned to its
  numeric order rather than its lexicographic one. Each call builds a fresh `HashMap` and std gives every
  `HashMap` in a thread its own hash keys, so the call is repeated to sample
  several orders within the single test process.
- `rrf_multi_source_ties_break_on_file_path` — the multi-query path, where a single
  rank can carry a tie as wide as the number of sources. Six disjoint sets with one
  hit each at rank 1 give a six-way bit-identical tie, so the pre-fix code has a
  1-in-720 chance of producing the expected order by luck.

**Reinjection.** Two variants, both confirmed to fail with the real symptom rather
than a compile error.

Truncating the comparator to `(file_path, line_start)` — the shape that would slip
past a test asserting only those two fields — fails the two-source test 3 runs out
of 3, on the rank-4 pair alone:

```
assertion `left == right` failed: tied RRF scores must order by (file_path, line_start, line_end)
  left: [..., ("shared.rs", 300, 1000), ("shared.rs", 300, 305)]
 right: [..., ("shared.rs", 300, 305), ("shared.rs", 300, 1000)]
```

Reverting the whole `.then_with(...)`: Five consecutive runs (each a new
process, so a new seed): the six-way test failed 5/5, the two-source test failed
4/5 before the repetition loop was added. Sample output:

```
---- rrf_multi_source_ties_break_on_file_path stdout ----
assertion `left == right` failed: a tie across all sources must order by
file_path, not by insertion or hash order
  left: ["e.rs", "c.rs", "a.rs", "f.rs", "d.rs", "b.rs"]
 right: ["a.rs", "b.rs", "c.rs", "d.rs", "e.rs", "f.rs"]

---- rrf_ties_break_on_file_path_then_line_range stdout ----
assertion `left == right` failed: tied RRF scores must order by
(file_path, line_start, line_end)
  left: [("z_bm25.rs", 1), ("m_vec.rs", 1), ...]
 right: [("m_vec.rs", 1), ("z_bm25.rs", 1), ...]
```

The `left` values change from run to run, which is the bug stated as an assertion
failure.

## Verification

```
cargo fmt --check                                          clean
cargo test -p vera-core --lib                              795 passed, 0 failed
cargo test -p vera-cli --bin vera                           97 passed, 0 failed
cargo clippy -p vera-core --lib | grep -c '^warning: [a-z]'  5  (unchanged)
```

`rrf_with_known_inputs_produces_exact_scores` and the rest of the existing RRF
suite still pass; that test has no ties, so the new comparator arm is never
reached by it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency of search results when multiple items have the same relevance score.
  * Tied results now appear in a predictable order based on file location, regardless of internal processing order.

* **Tests**
  * Added coverage to verify stable ordering across repeated and multi-source searches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make RRF fusion deterministic by breaking equal-score ties on a stable key. Previously, ties were ordered by `HashMap` iteration (per-process random), causing result order and `--limit` truncation to vary; now ties sort by `(file_path, line_start, line_end)` without changing scores.

- Updates comparator in `fuse_rrf_multi_weighted` in `crates/vera-core/src/retrieval/hybrid.rs`; `fuse_rrf` and `fuse_rrf_weighted` inherit this behavior.
- Tie-break uses the same triple as the dedupe key and compares `line_start/line_end` numerically, yielding a total, rebuild-stable order.
- Keeps `HashMap` and adds an explicit comparator arm to avoid `BTreeMap` hot-path `O(log n)` inserts.
- Tests in `crates/vera-core/src/retrieval/hybrid_tests.rs` cover multi-source ties and explicitly pin the `line_end` arm and numeric ordering.

<sup>Written for commit f794d5b61085bcf9af926ba2e03ce95582452768. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/VeraTools/Vera/pull/127?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

