### PR TITLE
fix(embedding): single-source the CodeRankEmbed query prefix

### DIFF
--- a/crates/vera-core/src/embedding/provider.rs
+++ b/crates/vera-core/src/embedding/provider.rs
@@ -1368,31 +1368,44 @@ mod tests {
     }
 
     /// The local ONNX path and the API path must embed the same query
-    /// identically. They apply the prefix differently (`query_text` trims and
-    /// joins with one space, `prepare_query_text` concatenates raw), so this
-    /// pins the resulting text rather than the constant.
+    /// identically. They apply the prefix differently (`query_text` trims the
+    /// *prefix* and rejoins it with one space, `prepare_query_text`
+    /// concatenates a prefix that already carries its own trailing space), so
+    /// this pins the resulting text rather than the constant.
+    ///
+    /// Neither path touches the query itself, so an un-normalized query has to
+    /// survive verbatim and identically on both sides; that case is covered
+    /// here so a one-sided `trim()` cannot be added without failing.
     #[test]
     fn coderankembed_query_text_matches_across_local_and_api_paths() {
-        let query = "find router code";
+        let cases = [
+            (
+                "find router code",
+                "Represent this query for searching relevant code: find router code",
+            ),
+            (
+                "  find router code  ",
+                "Represent this query for searching relevant code:   find router code  ",
+            ),
+        ];
 
-        let local =
-            crate::local_models::LocalEmbeddingModelConfig::coderankembed().query_text(query);
+        for (query, expected) in cases {
+            let local =
+                crate::local_models::LocalEmbeddingModelConfig::coderankembed().query_text(query);
 
-        let mut config = EmbeddingProviderConfig::new(
-            "http://x".into(),
-            "krlvi/CodeRankEmbed".into(),
-            "k".into(),
-        );
-        config.query_prefix = default_query_prefix_for_model(&config.model_id);
-        let api = OpenAiProvider::new(config)
-            .unwrap()
-            .prepare_query_text(query);
+            let mut config = EmbeddingProviderConfig::new(
+                "http://x".into(),
+                "krlvi/CodeRankEmbed".into(),
+                "k".into(),
+            );
+            config.query_prefix = default_query_prefix_for_model(&config.model_id);
+            let api = OpenAiProvider::new(config)
+                .unwrap()
+                .prepare_query_text(query);
 
-        assert_eq!(local, api);
-        assert_eq!(
-            local,
-            "Represent this query for searching relevant code: find router code"
-        );
+            assert_eq!(local, api, "paths diverged on {query:?}");
+            assert_eq!(local, expected, "unexpected prefixed text for {query:?}");
+        }
     }
 
     #[test]

--- a/crates/vera-core/src/embedding/provider.rs
+++ b/crates/vera-core/src/embedding/provider.rs
@@ -11,6 +11,7 @@ use tokio_util::sync::CancellationToken;
 use tracing::{debug, warn};
 
 use crate::chunk_text;
+use crate::local_models::CODERANK_QUERY_PREFIX;
 use crate::types::Chunk;
 
 // ── Error types ──────────────────────────────────────────────────────
@@ -193,7 +194,9 @@ fn default_query_prefix_for_model(model_id: &str) -> Option<String> {
     if id.contains("qwen3-embedding") || id.contains("qwen3_embedding") {
         Some("Instruct: Given a code search query, retrieve relevant code snippets that match the query\nQuery: ".into())
     } else if id.contains("coderankembed") {
-        Some("Represent this query for retrieving relevant code: ".into())
+        // `prepare_query_text` concatenates without a separator, so the
+        // trailing space belongs here rather than in the shared constant.
+        Some(format!("{CODERANK_QUERY_PREFIX} "))
     } else if id.contains("e5-") || id.contains("e5_") {
         Some("query: ".into())
     } else if id.contains("bge-") || id.contains("bge_") {
@@ -1356,8 +1359,40 @@ mod tests {
     #[test]
     fn auto_detect_coderankembed_prefix() {
         let prefix = default_query_prefix_for_model("krlvi/CodeRankEmbed");
-        assert!(prefix.is_some());
-        assert!(prefix.unwrap().contains("Represent this query"));
+        // Exact: the published prompt in the model's
+        // `config_sentence_transformers.json`, trailing space included.
+        assert_eq!(
+            prefix.as_deref(),
+            Some("Represent this query for searching relevant code: ")
+        );
+    }
+
+    /// The local ONNX path and the API path must embed the same query
+    /// identically. They apply the prefix differently (`query_text` trims and
+    /// joins with one space, `prepare_query_text` concatenates raw), so this
+    /// pins the resulting text rather than the constant.
+    #[test]
+    fn coderankembed_query_text_matches_across_local_and_api_paths() {
+        let query = "find router code";
+
+        let local =
+            crate::local_models::LocalEmbeddingModelConfig::coderankembed().query_text(query);
+
+        let mut config = EmbeddingProviderConfig::new(
+            "http://x".into(),
+            "krlvi/CodeRankEmbed".into(),
+            "k".into(),
+        );
+        config.query_prefix = default_query_prefix_for_model(&config.model_id);
+        let api = OpenAiProvider::new(config)
+            .unwrap()
+            .prepare_query_text(query);
+
+        assert_eq!(local, api);
+        assert_eq!(
+            local,
+            "Represent this query for searching relevant code: find router code"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Problem

CodeRankEmbed's query prefix was written out twice, with different text:

| Site | String |
|---|---|
| `crates/vera-core/src/local_models/mod.rs:23` | `Represent this query for searching relevant code:` |
| `crates/vera-core/src/embedding/provider.rs:196` | `Represent this query for retrieving relevant code: ` |

**searching** versus **retrieving**. The local ONNX path and the API path therefore
embedded the same query differently under one model name, and neither path errors.

The test at `provider.rs:1360` asserted `contains("Represent this query")`, which
matches both spellings, so the suite never saw it.

## Which string is correct

**`Represent this query for searching relevant code: `** — the local path was right,
the API path was wrong.

Evidence is the machine-readable prompt field, not the model card prose. Both the
re-export Vera actually pulls and the upstream original ship an identical
`config_sentence_transformers.json`:

```
$ curl -s https://huggingface.co/Zenabius/CodeRankEmbed-onnx/raw/main/config_sentence_transformers.json
$ curl -s https://huggingface.co/nomic-ai/CodeRankEmbed/raw/main/config_sentence_transformers.json
```

Both return:

```json
"prompts": {
  "query": "Represent this query for searching relevant code: "
},
"default_prompt_name": null
```

`sentence-transformers` concatenates prompt and text with no separator, so the
canonical query text is `Represent this query for searching relevant code: <query>`
with exactly one space.

## The trailing space

The two call sites apply the prefix differently, so the shared constant cannot carry
a separator that suits both:

- `LocalEmbeddingModelConfig::query_text` (`local_models/mod.rs:295`) trims the prefix,
  then joins with exactly one space.
- `OpenAiProvider::prepare_query_text` (`provider.rs:463`) concatenates raw, which is
  why every sibling entry in `default_query_prefix_for_model` carries its own
  trailing space.

The constant keeps the semantic text with no trailing space, exactly as it is today,
and the API site appends the separator its call site requires. Both paths then produce
the byte-identical canonical string.

Worth noting: `query_text`'s `if prefix.chars().last().is_some_and(char::is_whitespace)`
branch is unreachable, because the prefix is `str::trim`ed two lines above. Left alone
here, but it means a trailing space on the constant would have been silently swallowed
on the local side while doubling on the API side.

## Change

- `crates/vera-core/src/embedding/provider.rs:196` now reads `CODERANK_QUERY_PREFIX`
  from `local_models` instead of holding a second literal.
- `crates/vera-core/src/local_models/mod.rs:23` is unchanged.

`CODERANK_QUERY_PREFIX` is the only prompt string that had two homes. The other
entries in `default_query_prefix_for_model` (qwen3, e5, bge) have no local-preset
counterpart, so they are single-sited and cannot diverge the same way. The remaining
copies are a CLI usage example in `docs/models.md:50` and an expected-output assertion
in `local_models/tests.rs:26`; both are correct and neither feeds production.

## No re-index

The local path's effective query text does not change, so this does not move
`model_identity`.

`model_identity` (`local_models/mod.rs:279`) short-circuits to `display_name()` when
the config equals `Self::coderankembed()`. That preset is built from
`CODERANK_QUERY_PREFIX`, which this PR does not touch, so a stored
`~/.vera/config.json` that matched the preset before still matches it. Had the constant
gained the trailing space instead, every stored config would have stopped comparing
equal, dropped out of the short-circuit into the long-form identity, and forced a
re-index for a change with no effect on the embedded text.

The API path change is query-side only. `prepare_query_text` is not applied to
documents, so no stored vector changes; API-configured users get queries embedded into
the space their index was actually built for, with no re-index.

## Tests

- `auto_detect_coderankembed_prefix` now asserts the exact string rather than a
  substring.
- `coderankembed_query_text_matches_across_local_and_api_paths` is new. It runs a query
  through both real code paths (`LocalEmbeddingModelConfig::coderankembed().query_text`
  and `OpenAiProvider::prepare_query_text`) and asserts the results are byte-identical
  and equal to the published prompt. It pins the property rather than the constant, so
  it fails whichever side is edited, including a change to how either applies its
  separator. No network, no model assets.

  It runs two queries: a normalized one and `"  find router code  "`. Neither path
  normalizes the query — `query_text` trims the *prefix*, `prepare_query_text`
  concatenates a prefix that already carries its separator, and both interpolate the
  query verbatim — so an un-normalized query has to survive identically on both sides.
  Covering it means a one-sided `trim()` cannot be introduced without failing the test.

Verified by reinjection, two variants:

- restoring the `retrieving` literal fails both tests with the real divergence, and the
  parity test reports the two paths' actual strings;
- trimming the query on the API side only (`format!("{prefix}{}", query.trim())`) passes
  the normalized case and fails the whitespace one:

```
assertion `left == right` failed: paths diverged on "  find router code  "
  left: "Represent this query for searching relevant code:   find router code  "
 right: "Represent this query for searching relevant code: find router code"
```

Fixes #118


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized CodeRank query-prefix handling for more consistent embedding behavior.
  * Ensured local and API-based embedding paths produce identical query text.
  * Improved accuracy by using the published query prefix format, including the required trailing space.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Single-sources the CodeRankEmbed query prefix so local and API paths embed the same query text. Before: local used “searching” and API used “retrieving,” producing different embeddings; now both use the published prompt and generate identical strings.

- Notes for review
  - `default_query_prefix_for_model` reads `CODERANK_QUERY_PREFIX` and appends a trailing space to match `prepare_query_text`; the constant remains space-free for local joins.
  - Tests assert the exact prefix (including the trailing space) and add a parity test that covers both normalized and un-normalized queries, ensuring byte-identical outputs across local and API paths; corrected a stale doc comment.
  - No migration or re-index: stored configs still match the preset and document vectors do not change.

<sup>Written for commit e395ee577b9ddadd786f64b7206840b46b61d9ba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/VeraTools/Vera/pull/129?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

