### PR TITLE
fix(cli): emit one JSON document from `vera uninstall`

### DIFF
--- a/crates/vera-cli/src/commands/agent.rs
+++ b/crates/vera-cli/src/commands/agent.rs
@@ -558,33 +558,61 @@ fn do_remove(locations: &[SkillLocation], json_output: bool) -> anyhow::Result<(
         return Ok(());
     }
 
-    let reports = remove_skill_locations(locations)?;
+    let removal = remove_skill_locations(locations);
 
+    // Report before failing: a location deleted earlier in the run stays visible
+    // even when a later one cannot be deleted.
     if json_output {
-        println!("{}", serde_json::to_string_pretty(&reports)?);
+        println!("{}", serde_json::to_string_pretty(&removal.reports)?);
     } else {
-        write_removed_skill_locations(&reports, &mut std::io::stdout().lock())?;
+        write_removed_skill_locations(&removal, &mut std::io::stdout().lock())?;
+    }
+
+    let mut failures = removal.failures.into_iter();
+    if let Some(first) = failures.next() {
+        for error in failures {
+            tracing::warn!("{error:#}");
+        }
+        return Err(first);
     }
 
     Ok(())
 }
 
+/// One report per location plus the deletions that failed. The two are returned
+/// together because a failure partway through must not discard the locations
+/// already deleted: callers report what happened, then decide whether to fail.
+#[derive(Default)]
+pub(crate) struct SkillRemoval {
+    pub(crate) reports: Vec<SkillLocationReport>,
+    pub(crate) failures: Vec<anyhow::Error>,
+}
+
 /// Delete the skill directory at each location, reporting per location whether
-/// anything was actually there to delete.
-fn remove_skill_locations(locations: &[SkillLocation]) -> anyhow::Result<Vec<SkillLocationReport>> {
-    let mut reports = Vec::with_capacity(locations.len());
+/// a skill was actually there and deleted. A location that cannot be deleted is
+/// recorded as not removed and does not stop the remaining locations.
+fn remove_skill_locations(locations: &[SkillLocation]) -> SkillRemoval {
+    let mut removal = SkillRemoval {
+        reports: Vec::with_capacity(locations.len()),
+        failures: Vec::new(),
+    };
 
     for location in locations {
-        let removed = location.path.join("SKILL.md").exists();
-        if removed {
-            fs::remove_dir_all(&location.path).with_context(|| {
-                format!(
-                    "failed to remove installed skill at {}",
-                    location.path.display()
-                )
-            })?;
-        }
-        reports.push(SkillLocationReport {
+        let installed = location.path.join("SKILL.md").exists();
+        let removed = installed
+            && match fs::remove_dir_all(&location.path) {
+                Ok(()) => true,
+                Err(error) => {
+                    removal
+                        .failures
+                        .push(anyhow::Error::new(error).context(format!(
+                            "failed to remove installed skill at {}",
+                            location.path.display()
+                        )));
+                    false
+                }
+            };
+        removal.reports.push(SkillLocationReport {
             client: location.client,
             scope: location.scope,
             path: location.path.display().to_string(),
@@ -594,30 +622,33 @@ fn remove_skill_locations(locations: &[SkillLocation]) -> anyhow::Result<Vec<Ski
         });
     }
 
-    Ok(reports)
+    removal
 }
 
 /// Remove every supported client/scope skill install under the given roots,
 /// without printing anything. Used by `vera uninstall`, which folds the result
 /// into its own single output document.
-pub(crate) fn remove_all_skills(
-    cwd: &Path,
-    home: &Path,
-) -> anyhow::Result<Vec<SkillLocationReport>> {
+pub(crate) fn remove_all_skills(cwd: &Path, home: &Path) -> anyhow::Result<SkillRemoval> {
     let locations = resolve_locations_with_roots(AgentClient::All, AgentScope::All, cwd, home)?;
-    remove_skill_locations(&locations)
+    Ok(remove_skill_locations(&locations))
 }
 
 pub(crate) fn write_removed_skill_locations(
-    reports: &[SkillLocationReport],
+    removal: &SkillRemoval,
     out: &mut dyn Write,
 ) -> std::io::Result<()> {
-    let removed: Vec<&SkillLocationReport> = reports
+    let removed: Vec<&SkillLocationReport> = removal
+        .reports
         .iter()
         .filter(|report| report.was_removed())
         .collect();
-    if removed.is_empty() {
+    // Only claim nothing was installed when nothing was found; a location that
+    // was found and could not be deleted is a failure, not an absence.
+    if removed.is_empty() && removal.failures.is_empty() {
         writeln!(out, "No Vera skill installations found.")?;
+        return Ok(());
+    }
+    if removed.is_empty() {
         return Ok(());
     }
 

--- a/crates/vera-cli/src/commands/agent.rs
+++ b/crates/vera-cli/src/commands/agent.rs
@@ -2,6 +2,7 @@
 
 use std::collections::BTreeSet;
 use std::fs;
+use std::io::Write;
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, bail};
@@ -170,6 +171,20 @@ pub struct SkillLocationReport {
     installed: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     up_to_date: Option<bool>,
+    /// Only set on the removal path: whether a skill was actually present and
+    /// deleted, as opposed to the location merely having been checked.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    removed: Option<bool>,
+}
+
+impl SkillLocationReport {
+    pub(crate) fn was_removed(&self) -> bool {
+        self.removed == Some(true)
+    }
+
+    pub(crate) fn path(&self) -> &str {
+        &self.path
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -444,6 +459,7 @@ fn do_install(locations: &[SkillLocation], json_output: bool) -> anyhow::Result<
             path: location.path.display().to_string(),
             installed: true,
             up_to_date: Some(true),
+            removed: None,
         })
         .collect();
 
@@ -542,11 +558,25 @@ fn do_remove(locations: &[SkillLocation], json_output: bool) -> anyhow::Result<(
         return Ok(());
     }
 
+    let reports = remove_skill_locations(locations)?;
+
+    if json_output {
+        println!("{}", serde_json::to_string_pretty(&reports)?);
+    } else {
+        write_removed_skill_locations(&reports, &mut std::io::stdout().lock())?;
+    }
+
+    Ok(())
+}
+
+/// Delete the skill directory at each location, reporting per location whether
+/// anything was actually there to delete.
+fn remove_skill_locations(locations: &[SkillLocation]) -> anyhow::Result<Vec<SkillLocationReport>> {
     let mut reports = Vec::with_capacity(locations.len());
 
     for location in locations {
-        let installed = location.path.join("SKILL.md").exists();
-        if installed {
+        let removed = location.path.join("SKILL.md").exists();
+        if removed {
             fs::remove_dir_all(&location.path).with_context(|| {
                 format!(
                     "failed to remove installed skill at {}",
@@ -560,26 +590,51 @@ fn do_remove(locations: &[SkillLocation], json_output: bool) -> anyhow::Result<(
             path: location.path.display().to_string(),
             installed: false,
             up_to_date: None,
+            removed: Some(removed),
         });
     }
 
-    if json_output {
-        println!("{}", serde_json::to_string_pretty(&reports)?);
-    } else {
-        let red = console::Style::new().red();
-        let dim = console::Style::new().dim();
-        println!("Removed Vera skill from:");
-        println!();
-        for report in &reports {
-            let name = format!("{:?}", report.client).to_lowercase();
-            let scope = format!("{:?}", report.scope).to_lowercase();
-            println!(
-                "  {} {:<7} {}",
-                red.apply_to(format!("{:<14}", name)),
-                scope,
-                dim.apply_to(&report.path)
-            );
-        }
+    Ok(reports)
+}
+
+/// Remove every supported client/scope skill install under the given roots,
+/// without printing anything. Used by `vera uninstall`, which folds the result
+/// into its own single output document.
+pub(crate) fn remove_all_skills(
+    cwd: &Path,
+    home: &Path,
+) -> anyhow::Result<Vec<SkillLocationReport>> {
+    let locations = resolve_locations_with_roots(AgentClient::All, AgentScope::All, cwd, home)?;
+    remove_skill_locations(&locations)
+}
+
+pub(crate) fn write_removed_skill_locations(
+    reports: &[SkillLocationReport],
+    out: &mut dyn Write,
+) -> std::io::Result<()> {
+    let removed: Vec<&SkillLocationReport> = reports
+        .iter()
+        .filter(|report| report.was_removed())
+        .collect();
+    if removed.is_empty() {
+        writeln!(out, "No Vera skill installations found.")?;
+        return Ok(());
+    }
+
+    let red = console::Style::new().red();
+    let dim = console::Style::new().dim();
+    writeln!(out, "Removed Vera skill from:")?;
+    writeln!(out)?;
+    for report in removed {
+        let name = format!("{:?}", report.client).to_lowercase();
+        let scope = format!("{:?}", report.scope).to_lowercase();
+        writeln!(
+            out,
+            "  {} {:<7} {}",
+            red.apply_to(format!("{:<14}", name)),
+            scope,
+            dim.apply_to(&report.path)
+        )?;
     }
 
     Ok(())
@@ -605,6 +660,7 @@ fn status(client: AgentClient, scope: AgentScope, json_output: bool) -> anyhow::
                     path: path.display().to_string(),
                     installed: scope_status.installed,
                     up_to_date: scope_status.installed.then_some(scope_status.up_to_date),
+                    removed: None,
                 }
             })
         })

--- a/crates/vera-cli/src/commands/agent.rs
+++ b/crates/vera-cli/src/commands/agent.rs
@@ -589,8 +589,9 @@ pub(crate) struct SkillRemoval {
 }
 
 /// Delete the skill directory at each location, reporting per location whether
-/// a skill was actually there and deleted. A location that cannot be deleted is
-/// recorded as not removed and does not stop the remaining locations.
+/// a skill was actually there and deleted. A location that cannot be inspected
+/// or deleted is recorded as not removed, with the reason kept as a failure, and
+/// does not stop the remaining locations.
 fn remove_skill_locations(locations: &[SkillLocation]) -> SkillRemoval {
     let mut removal = SkillRemoval {
         reports: Vec::with_capacity(locations.len()),
@@ -598,7 +599,23 @@ fn remove_skill_locations(locations: &[SkillLocation]) -> SkillRemoval {
     };
 
     for location in locations {
-        let installed = location.path.join("SKILL.md").exists();
+        let marker = location.path.join("SKILL.md");
+        // `Path::exists` coerces a permission error into `false`, which reports an
+        // installed skill as absent. `try_exists` keeps that call's symlink-following
+        // semantics, so a broken `SKILL.md` symlink stays "not installed" exactly as
+        // before, and only separates "cannot tell" from "not there".
+        let installed = match marker.try_exists() {
+            Ok(installed) => installed,
+            Err(error) => {
+                removal
+                    .failures
+                    .push(anyhow::Error::new(error).context(format!(
+                        "failed to check for an installed skill at {}",
+                        marker.display()
+                    )));
+                false
+            }
+        };
         let removed = installed
             && match fs::remove_dir_all(&location.path) {
                 Ok(()) => true,

--- a/crates/vera-cli/src/commands/uninstall.rs
+++ b/crates/vera-cli/src/commands/uninstall.rs
@@ -361,6 +361,45 @@ mod tests {
         );
     }
 
+    /// A skill whose `SKILL.md` cannot be stat'd at all, because its own
+    /// directory denies traversal. `Path::exists` reports that as absent.
+    #[cfg(unix)]
+    fn install_uninspectable_claude_global_skill(home: &Path) -> PathBuf {
+        use std::os::unix::fs::PermissionsExt;
+        let path = home.join(".claude").join("skills").join("vera");
+        fs::create_dir_all(&path).unwrap();
+        fs::write(path.join("SKILL.md"), "test").unwrap();
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o000)).unwrap();
+        path
+    }
+
+    /// An installed skill that cannot be inspected is not an absent one. Reporting
+    /// it as absent leaves it on disk while claiming it was never there.
+    #[cfg(unix)]
+    #[test]
+    fn uninstall_does_not_report_an_uninspectable_skill_as_absent() {
+        let roots = roots();
+        let locked = install_uninspectable_claude_global_skill(&roots.home);
+
+        let (stdout, stderr) = uninstall(&roots, false);
+        allow_cleanup(&locked);
+        let skill_survived = locked.join("SKILL.md").exists();
+
+        assert!(
+            skill_survived,
+            "fixture does not discriminate: the skill was deleted after all"
+        );
+        assert!(
+            !stdout.contains("No Vera skill installations found."),
+            "claimed nothing was installed while {} was still on disk: {stdout}",
+            locked.display()
+        );
+        assert!(
+            stderr.contains("failed to check for an installed skill at"),
+            "the inspection failure was never reported: {stderr}"
+        );
+    }
+
     #[test]
     fn uninstall_human_output_reports_nothing_when_no_skills_are_installed() {
         let roots = roots();

--- a/crates/vera-cli/src/commands/uninstall.rs
+++ b/crates/vera-cli/src/commands/uninstall.rs
@@ -74,14 +74,21 @@ fn run_at(
     let mut removed = Vec::new();
 
     // 1. Remove agent skill files (all clients, all scopes).
-    let skill_reports = match agent::remove_all_skills(cwd, home) {
-        Ok(reports) => reports,
+    let skill_removal = match agent::remove_all_skills(cwd, home) {
+        Ok(removal) => removal,
         Err(e) => {
-            tracing::warn!("failed to remove agent skills: {e:#}");
-            Vec::new()
+            tracing::warn!("failed to resolve agent skill locations: {e:#}");
+            agent::SkillRemoval::default()
         }
     };
-    let removed_skills: Vec<&str> = skill_reports
+    // Uninstall continues past a skill that cannot be deleted, so the failure is
+    // only visible if it is reported here. stderr keeps it out of the JSON
+    // document on stdout.
+    for error in &skill_removal.failures {
+        writeln!(stderr, "  {error:#}")?;
+    }
+    let removed_skills: Vec<&str> = skill_removal
+        .reports
         .iter()
         .filter(|report| report.was_removed())
         .map(|report| report.path())
@@ -90,7 +97,7 @@ fn run_at(
         removed.push("agent skills");
     }
     if !json_output {
-        agent::write_removed_skill_locations(&skill_reports, stdout)?;
+        agent::write_removed_skill_locations(&skill_removal, stdout)?;
     }
 
     // 2. Remove Vera data directory (binary cache, models, libs, config, credentials).
@@ -257,6 +264,101 @@ mod tests {
         );
         // Heading, blank line, and exactly one row.
         assert_eq!(stdout.lines().count(), 3, "{stdout}");
+    }
+
+    /// A skill directory that cannot be deleted, ordered after Claude's so an
+    /// earlier location is already gone by the time it fails.
+    #[cfg(unix)]
+    fn install_unremovable_gemini_global_skill(home: &Path) -> PathBuf {
+        use std::os::unix::fs::PermissionsExt;
+        let path = home.join(".gemini").join("skills").join("vera");
+        fs::create_dir_all(&path).unwrap();
+        fs::write(path.join("SKILL.md"), "test").unwrap();
+        let parent = home.join(".gemini").join("skills");
+        fs::set_permissions(&parent, fs::Permissions::from_mode(0o555)).unwrap();
+        parent
+    }
+
+    #[cfg(unix)]
+    fn allow_cleanup(parent: &Path) {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(parent, fs::Permissions::from_mode(0o755)).unwrap();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn uninstall_json_reports_skills_removed_before_a_later_removal_failed() {
+        let roots = roots();
+        let claude = install_claude_global_skill(&roots.home);
+        let locked = install_unremovable_gemini_global_skill(&roots.home);
+
+        let (stdout, _) = uninstall(&roots, true);
+        let claude_was_deleted = !claude.exists();
+        allow_cleanup(&locked);
+
+        assert!(
+            claude_was_deleted,
+            "fixture does not discriminate: the earlier skill was never deleted"
+        );
+        let document: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+        assert_eq!(
+            document["skills"],
+            serde_json::json!([claude.display().to_string()]),
+            "{stdout}"
+        );
+        assert_eq!(
+            document["removed"],
+            serde_json::json!(["agent skills"]),
+            "{stdout}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn uninstall_human_output_names_skills_removed_before_a_later_removal_failed() {
+        let roots = roots();
+        let claude = install_claude_global_skill(&roots.home);
+        let locked = install_unremovable_gemini_global_skill(&roots.home);
+
+        let (stdout, stderr) = uninstall(&roots, false);
+        let claude_was_deleted = !claude.exists();
+        allow_cleanup(&locked);
+
+        assert!(
+            claude_was_deleted,
+            "fixture does not discriminate: the earlier skill was never deleted"
+        );
+        assert!(stdout.contains(&claude.display().to_string()), "{stdout}");
+        assert!(
+            !stdout.contains("No Vera skill installations found."),
+            "claimed nothing was installed after deleting {}: {stdout}",
+            claude.display()
+        );
+        assert!(
+            stderr.contains("failed to remove installed skill at"),
+            "the failure was never reported: {stderr}"
+        );
+    }
+
+    /// The only installed skill fails to delete: nothing was removed, but
+    /// claiming nothing was *installed* would be a different lie.
+    #[cfg(unix)]
+    #[test]
+    fn uninstall_human_output_does_not_claim_nothing_was_installed_when_removal_failed() {
+        let roots = roots();
+        let locked = install_unremovable_gemini_global_skill(&roots.home);
+
+        let (stdout, stderr) = uninstall(&roots, false);
+        allow_cleanup(&locked);
+
+        assert!(
+            !stdout.contains("No Vera skill installations found."),
+            "{stdout}"
+        );
+        assert!(
+            stderr.contains("failed to remove installed skill at"),
+            "{stderr}"
+        );
     }
 
     #[test]

--- a/crates/vera-cli/src/commands/uninstall.rs
+++ b/crates/vera-cli/src/commands/uninstall.rs
@@ -1,20 +1,19 @@
 //! `vera uninstall` — remove Vera binary, models, config, and agent skills.
 
 use std::fs;
-use std::path::PathBuf;
+use std::io::Write;
+use std::path::{Path, PathBuf};
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 
 use super::agent;
 use crate::state;
 
 /// Candidate directories where the shim may have been placed.
-fn shim_candidates(home: &std::path::Path) -> Vec<PathBuf> {
+fn shim_candidates(home: &Path, user_bin_dir: Option<&Path>) -> Vec<PathBuf> {
     let mut dirs = Vec::new();
-    if let Ok(v) = std::env::var("VERA_USER_BIN_DIR") {
-        if !v.is_empty() {
-            dirs.push(PathBuf::from(v));
-        }
+    if let Some(dir) = user_bin_dir {
+        dirs.push(dir.to_path_buf());
     }
     #[cfg(windows)]
     {
@@ -40,34 +39,73 @@ fn shim_name() -> &'static str {
     if cfg!(windows) { "vera.cmd" } else { "vera" }
 }
 
+fn configured_user_bin_dir() -> Option<PathBuf> {
+    std::env::var_os("VERA_USER_BIN_DIR")
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from)
+}
+
 pub fn run(json_output: bool) -> Result<()> {
     let home = state::user_home_dir()?;
     let vera_home = state::vera_dir()?;
+    let cwd = std::env::current_dir().context("failed to resolve current directory")?;
+    let user_bin_dir = configured_user_bin_dir();
+
+    run_at(
+        &home,
+        &vera_home,
+        &cwd,
+        user_bin_dir.as_deref(),
+        json_output,
+        &mut std::io::stdout().lock(),
+        &mut std::io::stderr().lock(),
+    )
+}
+
+fn run_at(
+    home: &Path,
+    vera_home: &Path,
+    cwd: &Path,
+    user_bin_dir: Option<&Path>,
+    json_output: bool,
+    stdout: &mut dyn Write,
+    stderr: &mut dyn Write,
+) -> Result<()> {
     let mut removed = Vec::new();
 
     // 1. Remove agent skill files (all clients, all scopes).
-    if let Err(e) = agent::run(
-        agent::AgentCommand::Remove,
-        Some(agent::AgentClient::All),
-        Some(agent::AgentScope::All),
-        json_output,
-    ) {
-        tracing::warn!("failed to remove agent skills: {e:#}");
+    let skill_reports = match agent::remove_all_skills(cwd, home) {
+        Ok(reports) => reports,
+        Err(e) => {
+            tracing::warn!("failed to remove agent skills: {e:#}");
+            Vec::new()
+        }
+    };
+    let removed_skills: Vec<&str> = skill_reports
+        .iter()
+        .filter(|report| report.was_removed())
+        .map(|report| report.path())
+        .collect();
+    if !removed_skills.is_empty() {
+        removed.push("agent skills");
     }
-    removed.push("agent skills");
+    if !json_output {
+        agent::write_removed_skill_locations(&skill_reports, stdout)?;
+    }
 
     // 2. Remove Vera data directory (binary cache, models, libs, config, credentials).
     if vera_home.exists() {
-        fs::remove_dir_all(&vera_home)?;
+        fs::remove_dir_all(vera_home)?;
+        removed.push("vera data dir");
         if !json_output {
-            eprintln!("  Removed {}", vera_home.display());
+            writeln!(stderr, "  Removed {}", vera_home.display())?;
         }
     }
-    removed.push("vera data dir");
 
     // 3. Remove the PATH shim.
     let name = shim_name();
-    for dir in shim_candidates(&home) {
+    let mut removed_any_shim = false;
+    for dir in shim_candidates(home, user_bin_dir) {
         let shim = dir.join(name);
         if shim.exists() {
             // Only remove if it's a Vera shim (contains "vera" in content or is a symlink to vera).
@@ -79,24 +117,155 @@ pub fn run(json_output: bool) -> Result<()> {
                     .unwrap_or(false);
             if is_vera_shim {
                 fs::remove_file(&shim)?;
+                removed_any_shim = true;
                 if !json_output {
-                    eprintln!("  Removed shim {}", shim.display());
+                    writeln!(stderr, "  Removed shim {}", shim.display())?;
                 }
             }
         }
     }
-    removed.push("PATH shim");
+    if removed_any_shim {
+        removed.push("PATH shim");
+    }
 
     if json_output {
-        println!(
+        writeln!(
+            stdout,
             "{}",
-            serde_json::json!({ "uninstalled": true, "removed": removed })
-        );
+            serde_json::json!({
+                "uninstalled": true,
+                "removed": removed,
+                "skills": removed_skills,
+            })
+        )?;
     } else {
-        eprintln!();
-        eprintln!("Vera has been uninstalled.");
-        eprintln!("Per-project indexes (.vera/ in each project) were not removed.");
+        writeln!(stderr)?;
+        writeln!(stderr, "Vera has been uninstalled.")?;
+        writeln!(
+            stderr,
+            "Per-project indexes (.vera/ in each project) were not removed."
+        )?;
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    struct Roots {
+        _temp: tempfile::TempDir,
+        home: PathBuf,
+        cwd: PathBuf,
+        vera_home: PathBuf,
+        user_bin_dir: PathBuf,
+    }
+
+    /// A home/project tree that exists only under a temp directory, so no test
+    /// can reach a real skill install.
+    fn roots() -> Roots {
+        let temp = tempdir().unwrap();
+        let home = temp.path().join("home");
+        let cwd = temp.path().join("project");
+        let vera_home = home.join(".vera");
+        let user_bin_dir = temp.path().join("bin");
+        fs::create_dir_all(&home).unwrap();
+        fs::create_dir_all(&cwd).unwrap();
+        fs::create_dir_all(&user_bin_dir).unwrap();
+        Roots {
+            _temp: temp,
+            home,
+            cwd,
+            vera_home,
+            user_bin_dir,
+        }
+    }
+
+    /// Install a fake Claude global skill: `<home>/.claude/skills/vera/SKILL.md`.
+    fn install_claude_global_skill(home: &Path) -> PathBuf {
+        let path = home.join(".claude").join("skills").join("vera");
+        fs::create_dir_all(&path).unwrap();
+        fs::write(path.join("SKILL.md"), "test").unwrap();
+        path
+    }
+
+    fn uninstall(roots: &Roots, json_output: bool) -> (String, String) {
+        let mut stdout = Vec::new();
+        let mut stderr = Vec::new();
+        run_at(
+            &roots.home,
+            &roots.vera_home,
+            &roots.cwd,
+            Some(roots.user_bin_dir.as_path()),
+            json_output,
+            &mut stdout,
+            &mut stderr,
+        )
+        .unwrap();
+        (
+            String::from_utf8(stdout).unwrap(),
+            String::from_utf8(stderr).unwrap(),
+        )
+    }
+
+    #[test]
+    fn uninstall_json_emits_exactly_one_document() {
+        let roots = roots();
+        let skill = install_claude_global_skill(&roots.home);
+
+        let (stdout, _) = uninstall(&roots, true);
+
+        // Strict parse: this is what `json.load` and `serde_json::from_str` do,
+        // and it fails with trailing input if a second document is printed.
+        let document: serde_json::Value = serde_json::from_str(&stdout)
+            .unwrap_or_else(|e| panic!("stdout is not a single JSON document ({e}): {stdout}"));
+
+        assert_eq!(document["uninstalled"], serde_json::json!(true));
+        assert_eq!(
+            document["skills"],
+            serde_json::json!([skill.display().to_string()])
+        );
+        assert!(!skill.exists());
+    }
+
+    #[test]
+    fn uninstall_json_claims_only_categories_that_were_removed() {
+        let roots = roots();
+
+        let (stdout, _) = uninstall(&roots, true);
+
+        let document: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+        assert_eq!(document["removed"], serde_json::json!([]));
+        assert_eq!(document["skills"], serde_json::json!([]));
+    }
+
+    #[test]
+    fn uninstall_human_output_lists_only_removed_locations() {
+        let roots = roots();
+        let skill = install_claude_global_skill(&roots.home);
+        let not_installed = roots.home.join(".gemini").join("skills").join("vera");
+
+        let (stdout, _) = uninstall(&roots, false);
+
+        assert!(stdout.contains("Removed Vera skill from:"), "{stdout}");
+        assert!(stdout.contains(&skill.display().to_string()), "{stdout}");
+        assert!(
+            !stdout.contains(&not_installed.display().to_string()),
+            "{stdout}"
+        );
+        // Heading, blank line, and exactly one row.
+        assert_eq!(stdout.lines().count(), 3, "{stdout}");
+    }
+
+    #[test]
+    fn uninstall_human_output_reports_nothing_when_no_skills_are_installed() {
+        let roots = roots();
+
+        let (stdout, stderr) = uninstall(&roots, false);
+
+        assert_eq!(stdout.trim(), "No Vera skill installations found.");
+        assert!(stderr.contains("Vera has been uninstalled."));
+    }
 }


### PR DESCRIPTION
Part of #99

Fixes the first half only. The `vera doctor` exit code is the other half and is left alone deliberately: it is a behaviour change for anyone already running `vera doctor` in a pipeline, and the issue asks for a maintainer call on the direction. Happy to send it once you pick one.

## The bug

`vera uninstall --json` printed two JSON documents on stdout:

```
$ vera uninstall --json | python3 -c "import json,sys; json.load(sys.stdin)"
json.decoder.JSONDecodeError: Extra data
```

`commands/uninstall.rs:49-54` delegated skill removal to `agent::run(Remove, All, All, json_output)`, which reaches `do_remove` and prints `serde_json::to_string_pretty(&reports)`, an array. `commands/uninstall.rs:90-94` then printed a second object, `{"uninstalled": true, "removed": [...]}`.

The array was never empty. `resolve_locations(All, All)` yields every supported client crossed with both scopes regardless of what is installed, and `do_remove` pushed a report per location unconditionally while only deleting the directory when `SKILL.md` was present.

That same unconditional push made the human output wrong. On a machine with zero skills installed, `vera uninstall` printed `Removed Vera skill from:` followed by a row for each of the 62 client/scope pairs, none of which were removed.

## The fix

**Split the filesystem work out of the printing.** `remove_skill_locations` (`crates/vera-cli/src/commands/agent.rs:595`) deletes each location and returns a report per location; `do_remove` (`crates/vera-cli/src/commands/agent.rs:556`) is now that call plus its output, unchanged in behaviour for `vera agent remove`. `remove_all_skills` (`crates/vera-cli/src/commands/agent.rs:648`) is the silent entry point `uninstall` uses, so nothing prints on that path and `uninstall` folds the result into its own single document.

**Record whether a location was actually removed.** `SkillLocationReport` gains `removed: Option<bool>` (`crates/vera-cli/src/commands/agent.rs:177`), serialized only on the removal path, next to the existing `up_to_date: Option<bool>` and following the same convention. `installed` was already post-state and stays `false`; it could not answer "did anything happen here", which is what both renderers needed.

I went with the flag rather than dropping non-removed locations from the reports, because the two consumers want different things. `vera agent remove --json` is often called with an explicit `--client`/`--scope`, and reporting `[]` there loses the fact that the location was checked and found empty; the flag keeps that. `vera uninstall --json` and both human renderers filter on it, so they only ever name real removals. Dropping the entries would have been simpler but would have made `vera agent remove --json` silently indistinguishable between "not installed" and "not looked at".

**Human output.** `write_removed_skill_locations` (`crates/vera-cli/src/commands/agent.rs:653`) prints only `removed == Some(true)` rows, and falls back to `No Vera skill installations found.` when there are none, matching the message `remove_interactive` already used for the same situation. Both `vera uninstall` and `vera agent remove` render through it, so the JSON and the human output cannot disagree.

**Truthful categories.** `uninstall`'s `removed` array used to list `["agent skills", "vera data dir", "PATH shim"]` unconditionally, including when the data directory did not exist and no shim was found. Each entry is now pushed only when that step removed something (`crates/vera-cli/src/commands/uninstall.rs:90`, `:99`, `:128`). The document also carries `skills`, the paths actually deleted, which is the information the second document used to carry and which no parser could reach.

**Testability.** `uninstall::run_at` (`crates/vera-cli/src/commands/uninstall.rs:65`) takes the home, data directory, cwd, and shim directory as arguments and writes to injected sinks; `run` resolves them and passes real stdout/stderr. `VERA_USER_BIN_DIR` is now read once in `run` rather than deep inside `shim_candidates`, so a test can point every root at a temp tree and no test can reach a real skill install or a real shim.

Streams are unchanged: the skill listing goes to stdout as before, `uninstall`'s own progress lines and closing notes to stderr.

## After

```
$ vera uninstall --json
{"removed":["agent skills","vera data dir"],"skills":["/Users/me/.claude/skills/vera"],"uninstalled":true}

$ vera uninstall            # nothing installed
No Vera skill installations found.

Vera has been uninstalled.
Per-project indexes (.vera/ in each project) were not removed.
```

## Tests

Eight tests in `crates/vera-cli/src/commands/uninstall.rs`, all driven against a `tempdir()` tree with no environment variables involved:

- `uninstall_json_emits_exactly_one_document` parses stdout with `serde_json::from_str`, the strict parse that `json.load` performs, and asserts the removed skill path is in the document.
- `uninstall_json_claims_only_categories_that_were_removed` asserts `removed` and `skills` are both empty when nothing was installed.
- `uninstall_human_output_lists_only_removed_locations` asserts the one installed path is listed, a path for a client that was not installed is not, and stdout is exactly three lines.
- `uninstall_human_output_reports_nothing_when_no_skills_are_installed` asserts the fallback message.

Three more cover the partial-failure path added in `cbe424a`, each with a fixture where an earlier location is deleted and a later one cannot be:

- `uninstall_json_reports_skills_removed_before_a_later_removal_failed` asserts the deleted path is in `skills` and `agent skills` is in `removed`.
- `uninstall_human_output_names_skills_removed_before_a_later_removal_failed` asserts the deleted path is named in the human output.
- `uninstall_human_output_does_not_claim_nothing_was_installed_when_removal_failed` asserts the fallback message is absent when the only location found could not be deleted.

All three also assert the earlier directory really was deleted, so the fixture cannot pass vacuously.

One more covers the inspection side, added in `a18b7b6`:

- `uninstall_does_not_report_an_uninspectable_skill_as_absent` installs a skill whose own directory is `0o000`, so `SKILL.md` cannot be stat'd, and asserts the run neither claims nothing was installed nor stays silent about the reason. It also asserts the skill really did survive, so the fixture cannot pass vacuously.

### Verified by reinjection

Restoring the two original behaviours (report every checked location, and print `do_remove`'s array before the final object) fails all four of the first group with the production errors:

```
uninstall_json_emits_exactly_one_document
  stdout is not a single JSON document (trailing characters at line 437 column 1)

uninstall_json_claims_only_categories_that_were_removed
  Error("trailing characters", line: 437, column: 1)

uninstall_human_output_lists_only_removed_locations
  Removed Vera skill from:

    agents         global  /var/folders/.../home/.config/agents/skills/vera
    agents         project /var/folders/.../project/.agents/skills/vera
    amp            global  /var/folders/.../home/.config/agents/skills/vera
    ...  (62 rows, one installed)

uninstall_human_output_reports_nothing_when_no_skills_are_installed
   left: "Removed Vera skill from:\n\n  agents  global  ...(62 rows)"
  right: "No Vera skill installations found."
```

`trailing characters` is `serde_json`'s wording for the same condition Python reports as `Extra data`.

The partial-failure half was reinjected separately, one half of the fix at a time:

- Restoring the `?` on `fs::remove_dir_all`, so a failure propagates and `run_at` substitutes the default, fails all three of the second group. The JSON test reports the exact production document, `{"removed":[],"skills":[],"uninstalled":true}`, against a right-hand side naming the Claude skill path that really had been deleted.
- Restoring the unguarded `if removed.is_empty()` fallback fails exactly one, `uninstall_human_output_does_not_claim_nothing_was_installed_when_removal_failed`, which is the test whose fixture has an empty removal set and a non-empty failure set.
- Restoring `Path::exists` in place of `try_exists` fails exactly one, `uninstall_does_not_report_an_uninspectable_skill_as_absent`, with the production message: `claimed nothing was installed while .../.claude/skills/vera was still on disk: No Vera skill installations found.`

## Verification

- `cargo fmt --check` clean
- `cargo test -p vera-cli --bin vera` 105 passed, 0 failed
- `cargo test -p vera-core --lib` 793 passed, 0 failed
- `cargo clippy -p vera-core --lib` 5 warnings, the pre-existing ones, none added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Uninstall results now identify which skills and shims were actually removed.
  * JSON output includes removed skill locations.
  * Human-readable output clearly reports removed skills and shims.
  * Bulk skill removal supports reusable reporting and output handling.

* **Bug Fixes**
  * Missing skill locations are distinguished from successfully removed installations.
  * Skill removal failures are reported without stopping the rest of the uninstall process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Emits a single JSON document from `vera uninstall --json` and reports only actual removals. It preserves earlier successes when a later location fails, and records inspection/deletion errors instead of claiming skills were absent.

- Outputs one JSON object with `uninstalled`, `removed` (only categories actually deleted), and `skills` (paths actually deleted); failures go to stderr so stdout stays a single document.
- Adds `removed: Option<bool>` to `SkillLocationReport`; `vera agent remove --json` includes it and prints reports before returning the first failure, so successful deletions remain visible.
- Uses `try_exists` to distinguish unreadable skills from absent ones; does not print “No Vera skill installations found.” when failures occurred.
- Lists categories only when work was done (data dir and PATH shim are reported only if deleted). Streams unchanged: listings to stdout; progress/notes to stderr.

Migration:
- Update scripts that parsed multiple JSON documents from `vera uninstall --json` to read a single object and derive removed categories from `removed` and `skills`.

<sup>Written for commit a18b7b6c839ad38d9f3b405eace243fc39d0a28a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/VeraTools/Vera/pull/128?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

