### PR TITLE
fix(mcp): surface a stale-index warning in tool results

### DIFF
--- a/crates/vera-cli/src/helpers.rs
+++ b/crates/vera-cli/src/helpers.rs
@@ -66,16 +66,13 @@ pub fn load_runtime_config() -> anyhow::Result<vera_core::config::VeraConfig> {
 
 pub fn warn_if_index_stale(repo_path: &Path, indexing_config: &vera_core::config::IndexingConfig) {
     match vera_core::indexing::detect_staleness(repo_path, indexing_config) {
-        Ok(freshness) if freshness.is_stale() => {
-            let stderr = std::io::stderr();
-            let mut err = stderr.lock();
-            let _ = writeln!(
-                err,
-                "warning: index may be stale: {}. Search and grep only cover indexed files. Run `vera update .` or `vera watch .`.",
-                freshness.summary()
-            );
+        Ok(freshness) => {
+            if let Some(warning) = freshness.stale_warning() {
+                let stderr = std::io::stderr();
+                let mut err = stderr.lock();
+                let _ = writeln!(err, "{warning}");
+            }
         }
-        Ok(_) => {}
         Err(err) => {
             tracing::debug!(error = %err, "failed to check index freshness");
         }

--- a/crates/vera-core/src/indexing/freshness.rs
+++ b/crates/vera-core/src/indexing/freshness.rs
@@ -48,6 +48,19 @@ impl IndexFreshness {
         }
         parts.join(", ")
     }
+
+    /// The stale-index warning shown to users, or `None` when the index covers
+    /// the tree. Single-sourced here because the CLI prints it on stderr and
+    /// the MCP server attaches it to tool results, and the two must agree.
+    pub fn stale_warning(&self) -> Option<String> {
+        if !self.is_stale() {
+            return None;
+        }
+        Some(format!(
+            "warning: index may be stale: {}. Search and grep only cover indexed files. Run `vera update .` or `vera watch .`.",
+            self.summary()
+        ))
+    }
 }
 
 pub(crate) fn record_index_snapshot(
@@ -216,6 +229,26 @@ mod tests {
             std::fs::create_dir_all(parent).unwrap();
         }
         std::fs::write(path, content).unwrap();
+    }
+
+    #[test]
+    fn stale_warning_names_every_kind_of_drift() {
+        let freshness = IndexFreshness {
+            files_added: 1,
+            files_modified: 2,
+            files_deleted: 3,
+        };
+        assert_eq!(
+            freshness.stale_warning().unwrap(),
+            "warning: index may be stale: 1 added, 2 modified, 3 deleted. \
+             Search and grep only cover indexed files. \
+             Run `vera update .` or `vera watch .`."
+        );
+    }
+
+    #[test]
+    fn fresh_index_has_no_stale_warning() {
+        assert_eq!(IndexFreshness::default().stale_warning(), None);
     }
 
     #[test]

--- a/crates/vera-mcp/src/lib.rs
+++ b/crates/vera-mcp/src/lib.rs
@@ -16,5 +16,7 @@ pub mod protocol;
 pub mod saved_config;
 pub mod server;
 pub mod staleness;
+#[cfg(test)]
+mod test_support;
 pub mod tools;
 pub mod watcher;

--- a/crates/vera-mcp/src/lib.rs
+++ b/crates/vera-mcp/src/lib.rs
@@ -15,5 +15,6 @@
 pub mod protocol;
 pub mod saved_config;
 pub mod server;
+pub mod staleness;
 pub mod tools;
 pub mod watcher;

--- a/crates/vera-mcp/src/protocol.rs
+++ b/crates/vera-mcp/src/protocol.rs
@@ -156,6 +156,22 @@ impl ToolCallResult {
         }
     }
 
+    /// Create a success result carrying an optional advisory notice.
+    ///
+    /// The notice is a separate trailing content block, so `content[0]` stays
+    /// byte-identical to what [`ToolCallResult::success`] would have produced
+    /// and clients that parse it as JSON are unaffected.
+    pub fn success_with_notice(text: impl Into<String>, notice: Option<String>) -> Self {
+        let mut result = Self::success(text);
+        if let Some(notice) = notice {
+            result.content.push(TextContent {
+                r#type: "text",
+                text: notice,
+            });
+        }
+        result
+    }
+
     /// Create an error result with text content.
     pub fn error(text: impl Into<String>) -> Self {
         Self {
@@ -195,6 +211,22 @@ mod tests {
         assert!(!result.is_error);
         assert_eq!(result.content[0].text, "hello world");
         assert_eq!(result.content[0].r#type, "text");
+    }
+
+    #[test]
+    fn tool_call_result_notice_is_a_trailing_block() {
+        let result = ToolCallResult::success_with_notice("[]", Some("warning: stale".to_string()));
+        assert!(!result.is_error);
+        assert_eq!(result.content.len(), 2);
+        assert_eq!(result.content[0].text, "[]");
+        assert_eq!(result.content[1].text, "warning: stale");
+    }
+
+    #[test]
+    fn tool_call_result_without_notice_has_one_block() {
+        let result = ToolCallResult::success_with_notice("[]", None);
+        assert_eq!(result.content.len(), 1);
+        assert_eq!(result.content[0].text, "[]");
     }
 
     #[test]

--- a/crates/vera-mcp/src/staleness.rs
+++ b/crates/vera-mcp/src/staleness.rs
@@ -1,0 +1,136 @@
+//! Stale-index detection for MCP tool results.
+//!
+//! MCP has no out-of-band channel the agent reads, so a `tracing::warn!` never
+//! reaches it. The notice built here is attached to the tool result itself, in
+//! the same wording `vera search` prints on stderr, so both surfaces agree.
+//!
+//! A freshness scan re-hashes every tracked file, which is too expensive to run
+//! on every tool call, so the outcome is cached for [`STALENESS_TTL`].
+
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+use std::time::{Duration, Instant};
+
+use vera_core::indexing::IndexFreshness;
+
+/// How long one freshness scan result is reused before rescanning.
+const STALENESS_TTL: Duration = Duration::from_secs(30);
+
+static CACHE: Mutex<Option<CachedStaleness>> = Mutex::new(None);
+
+struct CachedStaleness {
+    repo: PathBuf,
+    checked_at: Instant,
+    notice: Option<String>,
+}
+
+/// Render the stale-index notice, or `None` when the index covers the tree.
+///
+/// The wording matches `warn_if_index_stale` in `vera-cli`.
+pub fn notice_for(freshness: &IndexFreshness) -> Option<String> {
+    if !freshness.is_stale() {
+        return None;
+    }
+    Some(format!(
+        "warning: index may be stale: {}. Search and grep only cover indexed files. Run `vera update .` or `vera watch .`.",
+        freshness.summary()
+    ))
+}
+
+/// Stale-index notice for `repo`, rescanning at most once per [`STALENESS_TTL`].
+///
+/// A scan failure is not a tool failure: it is logged and treated as fresh.
+pub fn notice_for_repo(repo: &Path) -> Option<String> {
+    let mut guard = CACHE.lock().unwrap_or_else(|err| err.into_inner());
+    if let Some(cached) = guard
+        .as_ref()
+        .filter(|cached| cached.repo == repo && cached.checked_at.elapsed() < STALENESS_TTL)
+    {
+        return cached.notice.clone();
+    }
+
+    let config = crate::saved_config::load_saved_runtime_config();
+    let notice = match vera_core::indexing::detect_staleness(repo, &config.indexing) {
+        Ok(freshness) => notice_for(&freshness),
+        Err(err) => {
+            tracing::debug!(error = %err, "failed to check index freshness");
+            None
+        }
+    };
+    *guard = Some(CachedStaleness {
+        repo: repo.to_path_buf(),
+        checked_at: Instant::now(),
+        notice: notice.clone(),
+    });
+    notice
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use vera_core::indexing::content_hash;
+    use vera_core::storage::metadata::MetadataStore;
+
+    fn write_file(root: &Path, relative: &str, content: &str) {
+        let path = root.join(relative);
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(path, content).unwrap();
+    }
+
+    fn open_metadata(root: &Path) -> MetadataStore {
+        let index_dir = root.join(".vera");
+        std::fs::create_dir_all(&index_dir).unwrap();
+        MetadataStore::open(&index_dir.join("metadata.db")).unwrap()
+    }
+
+    #[test]
+    fn stale_index_produces_a_notice_naming_the_drift() {
+        let dir = tempfile::tempdir().unwrap();
+        write_file(dir.path(), "src/lib.rs", "pub fn current() {}\n");
+        write_file(dir.path(), "src/new.rs", "pub fn added() {}\n");
+
+        let metadata = open_metadata(dir.path());
+        metadata
+            .set_file_hash("src/lib.rs", &content_hash("pub fn previous() {}\n"))
+            .unwrap();
+        drop(metadata);
+
+        let notice = notice_for_repo(dir.path()).expect("stale index must produce a notice");
+        assert_eq!(
+            notice,
+            "warning: index may be stale: 1 added, 1 modified. \
+             Search and grep only cover indexed files. \
+             Run `vera update .` or `vera watch .`."
+        );
+    }
+
+    #[test]
+    fn fresh_index_produces_no_notice() {
+        let dir = tempfile::tempdir().unwrap();
+        let source = "pub fn current() {}\n";
+        write_file(dir.path(), "src/lib.rs", source);
+
+        let metadata = open_metadata(dir.path());
+        metadata
+            .set_file_hash("src/lib.rs", &content_hash(source))
+            .unwrap();
+        drop(metadata);
+
+        assert_eq!(notice_for_repo(dir.path()), None);
+    }
+
+    #[test]
+    fn notice_reports_deletions() {
+        let freshness = IndexFreshness {
+            files_added: 0,
+            files_modified: 0,
+            files_deleted: 3,
+        };
+        assert_eq!(
+            notice_for(&freshness).unwrap(),
+            "warning: index may be stale: 3 deleted. \
+             Search and grep only cover indexed files. \
+             Run `vera update .` or `vera watch .`."
+        );
+    }
+}

--- a/crates/vera-mcp/src/staleness.rs
+++ b/crates/vera-mcp/src/staleness.rs
@@ -1,8 +1,8 @@
 //! Stale-index detection for MCP tool results.
 //!
 //! MCP has no out-of-band channel the agent reads, so a `tracing::warn!` never
-//! reaches it. The notice built here is attached to the tool result itself, in
-//! the same wording `vera search` prints on stderr, so both surfaces agree.
+//! reaches it. The notice is `IndexFreshness::stale_warning`, the same string
+//! `vera search` prints on stderr, attached to the tool result itself.
 //!
 //! A freshness scan re-hashes every tracked file, which is too expensive to run
 //! on every tool call, so the outcome is cached for [`STALENESS_TTL`].
@@ -11,12 +11,15 @@ use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 use std::time::{Duration, Instant};
 
-use vera_core::indexing::IndexFreshness;
-
 /// How long one freshness scan result is reused before rescanning.
 const STALENESS_TTL: Duration = Duration::from_secs(30);
 
-static CACHE: Mutex<Option<CachedStaleness>> = Mutex::new(None);
+/// How many repositories keep a scan result at once. `get_overview` takes a
+/// `path` argument, so one server answers about more than the tree it was
+/// started in, and a single-entry cache would rescan on every alternation.
+const CACHE_CAPACITY: usize = 8;
+
+static CACHE: Mutex<Vec<CachedStaleness>> = Mutex::new(Vec::new());
 
 struct CachedStaleness {
     repo: PathBuf,
@@ -24,76 +27,76 @@ struct CachedStaleness {
     notice: Option<String>,
 }
 
-/// Render the stale-index notice, or `None` when the index covers the tree.
-///
-/// The wording matches `warn_if_index_stale` in `vera-cli`.
-pub fn notice_for(freshness: &IndexFreshness) -> Option<String> {
-    if !freshness.is_stale() {
-        return None;
+/// Cache key for `repo`: the resolved path, so that `.` and the absolute path
+/// to the same tree share one entry. An unresolvable path keys on itself.
+fn cache_key(repo: &Path) -> PathBuf {
+    std::fs::canonicalize(repo).unwrap_or_else(|_| repo.to_path_buf())
+}
+
+/// Cached notice for `key`, or `None` when there is no live entry.
+fn cached_notice(key: &Path) -> Option<Option<String>> {
+    let guard = CACHE.lock().unwrap_or_else(|err| err.into_inner());
+    guard
+        .iter()
+        .find(|cached| cached.repo == key && cached.checked_at.elapsed() < STALENESS_TTL)
+        .map(|cached| cached.notice.clone())
+}
+
+/// Record `notice` for `key`, replacing any entry for the same repository and
+/// dropping the least recently scanned one once [`CACHE_CAPACITY`] is reached.
+fn store_notice(key: PathBuf, notice: Option<String>) {
+    let mut guard = CACHE.lock().unwrap_or_else(|err| err.into_inner());
+    guard.retain(|cached| cached.repo != key);
+    if guard.len() >= CACHE_CAPACITY {
+        if let Some(oldest) = guard
+            .iter()
+            .enumerate()
+            .min_by_key(|(_, cached)| cached.checked_at)
+            .map(|(index, _)| index)
+        {
+            guard.remove(oldest);
+        }
     }
-    Some(format!(
-        "warning: index may be stale: {}. Search and grep only cover indexed files. Run `vera update .` or `vera watch .`.",
-        freshness.summary()
-    ))
+    guard.push(CachedStaleness {
+        repo: key,
+        checked_at: Instant::now(),
+        notice,
+    });
 }
 
 /// Stale-index notice for `repo`, rescanning at most once per [`STALENESS_TTL`].
 ///
 /// A scan failure is not a tool failure: it is logged and treated as fresh.
 pub fn notice_for_repo(repo: &Path) -> Option<String> {
-    let mut guard = CACHE.lock().unwrap_or_else(|err| err.into_inner());
-    if let Some(cached) = guard
-        .as_ref()
-        .filter(|cached| cached.repo == repo && cached.checked_at.elapsed() < STALENESS_TTL)
-    {
-        return cached.notice.clone();
+    let key = cache_key(repo);
+    if let Some(notice) = cached_notice(&key) {
+        return notice;
     }
 
+    // Scanned without the lock: it re-hashes every tracked file, and holding
+    // the lock across that would serialize unrelated repositories. A duplicate
+    // concurrent scan of the same repository is wasteful, never wrong.
     let config = crate::saved_config::load_saved_runtime_config();
     let notice = match vera_core::indexing::detect_staleness(repo, &config.indexing) {
-        Ok(freshness) => notice_for(&freshness),
+        Ok(freshness) => freshness.stale_warning(),
         Err(err) => {
             tracing::debug!(error = %err, "failed to check index freshness");
             None
         }
     };
-    *guard = Some(CachedStaleness {
-        repo: repo.to_path_buf(),
-        checked_at: Instant::now(),
-        notice: notice.clone(),
-    });
+    store_notice(key, notice.clone());
     notice
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use vera_core::indexing::content_hash;
-    use vera_core::storage::metadata::MetadataStore;
-
-    fn write_file(root: &Path, relative: &str, content: &str) {
-        let path = root.join(relative);
-        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
-        std::fs::write(path, content).unwrap();
-    }
-
-    fn open_metadata(root: &Path) -> MetadataStore {
-        let index_dir = root.join(".vera");
-        std::fs::create_dir_all(&index_dir).unwrap();
-        MetadataStore::open(&index_dir.join("metadata.db")).unwrap()
-    }
+    use crate::test_support::{repo_indexed_as, write_file};
 
     #[test]
     fn stale_index_produces_a_notice_naming_the_drift() {
-        let dir = tempfile::tempdir().unwrap();
-        write_file(dir.path(), "src/lib.rs", "pub fn current() {}\n");
+        let dir = repo_indexed_as("pub fn current() {}\n", "pub fn previous() {}\n");
         write_file(dir.path(), "src/new.rs", "pub fn added() {}\n");
-
-        let metadata = open_metadata(dir.path());
-        metadata
-            .set_file_hash("src/lib.rs", &content_hash("pub fn previous() {}\n"))
-            .unwrap();
-        drop(metadata);
 
         let notice = notice_for_repo(dir.path()).expect("stale index must produce a notice");
         assert_eq!(
@@ -106,31 +109,28 @@ mod tests {
 
     #[test]
     fn fresh_index_produces_no_notice() {
-        let dir = tempfile::tempdir().unwrap();
         let source = "pub fn current() {}\n";
-        write_file(dir.path(), "src/lib.rs", source);
-
-        let metadata = open_metadata(dir.path());
-        metadata
-            .set_file_hash("src/lib.rs", &content_hash(source))
-            .unwrap();
-        drop(metadata);
+        let dir = repo_indexed_as(source, source);
 
         assert_eq!(notice_for_repo(dir.path()), None);
     }
 
     #[test]
-    fn notice_reports_deletions() {
-        let freshness = IndexFreshness {
-            files_added: 0,
-            files_modified: 0,
-            files_deleted: 3,
-        };
+    fn checking_one_repo_does_not_evict_another() {
+        let first = repo_indexed_as("pub fn current() {}\n", "pub fn previous() {}\n");
+        let second = repo_indexed_as("pub fn other() {}\n", "pub fn other() {}\n");
+
+        let cached = notice_for_repo(first.path()).expect("stale index must produce a notice");
+        assert_eq!(notice_for_repo(second.path()), None);
+
+        // The first tree is now genuinely fresh, so a rescan would answer
+        // `None`. Within the TTL the cached answer must survive the second
+        // repository's check.
+        write_file(first.path(), "src/lib.rs", "pub fn previous() {}\n");
         assert_eq!(
-            notice_for(&freshness).unwrap(),
-            "warning: index may be stale: 3 deleted. \
-             Search and grep only cover indexed files. \
-             Run `vera update .` or `vera watch .`."
+            notice_for_repo(first.path()).as_deref(),
+            Some(cached.as_str()),
+            "a second repository's check must not evict the first repository's cached scan"
         );
     }
 }

--- a/crates/vera-mcp/src/test_support.rs
+++ b/crates/vera-mcp/src/test_support.rs
@@ -1,0 +1,36 @@
+//! Fixtures shared by the staleness and tool-result tests.
+//!
+//! Both build a repository whose working tree and recorded index hashes are
+//! set independently, which is what makes an index look stale.
+
+use std::path::Path;
+
+use tempfile::TempDir;
+use vera_core::indexing::content_hash;
+use vera_core::storage::metadata::MetadataStore;
+
+/// Write `content` to `relative` under `root`, creating parent directories.
+pub fn write_file(root: &Path, relative: &str, content: &str) {
+    let path = root.join(relative);
+    std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+    std::fs::write(path, content).unwrap();
+}
+
+/// Open (creating if needed) the metadata store of the index under `root`.
+pub fn open_metadata(root: &Path) -> MetadataStore {
+    let index_dir = root.join(".vera");
+    std::fs::create_dir_all(&index_dir).unwrap();
+    MetadataStore::open(&index_dir.join("metadata.db")).unwrap()
+}
+
+/// Build a repository holding `source` in `src/lib.rs`, indexed under the hash
+/// of `indexed_source`. Passing the same text twice yields a fresh index.
+pub fn repo_indexed_as(source: &str, indexed_source: &str) -> TempDir {
+    let dir = tempfile::tempdir().unwrap();
+    write_file(dir.path(), "src/lib.rs", source);
+    let metadata = open_metadata(dir.path());
+    metadata
+        .set_file_hash("src/lib.rs", &content_hash(indexed_source))
+        .unwrap();
+    dir
+}

--- a/crates/vera-mcp/src/tools.rs
+++ b/crates/vera-mcp/src/tools.rs
@@ -1012,23 +1012,7 @@ fn handle_explain_path(args: &Value) -> ToolCallResult {
 mod tests {
     use super::*;
 
-    /// Build a repo holding `source`, indexed under the hash of `indexed_source`.
-    /// Passing the same text twice yields a fresh index.
-    fn repo_indexed_as(source: &str, indexed_source: &str) -> tempfile::TempDir {
-        let dir = tempfile::tempdir().unwrap();
-        std::fs::create_dir_all(dir.path().join("src")).unwrap();
-        std::fs::write(dir.path().join("src/lib.rs"), source).unwrap();
-        std::fs::create_dir_all(dir.path().join(".vera")).unwrap();
-        let db_path = dir.path().join(".vera/metadata.db");
-        let metadata = vera_core::storage::metadata::MetadataStore::open(&db_path).unwrap();
-        metadata
-            .set_file_hash(
-                "src/lib.rs",
-                &vera_core::indexing::content_hash(indexed_source),
-            )
-            .unwrap();
-        dir
-    }
+    use crate::test_support::repo_indexed_as;
 
     #[test]
     fn stale_index_result_carries_the_warning_after_the_results() {

--- a/crates/vera-mcp/src/tools.rs
+++ b/crates/vera-mcp/src/tools.rs
@@ -86,6 +86,15 @@ fn compact_results_json(
     serde_json::to_string(&compact)
 }
 
+/// Wrap serialized results in a tool result, attaching a stale-index notice
+/// when the working tree has drifted from the index.
+///
+/// The notice rides in its own content block, so it stays outside
+/// `MCP_OUTPUT_BUDGET` and cannot silently evict results.
+fn results_with_staleness(cwd: &std::path::Path, json: String) -> ToolCallResult {
+    ToolCallResult::success_with_notice(json, crate::staleness::notice_for_repo(cwd))
+}
+
 /// Git-scope filter properties shared by tool schemas: `changed`, `since`,
 /// `base`. `what` names the restricted operation (e.g. "search").
 fn git_scope_properties(what: &str) -> serde_json::Map<String, Value> {
@@ -624,7 +633,7 @@ fn handle_search_code(args: &Value) -> ToolCallResult {
         .unwrap_or(false);
 
     match compact_results_json(&all_results, MCP_OUTPUT_BUDGET, signatures_only) {
-        Ok(json) => ToolCallResult::success(json),
+        Ok(json) => results_with_staleness(&cwd, json),
         Err(e) => ToolCallResult::error(format!("Failed to serialize results: {e}")),
     }
 }
@@ -767,7 +776,7 @@ fn handle_get_overview(args: &Value) -> ToolCallResult {
     };
     match vera_core::stats::collect_overview_filtered(&repo_path, exact_paths.as_ref()) {
         Ok(overview) => match serde_json::to_string_pretty(&overview) {
-            Ok(json) => ToolCallResult::success(json),
+            Ok(json) => results_with_staleness(&repo_path, json),
             Err(e) => ToolCallResult::error(format!("Failed to serialize overview: {e}")),
         },
         Err(e) => ToolCallResult::error(format!("Failed to collect overview: {e}")),
@@ -828,7 +837,7 @@ fn handle_regex_search(args: &Value) -> ToolCallResult {
                 .and_then(|v| v.as_bool())
                 .unwrap_or(false);
             match compact_results_json(&results, MCP_OUTPUT_BUDGET, signatures_only) {
-                Ok(json) => ToolCallResult::success(json),
+                Ok(json) => results_with_staleness(&cwd, json),
                 Err(e) => ToolCallResult::error(format!("Failed to serialize results: {e}")),
             }
         }
@@ -880,7 +889,7 @@ fn handle_structural_search(args: &Value) -> ToolCallResult {
                 .and_then(|v| v.as_bool())
                 .unwrap_or(false);
             match compact_results_json(&results, MCP_OUTPUT_BUDGET, signatures_only) {
-                Ok(json) => ToolCallResult::success(json),
+                Ok(json) => results_with_staleness(&cwd, json),
                 Err(e) => ToolCallResult::error(format!("Failed to serialize results: {e}")),
             }
         }
@@ -926,7 +935,7 @@ fn handle_find_references(args: &Value) -> ToolCallResult {
                 }
                 results.truncate(limit);
                 match serde_json::to_string(&results) {
-                    Ok(json) => ToolCallResult::success(json),
+                    Ok(json) => results_with_staleness(&cwd, json),
                     Err(err) => {
                         ToolCallResult::error(format!("Failed to serialize references: {err}"))
                     }
@@ -948,7 +957,7 @@ fn handle_find_references(args: &Value) -> ToolCallResult {
                     .and_then(|v| v.as_bool())
                     .unwrap_or(false);
                 match compact_results_json(&results, MCP_OUTPUT_BUDGET, signatures_only) {
-                    Ok(json) => ToolCallResult::success(json),
+                    Ok(json) => results_with_staleness(&cwd, json),
                     Err(err) => {
                         ToolCallResult::error(format!("Failed to serialize references: {err}"))
                     }
@@ -1002,6 +1011,57 @@ fn handle_explain_path(args: &Value) -> ToolCallResult {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Build a repo holding `source`, indexed under the hash of `indexed_source`.
+    /// Passing the same text twice yields a fresh index.
+    fn repo_indexed_as(source: &str, indexed_source: &str) -> tempfile::TempDir {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join("src")).unwrap();
+        std::fs::write(dir.path().join("src/lib.rs"), source).unwrap();
+        std::fs::create_dir_all(dir.path().join(".vera")).unwrap();
+        let db_path = dir.path().join(".vera/metadata.db");
+        let metadata = vera_core::storage::metadata::MetadataStore::open(&db_path).unwrap();
+        metadata
+            .set_file_hash(
+                "src/lib.rs",
+                &vera_core::indexing::content_hash(indexed_source),
+            )
+            .unwrap();
+        dir
+    }
+
+    #[test]
+    fn stale_index_result_carries_the_warning_after_the_results() {
+        let dir = repo_indexed_as("pub fn current() {}\n", "pub fn previous() {}\n");
+        let results = r#"[{"file_path":"src/lib.rs"}]"#;
+
+        let result = results_with_staleness(dir.path(), results.to_string());
+
+        assert!(!result.is_error);
+        assert_eq!(
+            result.content.len(),
+            2,
+            "stale index must add a notice block, got {:?}",
+            result.content
+        );
+        assert_eq!(result.content[0].text, results);
+        assert_eq!(
+            result.content[1].text,
+            "warning: index may be stale: 1 modified. \
+             Search and grep only cover indexed files. \
+             Run `vera update .` or `vera watch .`."
+        );
+    }
+
+    #[test]
+    fn fresh_index_result_is_a_single_results_block() {
+        let dir = repo_indexed_as("pub fn current() {}\n", "pub fn current() {}\n");
+        let results = r#"[{"file_path":"src/lib.rs"}]"#;
+        let result = results_with_staleness(dir.path(), results.to_string());
+
+        assert_eq!(result.content.len(), 1);
+        assert_eq!(result.content[0].text, results);
+    }
 
     #[test]
     fn tool_definitions_has_seven_tools() {


### PR DESCRIPTION
Part of #117.

## The bug

`warn_if_index_stale` / `detect_staleness` exist only in `vera-cli`
(`crates/vera-cli/src/helpers.rs:67`, called from `helpers.rs:183` and
`commands/overview.rs:20`). There is no caller anywhere in `vera-mcp`.

`ensure_index_and_watcher` (`crates/vera-mcp/src/tools.rs:632` at the base commit)
indexes only when the index directory is missing. After a `git pull`, `.vera/`
exists, so `search_code` skips indexing and searches stale content. The watcher it
starts observes changes from that moment forward, so nothing backfills what was
already missed.

The agent gets stale snippets with `isError: false` and no indication that they are
stale, and presents them as current repository facts. `vera search` on the same
repo, at the same moment, prints a warning.

## The fix

The notice is attached to the tool result itself, as a **trailing content block**.

Why not `tracing::warn!`: MCP has no out-of-band channel the client reads, so a
log line never reaches the agent. It is the agent that needs to know.

Why a separate trailing block rather than a line prepended to the result text:

- `content[0].text` stays byte-identical to the serialized results, so a client
  that parses it as JSON is unaffected. Prepending would break it; wrapping the
  array in an object would change the shape for every existing consumer.
- The notice is not part of the results string, so it is outside
  `MCP_OUTPUT_BUDGET` (`tools.rs:31`) and cannot silently push results out. The
  budget still gets its full 20,000 characters.
- Trailing rather than leading keeps `content[0]` addressable while still placing
  the warning at the end of the tool result, where a model reads it.

The wording is `IndexFreshness::stale_warning`
(`crates/vera-core/src/indexing/freshness.rs:55`), which the CLI's
`warn_if_index_stale` now also calls, so the two surfaces cannot drift:

    warning: index may be stale: 6 added, 59 modified. Search and grep only cover indexed files. Run `vera update .` or `vera watch .`.

The CLI's output is unchanged, checked against the released binary on the same
repository at the same moment:

    $ VERA_NO_UPDATE_CHECK=1 vera overview 2>&1 >/dev/null | head -1        # vera 1.0.0
    warning: index may be stale: 4 added, 33 modified. Search and grep only cover indexed files. Run `vera update .` or `vera watch .`.
    $ VERA_NO_UPDATE_CHECK=1 ./target/debug/vera overview 2>&1 >/dev/null | head -1   # this branch
    warning: index may be stale: 4 added, 33 modified. Search and grep only cover indexed files. Run `vera update .` or `vera watch .`.

No auto-indexing was added. `detect_staleness` walks and re-hashes every tracked
file, and indexing inside a tool call is a known problem on this surface.

## Cost, measured

A freshness scan against this repository's own index, release build, re-measured
at the head of this branch:

| call | elapsed |
|------|---------|
| 1 (cold) | 87.7 ms |
| 2 | 20.9 us |
| 3-5 | 5.0-7.3 us |

88 ms per tool call is not acceptable on a hot path, so the scan result is cached
for 30 seconds per repository (`STALENESS_TTL` in `crates/vera-mcp/src/staleness.rs:15`).
The trade is bounded in both directions: at most 30 seconds of a stale notice after
an update lands, or of silence after the tree drifts. The CLI does not cache,
because it scans once per process.

The cached path costs microseconds rather than nanoseconds because it resolves the
repository path before looking it up, so `.` and the absolute path to the same tree
share one entry. Against an 88 ms scan, and against the work a search tool call
does anyway, that is not a cost worth avoiding.

Up to eight repositories are cached at once (`CACHE_CAPACITY`). One entry was not
enough: `get_overview` takes a `path` argument, so a single server answers about
more than the tree it was started in, and checking a second repository evicted the
first and forced a rescan inside the TTL.

## Where it applies

`search_code`, `regex_search`, `structural_search`, `find_references` and
`get_overview` — the tools whose output is derived from the index. `get_overview`
is included because `vera overview` warns on the CLI side too.

A scan failure is logged at debug and treated as fresh, matching `warn_if_index_stale`.

## Tests

- `tools::tests::stale_index_result_carries_the_warning_after_the_results` — asserts
  the full notice text in `content[1]` and that `content[0]` is the unmodified
  results JSON.
- `tools::tests::fresh_index_result_is_a_single_results_block` — a matching index
  produces exactly one block.
- `staleness::tests::{stale_index_produces_a_notice_naming_the_drift, fresh_index_produces_no_notice, checking_one_repo_does_not_evict_another}`
- `protocol::tests::{tool_call_result_notice_is_a_trailing_block, tool_call_result_without_notice_has_one_block}`
- `indexing::freshness::tests::{stale_warning_names_every_kind_of_drift, fresh_index_has_no_stale_warning}`

Verified by reinjection. Reverting `results_with_staleness` to the old
`ToolCallResult::success(json)` and rerunning:

    ---- tools::tests::stale_index_result_carries_the_warning_after_the_results stdout ----
    assertion `left == right` failed: stale index must add a notice block, got [TextContent { type: "text", text: "[{\"file_path\":\"src/lib.rs\"}]" }]
      left: 1
     right: 2

    test result: FAILED. 43 passed; 1 failed

And, for the per-repository cache, restoring the single-slot cache:

    ---- staleness::tests::checking_one_repo_does_not_evict_another stdout ----
    assertion `left == right` failed: a second repository's check must not evict the first repository's cached scan
      left: None
     right: Some("warning: index may be stale: 1 modified. Search and grep only cover indexed files. Run `vera update .` or `vera watch .`.")

    test result: FAILED. 3 passed; 1 failed

## Verification

    cargo fmt --check                                            clean
    cargo test -p vera-core --lib                                795 passed, 0 failed
    cargo test -p vera-cli --bin vera                             97 passed, 0 failed
    cargo test -p vera-mcp                                        44 passed, 0 failed
    cargo build --workspace                                      clean
    cargo clippy -p vera-core --lib | grep -cE "^warning: [a-z]"   5   (all pre-existing)

`cargo clippy -p vera-mcp --lib --tests` and `cargo clippy -p vera-cli --bin vera`
add no warnings of their own; both report only the same five pre-existing
`vera-core` ones.

## Not in this PR

Issue #117 has three parts. This is the first. Still open:

- the watcher rebuilding models on every debounce tick;
- `vera serve` loading the index per request.

Both are separate changes and are not touched here.
