### PR TITLE
fix(serve): cache each model per slot instead of rebuilding it per request

### DIFF
--- a/crates/vera-cli/src/cli.rs
+++ b/crates/vera-cli/src/cli.rs
@@ -70,9 +70,13 @@ pub enum Commands {
 
     /// Start the Vera HTTP API server for remote embedding and reranking.
     #[command(long_about = "Start the Vera HTTP API server.\n\n\
-                      Loads the embedding model and reranker ONCE at startup (using the \
-                      selected backend), then exposes them via HTTP so any unmodified \
-                      vera client can use this host for compute.\n\n\
+                      Loads the embedding model at startup and the reranker on its first \
+                      use (using the selected backend), then exposes both via HTTP so any \
+                      unmodified vera client can use this host for compute.\n\n\
+                      A loaded model is held in memory and reused across requests. It is \
+                      unloaded after --idle-timeout seconds of inactivity and reloaded on \
+                      the next request that needs it; see that flag for the values that \
+                      keep it loaded indefinitely or rebuild it per request.\n\n\
                       Standard client setup (no client changes needed):\n  \
                       1. Start server:  vera serve --onnx-jina-cuda\n  \
                       2. Configure client:\n  \
@@ -109,7 +113,7 @@ pub enum Commands {
         /// 0 = rebuild the model on every request, and hold one live model per
         /// concurrent request; only useful to pick up model files replaced under
         /// a running server. -1 = keep loaded indefinitely.
-        #[arg(long, default_value_t = 300)]
+        #[arg(long, default_value_t = 300, allow_negative_numbers = true)]
         idle_timeout: i64,
 
         #[command(flatten)]

--- a/crates/vera-cli/src/cli.rs
+++ b/crates/vera-cli/src/cli.rs
@@ -70,9 +70,14 @@ pub enum Commands {
 
     /// Start the Vera HTTP API server for remote embedding and reranking.
     #[command(long_about = "Start the Vera HTTP API server.\n\n\
-                      Loads the embedding model at startup and the reranker on its first \
-                      use (using the selected backend), then exposes both via HTTP so any \
-                      unmodified vera client can use this host for compute.\n\n\
+                      Loads the embedding model at startup and keeps it (using the \
+                      selected backend), then exposes it via HTTP so any unmodified vera \
+                      client can use this host for compute.\n\n\
+                      The reranker is built at startup too, to check it works, but that \
+                      copy is discarded rather than kept: a server that only answers \
+                      /v1/embeddings would otherwise hold it for nothing. Startup \
+                      therefore pays for both models, and the first /v1/rerank request \
+                      pays to load the reranker again.\n\n\
                       A loaded model is held in memory and reused across requests. It is \
                       unloaded after --idle-timeout seconds of inactivity and reloaded on \
                       the next request that needs it; see that flag for the values that \
@@ -112,7 +117,8 @@ pub enum Commands {
         /// Seconds of inactivity before a model is unloaded from memory.
         /// 0 = rebuild the model on every request, and hold one live model per
         /// concurrent request; only useful to pick up model files replaced under
-        /// a running server. -1 = keep loaded indefinitely.
+        /// a running server. Any negative value, -1 included, keeps models
+        /// loaded indefinitely.
         #[arg(long, default_value_t = 300, allow_negative_numbers = true)]
         idle_timeout: i64,
 

--- a/crates/vera-cli/src/cli.rs
+++ b/crates/vera-cli/src/cli.rs
@@ -105,10 +105,11 @@ pub enum Commands {
         #[arg(long)]
         api_key: Option<String>,
 
-        /// Seconds of inactivity before the model is unloaded from memory.
-        /// 0 = disable cache (reload per request, same behaviour as vera search).
-        /// -1 = keep loaded indefinitely.
-        #[arg(long, default_value = "0")]
+        /// Seconds of inactivity before a model is unloaded from memory.
+        /// 0 = rebuild the model on every request, and hold one live model per
+        /// concurrent request; only useful to pick up model files replaced under
+        /// a running server. -1 = keep loaded indefinitely.
+        #[arg(long, default_value_t = 300)]
         idle_timeout: i64,
 
         #[command(flatten)]

--- a/crates/vera-cli/src/commands/serve.rs
+++ b/crates/vera-cli/src/commands/serve.rs
@@ -12,19 +12,9 @@ pub fn run(
     config: VeraConfig,
     idle_timeout_secs: i64,
 ) -> Result<()> {
-    let idle_timeout = match idle_timeout_secs {
-        0 => None,
-        -1 => Some(std::time::Duration::MAX),
-        n if n > 0 => Some(std::time::Duration::from_secs(n as u64)),
-        _ => None,
-    };
+    let cache_mode = vera_serve::CacheMode::from_idle_timeout_secs(idle_timeout_secs);
     let rt = tokio::runtime::Runtime::new()?;
     rt.block_on(vera_serve::run_server(
-        config,
-        backend,
-        api_key,
-        host,
-        port,
-        idle_timeout,
+        config, backend, api_key, host, port, cache_mode,
     ))
 }

--- a/crates/vera-cli/src/main.rs
+++ b/crates/vera-cli/src/main.rs
@@ -882,6 +882,44 @@ mod tests {
         assert!(matches!(parse(&["vera", "stats"]), Commands::Stats));
     }
 
+    /// `--idle-timeout -1` is the spelling the flag's own help text documents.
+    /// Without `allow_negative_numbers`, clap reads the `-1` as an unknown flag
+    /// and only the `=` form works.
+    #[test]
+    fn cli_parses_a_negative_idle_timeout_in_the_documented_form() {
+        for argv in [
+            vec!["vera", "serve", "--idle-timeout", "-1"],
+            vec!["vera", "serve", "--idle-timeout=-1"],
+        ] {
+            let parsed = Cli::try_parse_from(argv.iter().copied())
+                .unwrap_or_else(|e| panic!("{argv:?} must parse: {e}"));
+            match parsed.command {
+                Commands::Serve { idle_timeout, .. } => assert_eq!(idle_timeout, -1),
+                _ => panic!("{argv:?} did not parse as serve"),
+            }
+        }
+
+        assert!(matches!(
+            parse(&["vera", "serve"]),
+            Commands::Serve {
+                idle_timeout: 300,
+                ..
+            }
+        ));
+        assert!(matches!(
+            parse(&["vera", "serve", "--idle-timeout", "0"]),
+            Commands::Serve {
+                idle_timeout: 0,
+                ..
+            }
+        ));
+
+        // The parser is loosened for negative numbers only: a hyphenated
+        // non-number is still an unknown flag rather than a swallowed value.
+        assert!(Cli::try_parse_from(["vera", "serve", "--idle-timeout", "-abc"]).is_err());
+        assert!(Cli::try_parse_from(["vera", "serve", "--idle-timeout", "--port"]).is_err());
+    }
+
     #[test]
     fn cli_parses_json_flag() {
         let cli = Cli::parse_from(["vera", "--json", "stats"]);

--- a/crates/vera-serve/src/handlers.rs
+++ b/crates/vera-serve/src/handlers.rs
@@ -1,7 +1,6 @@
 //! Axum route handlers for the Vera HTTP API.
 
 use std::sync::Arc;
-use std::time::Instant;
 
 use axum::{
     Json,
@@ -15,7 +14,7 @@ use vera_core::embedding::{DynamicProvider, EmbeddingError, EmbeddingProvider};
 use vera_core::retrieval::{DynamicReranker, Reranker, RerankerError};
 
 use crate::{
-    AppState, CachedProviders,
+    AppState,
     types::{
         ApiError, EmbeddingObject, EmbeddingsRequest, EmbeddingsResponse, EmbeddingsUsage,
         HealthResponse, RerankDocument, RerankRequest, RerankResponse, RerankResult,
@@ -24,83 +23,66 @@ use crate::{
 
 // ── Provider cache helpers ────────────────────────────────────────────────────
 
-type ProviderPair = (Arc<DynamicProvider>, Option<Arc<DynamicReranker>>);
 type AcquireError = (StatusCode, Json<ApiError>);
 
-async fn load_embedding(state: &AppState) -> Result<Arc<DynamicProvider>, AcquireError> {
-    let (embedding, _) =
-        vera_core::embedding::create_dynamic_provider(&state.config, state.backend)
-            .await
-            .map_err(|e| {
-                error!(error = %e, "failed to load embedding model");
-                (
-                    StatusCode::SERVICE_UNAVAILABLE,
-                    Json(ApiError::new("embedding model unavailable", "server_error")),
-                )
-            })?;
-    Ok(Arc::new(embedding))
+fn embedding_unavailable() -> AcquireError {
+    (
+        StatusCode::SERVICE_UNAVAILABLE,
+        Json(ApiError::new("embedding model unavailable", "server_error")),
+    )
 }
 
-async fn load_reranker(state: &AppState) -> Result<Option<Arc<DynamicReranker>>, AcquireError> {
+fn reranker_unavailable() -> (StatusCode, Json<ApiError>) {
+    (
+        StatusCode::SERVICE_UNAVAILABLE,
+        Json(ApiError::new(
+            "reranker not available on this server",
+            "server_error",
+        )),
+    )
+}
+
+/// Acquire the embedding provider from its own cache slot, loading it on first
+/// use unless the cache is disabled.
+async fn acquire_embedding(state: &AppState) -> Result<Arc<DynamicProvider>, AcquireError> {
+    state
+        .embedding
+        .get_or_load(|| async {
+            let (embedding, _) =
+                vera_core::embedding::create_dynamic_provider(&state.config, state.backend)
+                    .await
+                    .map_err(|e| {
+                        error!(error = %e, "failed to load embedding model");
+                        embedding_unavailable()
+                    })?;
+            Ok(Some(Arc::new(embedding)))
+        })
+        .await?
+        .ok_or_else(embedding_unavailable)
+}
+
+/// Acquire the reranker from its own cache slot. A failed load yields `None`
+/// and is not cached, so the next request retries rather than inheriting a
+/// transient failure for the lifetime of the process.
+async fn acquire_reranker(state: &AppState) -> Result<Option<Arc<DynamicReranker>>, AcquireError> {
     if !state.reranker_available {
         return Ok(None);
     }
 
-    Ok(
-        vera_core::retrieval::create_dynamic_reranker(&state.config, state.backend)
-            .await
-            .unwrap_or_else(|e| {
-                error!(error = %e, "failed to load reranker");
-                None
-            })
-            .map(Arc::new),
-    )
-}
-
-async fn load_fresh(state: &AppState) -> Result<ProviderPair, AcquireError> {
-    Ok((load_embedding(state).await?, load_reranker(state).await?))
-}
-
-/// Acquire the embedding provider: per-request when the cache is disabled, or
-/// from the shared pair cache when an idle timeout was configured.
-async fn acquire_embedding(state: &AppState) -> Result<Arc<DynamicProvider>, AcquireError> {
-    if state.idle_timeout.is_none() {
-        return load_embedding(state).await;
-    }
-
-    let mut guard = state.provider_cache.lock().await;
-    if guard.is_none() {
-        let (embedding, reranker) = load_fresh(state).await?;
-        *guard = Some(CachedProviders {
-            embedding,
-            reranker,
-            last_used: Instant::now(),
-        });
-    }
-    let cached = guard.as_mut().expect("provider cache initialized");
-    cached.last_used = Instant::now();
-    Ok(Arc::clone(&cached.embedding))
-}
-
-/// Acquire the reranker: per-request when the cache is disabled, or from the
-/// shared pair cache when an idle timeout was configured.
-async fn acquire_reranker(state: &AppState) -> Result<Option<Arc<DynamicReranker>>, AcquireError> {
-    if state.idle_timeout.is_none() {
-        return load_reranker(state).await;
-    }
-
-    let mut guard = state.provider_cache.lock().await;
-    if guard.is_none() {
-        let (embedding, reranker) = load_fresh(state).await?;
-        *guard = Some(CachedProviders {
-            embedding,
-            reranker,
-            last_used: Instant::now(),
-        });
-    }
-    let cached = guard.as_mut().expect("provider cache initialized");
-    cached.last_used = Instant::now();
-    Ok(cached.reranker.as_ref().map(Arc::clone))
+    state
+        .reranker
+        .get_or_load(|| async {
+            Ok(
+                vera_core::retrieval::create_dynamic_reranker(&state.config, state.backend)
+                    .await
+                    .unwrap_or_else(|e| {
+                        error!(error = %e, "failed to load reranker");
+                        None
+                    })
+                    .map(Arc::new),
+            )
+        })
+        .await
 }
 
 // ── Auth ──────────────────────────────────────────────────────────────────────
@@ -218,14 +200,7 @@ pub async fn rerank(
         return err.into_response();
     }
     if !state.reranker_available {
-        return (
-            StatusCode::SERVICE_UNAVAILABLE,
-            Json(ApiError::new(
-                "reranker not available on this server",
-                "server_error",
-            )),
-        )
-            .into_response();
+        return reranker_unavailable().into_response();
     }
 
     let reranker_opt = match acquire_reranker(&state).await {
@@ -233,14 +208,7 @@ pub async fn rerank(
         Err((status, body)) => return (status, body).into_response(),
     };
     let Some(reranker) = reranker_opt else {
-        return (
-            StatusCode::SERVICE_UNAVAILABLE,
-            Json(ApiError::new(
-                "reranker not available on this server",
-                "server_error",
-            )),
-        )
-            .into_response();
+        return reranker_unavailable().into_response();
     };
 
     let top_n = req.top_n;

--- a/crates/vera-serve/src/lib.rs
+++ b/crates/vera-serve/src/lib.rs
@@ -12,27 +12,23 @@
 //! `http://host:port/v1` will work without any modifications.
 
 mod handlers;
+mod provider_cache;
 pub mod types;
 
 use std::sync::Arc;
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 use anyhow::Result;
 use axum::{
     Router,
     routing::{get, post},
 };
-use tokio::sync::Mutex as AsyncMutex;
 use vera_core::config::{InferenceBackend, VeraConfig};
 use vera_core::embedding::DynamicProvider;
 use vera_core::retrieval::DynamicReranker;
 
-/// Live providers held in the idle cache.
-pub(crate) struct CachedProviders {
-    pub embedding: Arc<DynamicProvider>,
-    pub reranker: Option<Arc<DynamicReranker>>,
-    pub last_used: Instant,
-}
+pub use provider_cache::CacheMode;
+use provider_cache::ModelSlot;
 
 /// Shared state injected into every handler.
 pub struct AppState {
@@ -44,29 +40,31 @@ pub struct AppState {
     pub model_name: String,
     /// Whether a reranker is available (probed at startup).
     pub reranker_available: bool,
-    /// Cached providers, loaded on first use and evicted after `idle_timeout` of inactivity.
-    pub(crate) provider_cache: Arc<AsyncMutex<Option<CachedProviders>>>,
-    /// None = per-request (no cache). Some(MAX) = keep forever. Some(d) = evict after d idle.
-    pub(crate) idle_timeout: Option<Duration>,
+    /// The embedding model, cached independently of the reranker.
+    pub(crate) embedding: Arc<ModelSlot<DynamicProvider>>,
+    /// The reranker, cached independently of the embedding model.
+    pub(crate) reranker: Arc<ModelSlot<DynamicReranker>>,
 }
 
 /// Start the Vera HTTP server.
 ///
-/// Loads the embedding model and reranker once at startup, then listens for
-/// connections on `host:port`.
+/// Probes the embedding model and reranker at startup to validate the config,
+/// then listens for connections on `host:port`, loading each model on its first
+/// request and holding it as `cache_mode` dictates.
 ///
-/// - `config`   — vera retrieval/embedding config
-/// - `backend`  — compute backend (API, CPU, GPU)
-/// - `api_key`  — optional bearer token; `None` disables auth
-/// - `host`     — bind address (e.g. `"127.0.0.1"` or `"0.0.0.0"`)
-/// - `port`     — TCP port to listen on
+/// - `config`     — vera retrieval/embedding config
+/// - `backend`    — compute backend (API, CPU, GPU)
+/// - `api_key`    — optional bearer token; `None` disables auth
+/// - `host`       — bind address (e.g. `"127.0.0.1"` or `"0.0.0.0"`)
+/// - `port`       — TCP port to listen on
+/// - `cache_mode` — how long a loaded model stays resident
 pub async fn run_server(
     config: VeraConfig,
     backend: InferenceBackend,
     api_key: Option<String>,
     host: &str,
     port: u16,
-    idle_timeout: Option<Duration>,
+    cache_mode: CacheMode,
 ) -> Result<()> {
     eprintln!(
         "vera serve: initializing {} backend…",
@@ -101,37 +99,33 @@ pub async fn run_server(
         eprintln!("vera serve: no API key set — unauthenticated access allowed");
     }
 
-    match idle_timeout {
-        None => eprintln!("vera serve: model cache disabled (per-request load)"),
-        Some(Duration::MAX) => eprintln!("vera serve: model cache enabled (no idle timeout)"),
-        Some(d) => eprintln!(
-            "vera serve: model cache enabled (idle timeout {}s)",
+    match cache_mode {
+        CacheMode::PerRequest => eprintln!(
+            "vera serve: model cache disabled (--idle-timeout 0); every request rebuilds the model"
+        ),
+        CacheMode::Forever => eprintln!("vera serve: models stay loaded (no idle timeout)"),
+        CacheMode::Idle(d) => eprintln!(
+            "vera serve: models unload after {}s of inactivity",
             d.as_secs()
         ),
     }
 
-    let provider_cache: Arc<AsyncMutex<Option<CachedProviders>>> = Arc::new(AsyncMutex::new(None));
+    let embedding = Arc::new(ModelSlot::new(cache_mode));
+    let reranker = Arc::new(ModelSlot::new(cache_mode));
 
-    // Background task: evict cached providers after `idle_timeout` of inactivity.
-    if let Some(timeout) = idle_timeout.filter(|d| *d != Duration::MAX) {
-        let cache = Arc::clone(&provider_cache);
+    // Background task: unload each model after `cache_mode`'s idle timeout.
+    if let CacheMode::Idle(timeout) = cache_mode {
+        let embedding = Arc::clone(&embedding);
+        let reranker = Arc::clone(&reranker);
         tokio::spawn(async move {
             let check_interval = (timeout / 4).max(Duration::from_secs(1));
             loop {
                 tokio::time::sleep(check_interval).await;
-                let mut guard = cache.lock().await;
-                if let Some(ref cached) = *guard {
-                    // Skip eviction while a request still holds a provider Arc;
-                    // evicting now would force a second model load in parallel.
-                    let in_use = Arc::strong_count(&cached.embedding) > 1
-                        || cached
-                            .reranker
-                            .as_ref()
-                            .is_some_and(|r| Arc::strong_count(r) > 1);
-                    if cached.last_used.elapsed() >= timeout && !in_use {
-                        *guard = None;
-                        eprintln!("vera serve: model unloaded (idle timeout reached)");
-                    }
+                if embedding.evict_if_idle().await {
+                    eprintln!("vera serve: embedding model unloaded (idle timeout reached)");
+                }
+                if reranker.evict_if_idle().await {
+                    eprintln!("vera serve: reranker unloaded (idle timeout reached)");
                 }
             }
         });
@@ -143,8 +137,8 @@ pub async fn run_server(
         backend,
         model_name,
         reranker_available,
-        provider_cache,
-        idle_timeout,
+        embedding,
+        reranker,
     });
 
     let app = Router::new()

--- a/crates/vera-serve/src/lib.rs
+++ b/crates/vera-serve/src/lib.rs
@@ -49,8 +49,10 @@ pub struct AppState {
 /// Start the Vera HTTP server.
 ///
 /// Probes the embedding model and reranker at startup to validate the config,
-/// then listens for connections on `host:port`, loading each model on its first
-/// request and holding it as `cache_mode` dictates.
+/// then listens for connections on `host:port`. The embedding probe is kept and
+/// becomes the first resident model; the reranker is loaded on its first request,
+/// since holding it costs memory a server that only embeds never uses. Each model
+/// is then held as `cache_mode` dictates.
 ///
 /// - `config`     — vera retrieval/embedding config
 /// - `backend`    — compute backend (API, CPU, GPU)
@@ -71,14 +73,25 @@ pub async fn run_server(
         backend_label(backend)
     );
 
-    // Probe-load to validate config and obtain the model name, then release immediately.
+    // Probe-load to validate the config and obtain the model name.
     let (probe, model_name) = vera_core::embedding::create_dynamic_provider(&config, backend)
         .await
         .map_err(|e| anyhow::anyhow!("failed to load embedding model: {e}"))?;
-    drop(probe);
 
     eprintln!("vera serve: embedding model ready ({})", model_name);
 
+    let embedding = Arc::new(ModelSlot::new(cache_mode));
+    let reranker: Arc<ModelSlot<DynamicReranker>> = Arc::new(ModelSlot::new(cache_mode));
+
+    // The probe already paid for a full load, so hand it to the slot rather than
+    // dropping it and making the first request load the same model again. Seeded
+    // here, before the reranker probe, so `PerRequest` — where `seed` is a no-op —
+    // still releases it before anything else is loaded.
+    embedding.seed(Arc::new(probe)).await;
+
+    // The reranker probe is deliberately not seeded. It costs ~670 MB resident,
+    // and a server that only answers /v1/embeddings would hold it for nothing;
+    // it is loaded on the first /v1/rerank instead.
     let reranker_available = vera_core::retrieval::create_dynamic_reranker(&config, backend)
         .await
         .unwrap_or_else(|e| {
@@ -109,9 +122,6 @@ pub async fn run_server(
             d.as_secs()
         ),
     }
-
-    let embedding = Arc::new(ModelSlot::new(cache_mode));
-    let reranker = Arc::new(ModelSlot::new(cache_mode));
 
     // Background task: unload each model after `cache_mode`'s idle timeout.
     if let CacheMode::Idle(timeout) = cache_mode {

--- a/crates/vera-serve/src/lib.rs
+++ b/crates/vera-serve/src/lib.rs
@@ -89,9 +89,10 @@ pub async fn run_server(
     // still releases it before anything else is loaded.
     embedding.seed(Arc::new(probe)).await;
 
-    // The reranker probe is deliberately not seeded. It costs ~670 MB resident,
-    // and a server that only answers /v1/embeddings would hold it for nothing;
-    // it is loaded on the first /v1/rerank instead.
+    // The reranker probe is deliberately not seeded: it is built here, read for
+    // `reranker_available`, and dropped, so the first /v1/rerank loads it again.
+    // Keeping it would cost ~670 MB resident on a server that only answers
+    // /v1/embeddings and never reranks at all.
     let reranker_available = vera_core::retrieval::create_dynamic_reranker(&config, backend)
         .await
         .unwrap_or_else(|e| {

--- a/crates/vera-serve/src/provider_cache.rs
+++ b/crates/vera-serve/src/provider_cache.rs
@@ -92,6 +92,22 @@ impl<T> ModelSlot<T> {
         Ok(Some(model))
     }
 
+    /// Put an already-loaded model into the slot.
+    ///
+    /// `run_server` probe-loads the embedding model to validate the config
+    /// before it listens; seeding hands that model to the slot so the first
+    /// request does not pay for a second load of a model already in memory.
+    /// A no-op in `PerRequest` mode, which must rebuild per request.
+    pub(crate) async fn seed(&self, model: Arc<T>) {
+        if matches!(self.mode, CacheMode::PerRequest) {
+            return;
+        }
+        *self.resident.lock().await = Some(Resident {
+            model,
+            last_used: Instant::now(),
+        });
+    }
+
     /// Drop the model if it has been idle past the configured timeout and no
     /// request still holds it. Returns whether it evicted.
     pub(crate) async fn evict_if_idle(&self) -> bool {
@@ -217,6 +233,76 @@ mod tests {
         let again = slot.get_or_load(load).await.unwrap();
         assert_eq!(*again.unwrap(), 1);
         assert_eq!(attempts.load(Ordering::SeqCst), 2);
+        assert_eq!(builds.count(), 1);
+    }
+
+    #[tokio::test]
+    async fn a_failed_load_is_not_cached_and_a_later_load_succeeds() {
+        let slot: ModelSlot<usize> = ModelSlot::new(CacheMode::Forever);
+        let attempts = AtomicUsize::new(0);
+        let builds = Builds::new();
+
+        let load = || async {
+            if attempts.fetch_add(1, Ordering::SeqCst) == 0 {
+                // The shape `create_dynamic_provider` failures take on the
+                // embedding path: surfaced as an error, not as "unavailable".
+                return Err("cold start failed");
+            }
+            Ok(builds.load().await.unwrap())
+        };
+
+        assert_eq!(
+            slot.get_or_load(load).await.unwrap_err(),
+            "cold start failed"
+        );
+        assert_eq!(builds.count(), 0);
+
+        let model = slot.get_or_load(load).await.unwrap();
+        assert_eq!(*model.expect("retried after the errored load"), 1);
+
+        // And the recovered model is the cached one from here on.
+        let again = slot.get_or_load(load).await.unwrap();
+        assert_eq!(*again.unwrap(), 1);
+        assert_eq!(attempts.load(Ordering::SeqCst), 2);
+        assert_eq!(builds.count(), 1);
+    }
+
+    #[tokio::test]
+    async fn a_seeded_model_is_served_without_loading() {
+        let slot: ModelSlot<usize> = ModelSlot::new(CacheMode::Forever);
+        let builds = Builds::new();
+
+        slot.seed(Arc::new(9usize)).await;
+
+        for _ in 0..3 {
+            let model = slot.get_or_load(|| builds.load()).await.unwrap();
+            assert_eq!(*model.unwrap(), 9);
+        }
+        assert_eq!(builds.count(), 0);
+    }
+
+    #[tokio::test]
+    async fn per_request_mode_ignores_a_seed() {
+        let slot: ModelSlot<usize> = ModelSlot::new(CacheMode::PerRequest);
+        let builds = Builds::new();
+
+        slot.seed(Arc::new(9usize)).await;
+
+        let model = slot.get_or_load(|| builds.load()).await.unwrap();
+        assert_eq!(*model.unwrap(), 1);
+        assert_eq!(builds.count(), 1);
+    }
+
+    #[tokio::test]
+    async fn a_seeded_model_is_evicted_when_idle_like_a_loaded_one() {
+        let slot: ModelSlot<usize> = ModelSlot::new(CacheMode::Idle(Duration::ZERO));
+        let builds = Builds::new();
+
+        slot.seed(Arc::new(9usize)).await;
+        assert!(slot.evict_if_idle().await);
+
+        let model = slot.get_or_load(|| builds.load()).await.unwrap();
+        assert_eq!(*model.unwrap(), 1);
         assert_eq!(builds.count(), 1);
     }
 

--- a/crates/vera-serve/src/provider_cache.rs
+++ b/crates/vera-serve/src/provider_cache.rs
@@ -1,0 +1,323 @@
+//! Residency cache for the models `vera serve` hands to requests.
+//!
+//! Each model gets its own slot with its own lock, so a cold embedding load
+//! never blocks a rerank request. Within a slot the lock is held across the
+//! load deliberately: N concurrent cold requests then build one model instead
+//! of N.
+
+use std::future::Future;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use tokio::sync::Mutex as AsyncMutex;
+
+/// How long a loaded model stays resident.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum CacheMode {
+    /// Build a model per request and drop it when the request ends.
+    PerRequest,
+    /// Keep the model loaded, evicting it after this much inactivity.
+    Idle(Duration),
+    /// Keep the model loaded for the lifetime of the process.
+    Forever,
+}
+
+impl CacheMode {
+    /// Map the `--idle-timeout` seconds value onto a cache mode.
+    ///
+    /// `0` disables the cache, any negative value keeps models loaded for the
+    /// process lifetime, and a positive value evicts after that many seconds.
+    pub fn from_idle_timeout_secs(secs: i64) -> Self {
+        match secs {
+            0 => Self::PerRequest,
+            n if n < 0 => Self::Forever,
+            n => Self::Idle(Duration::from_secs(n as u64)),
+        }
+    }
+
+    fn idle_timeout(self) -> Option<Duration> {
+        match self {
+            Self::Idle(d) => Some(d),
+            Self::PerRequest | Self::Forever => None,
+        }
+    }
+}
+
+struct Resident<T> {
+    model: Arc<T>,
+    last_used: Instant,
+}
+
+/// One cached model, loaded on first use.
+pub(crate) struct ModelSlot<T> {
+    resident: AsyncMutex<Option<Resident<T>>>,
+    mode: CacheMode,
+}
+
+impl<T> ModelSlot<T> {
+    pub(crate) fn new(mode: CacheMode) -> Self {
+        Self {
+            resident: AsyncMutex::new(None),
+            mode,
+        }
+    }
+
+    /// Hand out the cached model, loading it through `load` if the slot is empty.
+    ///
+    /// A loader that reports the model as unavailable (`Ok(None)`) leaves the
+    /// slot empty, so a transient failure is retried by the next request instead
+    /// of being cached for the lifetime of the process.
+    pub(crate) async fn get_or_load<F, Fut, E>(&self, load: F) -> Result<Option<Arc<T>>, E>
+    where
+        F: FnOnce() -> Fut,
+        Fut: Future<Output = Result<Option<Arc<T>>, E>>,
+    {
+        if matches!(self.mode, CacheMode::PerRequest) {
+            return load().await;
+        }
+
+        let mut guard = self.resident.lock().await;
+        if let Some(resident) = guard.as_mut() {
+            resident.last_used = Instant::now();
+            return Ok(Some(Arc::clone(&resident.model)));
+        }
+
+        let Some(model) = load().await? else {
+            return Ok(None);
+        };
+        *guard = Some(Resident {
+            model: Arc::clone(&model),
+            last_used: Instant::now(),
+        });
+        Ok(Some(model))
+    }
+
+    /// Drop the model if it has been idle past the configured timeout and no
+    /// request still holds it. Returns whether it evicted.
+    pub(crate) async fn evict_if_idle(&self) -> bool {
+        let Some(timeout) = self.mode.idle_timeout() else {
+            return false;
+        };
+        let mut guard = self.resident.lock().await;
+        let Some(resident) = guard.as_ref() else {
+            return false;
+        };
+        // Evicting a model a request still holds would force a second load in
+        // parallel with the first one.
+        if Arc::strong_count(&resident.model) > 1 || resident.last_used.elapsed() < timeout {
+            return false;
+        }
+        *guard = None;
+        true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    /// Stand-in for a model: `Builds` counts how many were constructed, which is
+    /// the property under test. The real models need ONNX Runtime and downloaded
+    /// assets, so a test built on them would skip silently.
+    struct Builds(AtomicUsize);
+
+    impl Builds {
+        fn new() -> Self {
+            Self(AtomicUsize::new(0))
+        }
+
+        fn count(&self) -> usize {
+            self.0.load(Ordering::SeqCst)
+        }
+
+        /// A loader that succeeds, counting each construction.
+        async fn load(&self) -> Result<Option<Arc<usize>>, ()> {
+            let n = self.0.fetch_add(1, Ordering::SeqCst) + 1;
+            Ok(Some(Arc::new(n)))
+        }
+    }
+
+    #[tokio::test]
+    async fn cached_mode_builds_the_model_once_across_requests() {
+        let slot: ModelSlot<usize> = ModelSlot::new(CacheMode::Forever);
+        let builds = Builds::new();
+
+        for _ in 0..5 {
+            let model = slot.get_or_load(|| builds.load()).await.unwrap();
+            assert_eq!(*model.unwrap(), 1);
+        }
+
+        assert_eq!(builds.count(), 1);
+    }
+
+    #[tokio::test]
+    async fn per_request_mode_builds_the_model_every_time() {
+        let slot: ModelSlot<usize> = ModelSlot::new(CacheMode::PerRequest);
+        let builds = Builds::new();
+
+        for expected in 1..=3 {
+            let model = slot.get_or_load(|| builds.load()).await.unwrap();
+            assert_eq!(*model.unwrap(), expected);
+        }
+
+        assert_eq!(builds.count(), 3);
+    }
+
+    #[tokio::test]
+    async fn concurrent_cold_requests_share_one_build() {
+        let slot: Arc<ModelSlot<usize>> = Arc::new(ModelSlot::new(CacheMode::Forever));
+        let builds = Arc::new(Builds::new());
+
+        let mut tasks = Vec::new();
+        for _ in 0..8 {
+            let slot = Arc::clone(&slot);
+            let builds = Arc::clone(&builds);
+            tasks.push(tokio::spawn(async move {
+                let model = slot
+                    .get_or_load(|| async {
+                        // Widen the window a serialized load has to lose in.
+                        tokio::time::sleep(Duration::from_millis(20)).await;
+                        builds.load().await
+                    })
+                    .await
+                    .unwrap();
+                *model.unwrap()
+            }));
+        }
+
+        for task in tasks {
+            assert_eq!(task.await.unwrap(), 1);
+        }
+        assert_eq!(builds.count(), 1);
+    }
+
+    #[tokio::test]
+    async fn an_unavailable_model_is_not_cached_and_a_later_load_succeeds() {
+        let slot: ModelSlot<usize> = ModelSlot::new(CacheMode::Forever);
+        let attempts = AtomicUsize::new(0);
+        let builds = Builds::new();
+
+        let load = || async {
+            if attempts.fetch_add(1, Ordering::SeqCst) == 0 {
+                // The shape `create_dynamic_reranker` failures take: swallowed
+                // into "not available" rather than surfaced as an error.
+                return Ok(None);
+            }
+            builds.load().await
+        };
+
+        assert!(slot.get_or_load(load).await.unwrap().is_none());
+        assert_eq!(builds.count(), 0);
+
+        let model = slot.get_or_load(load).await.unwrap();
+        assert_eq!(*model.expect("retried after the failed load"), 1);
+
+        // And the recovered model is now the cached one.
+        let again = slot.get_or_load(load).await.unwrap();
+        assert_eq!(*again.unwrap(), 1);
+        assert_eq!(attempts.load(Ordering::SeqCst), 2);
+        assert_eq!(builds.count(), 1);
+    }
+
+    #[tokio::test]
+    async fn one_slots_cold_load_does_not_block_the_other_slot() {
+        let embedding: ModelSlot<usize> = ModelSlot::new(CacheMode::Forever);
+        let reranker: Arc<ModelSlot<usize>> = Arc::new(ModelSlot::new(CacheMode::Forever));
+
+        let (release, released) = tokio::sync::oneshot::channel::<()>();
+        let (entered, has_entered) = tokio::sync::oneshot::channel::<()>();
+        let slow = {
+            let reranker = Arc::clone(&reranker);
+            tokio::spawn(async move {
+                reranker
+                    .get_or_load(|| async {
+                        entered.send(()).unwrap();
+                        let _ = released.await;
+                        Ok::<_, ()>(Some(Arc::new(7usize)))
+                    })
+                    .await
+                    .unwrap()
+            })
+        };
+
+        // Only proceed once the reranker load is parked inside its slot lock.
+        has_entered.await.unwrap();
+
+        let builds = Builds::new();
+        let quick = tokio::time::timeout(
+            Duration::from_secs(5),
+            embedding.get_or_load(|| builds.load()),
+        )
+        .await
+        .expect("embedding acquire must not wait on the reranker load")
+        .unwrap();
+
+        assert_eq!(*quick.unwrap(), 1);
+        release.send(()).unwrap();
+        assert_eq!(*slow.await.unwrap().unwrap(), 7);
+    }
+
+    #[tokio::test]
+    async fn an_idle_model_is_evicted_and_the_next_request_rebuilds_it() {
+        let slot: ModelSlot<usize> = ModelSlot::new(CacheMode::Idle(Duration::ZERO));
+        let builds = Builds::new();
+
+        let first = slot.get_or_load(|| builds.load()).await.unwrap();
+        assert_eq!(*first.unwrap(), 1);
+
+        assert!(slot.evict_if_idle().await);
+
+        let second = slot.get_or_load(|| builds.load()).await.unwrap();
+        assert_eq!(*second.unwrap(), 2);
+        assert_eq!(builds.count(), 2);
+    }
+
+    #[tokio::test]
+    async fn eviction_spares_a_model_a_request_still_holds() {
+        let slot: ModelSlot<usize> = ModelSlot::new(CacheMode::Idle(Duration::ZERO));
+        let builds = Builds::new();
+
+        let held = slot.get_or_load(|| builds.load()).await.unwrap().unwrap();
+        assert!(!slot.evict_if_idle().await);
+
+        drop(held);
+        assert!(slot.evict_if_idle().await);
+    }
+
+    #[tokio::test]
+    async fn a_model_within_its_idle_window_is_not_evicted() {
+        let slot: ModelSlot<usize> = ModelSlot::new(CacheMode::Idle(Duration::from_secs(3600)));
+        let builds = Builds::new();
+
+        drop(slot.get_or_load(|| builds.load()).await.unwrap());
+        assert!(!slot.evict_if_idle().await);
+
+        let again = slot.get_or_load(|| builds.load()).await.unwrap();
+        assert_eq!(*again.unwrap(), 1);
+        assert_eq!(builds.count(), 1);
+    }
+
+    #[tokio::test]
+    async fn forever_and_per_request_modes_never_evict() {
+        let forever: ModelSlot<usize> = ModelSlot::new(CacheMode::Forever);
+        let builds = Builds::new();
+        drop(forever.get_or_load(|| builds.load()).await.unwrap());
+        assert!(!forever.evict_if_idle().await);
+
+        let per_request: ModelSlot<usize> = ModelSlot::new(CacheMode::PerRequest);
+        drop(per_request.get_or_load(|| builds.load()).await.unwrap());
+        assert!(!per_request.evict_if_idle().await);
+    }
+
+    #[test]
+    fn idle_timeout_seconds_map_onto_cache_modes() {
+        assert_eq!(CacheMode::from_idle_timeout_secs(0), CacheMode::PerRequest);
+        assert_eq!(CacheMode::from_idle_timeout_secs(-1), CacheMode::Forever);
+        assert_eq!(CacheMode::from_idle_timeout_secs(-42), CacheMode::Forever);
+        assert_eq!(
+            CacheMode::from_idle_timeout_secs(300),
+            CacheMode::Idle(Duration::from_secs(300))
+        );
+    }
+}

--- a/crates/vera-serve/src/provider_cache.rs
+++ b/crates/vera-serve/src/provider_cache.rs
@@ -115,12 +115,19 @@ impl<T> ModelSlot<T> {
             return false;
         };
         let mut guard = self.resident.lock().await;
-        let Some(resident) = guard.as_ref() else {
+        let Some(resident) = guard.as_mut() else {
             return false;
         };
         // Evicting a model a request still holds would force a second load in
-        // parallel with the first one.
-        if Arc::strong_count(&resident.model) > 1 || resident.last_used.elapsed() < timeout {
+        // parallel with the first one. A held model is also in use *now*, so
+        // restart its idle clock: `last_used` is stamped at acquisition, and
+        // without this a request that outlives the timeout would be followed by
+        // an immediate eviction instead of a fresh idle window.
+        if Arc::strong_count(&resident.model) > 1 {
+            resident.last_used = Instant::now();
+            return false;
+        }
+        if resident.last_used.elapsed() < timeout {
             return false;
         }
         *guard = None;
@@ -369,6 +376,38 @@ mod tests {
 
         drop(held);
         assert!(slot.evict_if_idle().await);
+    }
+
+    /// `last_used` is stamped at acquisition, so a request that outlives the
+    /// idle window would otherwise be followed by an immediate eviction: the
+    /// timeout has to measure inactivity after the last request, not since it
+    /// started. Real sleeps, because the slot uses `std::time::Instant`, which
+    /// tokio's paused clock does not control. Overshoot under load only makes
+    /// the eviction assertions more true; the one budget that matters is the
+    /// 1s window covering a `drop` and one call.
+    #[tokio::test]
+    async fn the_idle_clock_restarts_when_the_last_request_releases_the_model() {
+        let slot: ModelSlot<usize> = ModelSlot::new(CacheMode::Idle(Duration::from_secs(1)));
+        let builds = Builds::new();
+
+        let held = slot.get_or_load(|| builds.load()).await.unwrap().unwrap();
+
+        // A request still running well past the idle window.
+        tokio::time::sleep(Duration::from_millis(1500)).await;
+        assert!(!slot.evict_if_idle().await, "a held model must be spared");
+
+        drop(held);
+        assert!(
+            !slot.evict_if_idle().await,
+            "releasing the model must start a fresh idle window, not evict at once"
+        );
+
+        tokio::time::sleep(Duration::from_millis(1500)).await;
+        assert!(
+            slot.evict_if_idle().await,
+            "and it evicts once genuinely idle"
+        );
+        assert_eq!(builds.count(), 1);
     }
 
     #[tokio::test]

--- a/docs/features.md
+++ b/docs/features.md
@@ -275,10 +275,12 @@ Key flags:
 - `--port <PORT>`: TCP port to listen on (default: 3000)
 - `--host <HOST>`: bind address (default: 127.0.0.1)
 - `--api-key <KEY>`: require Bearer token authentication (or set `VERA_SERVE_KEY`)
-- `--idle-timeout <SECS>`: seconds of inactivity before unloading a model from memory (default: 300). `-1` keeps models loaded for the lifetime of the process. `0` disables the cache, rebuilding the model on every request and holding one live model per concurrent request; it exists to pick up model files replaced under a running server, and makes indexing through the server far slower.
+- `--idle-timeout <SECS>`: seconds of inactivity before unloading a model from memory (default: 300). Any negative value, `-1` included, keeps models loaded for the lifetime of the process. `0` disables the cache, rebuilding the model on every request and holding one live model per concurrent request; it exists to pick up model files replaced under a running server, and makes indexing through the server far slower.
 - Backend flags: `--potion-code`, `--onnx-jina-cuda`, `--onnx-jina-rocm`, `--onnx-jina-coreml`, `--onnx-jina-openvino`, `--onnx-jina-directml`, or `--api`
 
-The embedding model is loaded before the server accepts connections and stays resident from then on, so the first request does not pay for a load. The reranker is loaded on the first `/v1/rerank` request instead, because a server that only serves embeddings would otherwise hold it for nothing.
+The embedding model is loaded before the server accepts connections and kept, so the first request does not pay for a load. It is then subject to the same idle eviction as any other resident model, so under the default it is unloaded after 300 seconds with no requests and reloaded on the next one.
+
+The reranker is validated at startup too, but that probe is discarded rather than kept: a server that only answers `/v1/embeddings` would otherwise hold it for nothing. The first `/v1/rerank` request loads it again, for serving.
 
 ### Diagnostics
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -278,6 +278,8 @@ Key flags:
 - `--idle-timeout <SECS>`: seconds of inactivity before unloading a model from memory (default: 300). `-1` keeps models loaded for the lifetime of the process. `0` disables the cache, rebuilding the model on every request and holding one live model per concurrent request; it exists to pick up model files replaced under a running server, and makes indexing through the server far slower.
 - Backend flags: `--potion-code`, `--onnx-jina-cuda`, `--onnx-jina-rocm`, `--onnx-jina-coreml`, `--onnx-jina-openvino`, `--onnx-jina-directml`, or `--api`
 
+The embedding model is loaded before the server accepts connections and stays resident from then on, so the first request does not pay for a load. The reranker is loaded on the first `/v1/rerank` request instead, because a server that only serves embeddings would otherwise hold it for nothing.
+
 ### Diagnostics
 
 `vera doctor` reports the saved and active backend, installed version, checks GitHub for newer releases, and detects missing, corrupt, or truncated ONNX model caches. If model assets are damaged, it suggests running `vera repair --<backend>`; runtime embedding load errors provide the same repair hint. `--probe` adds a deeper read-only local backend check. `--json` outputs machine-readable diagnostics. `vera repair` re-fetches missing or corrupt local assets.

--- a/docs/features.md
+++ b/docs/features.md
@@ -275,7 +275,7 @@ Key flags:
 - `--port <PORT>`: TCP port to listen on (default: 3000)
 - `--host <HOST>`: bind address (default: 127.0.0.1)
 - `--api-key <KEY>`: require Bearer token authentication (or set `VERA_SERVE_KEY`)
-- `--idle-timeout <SECS>`: seconds of inactivity before unloading models from memory (0 = reload per request, -1 = keep loaded indefinitely, default: 0)
+- `--idle-timeout <SECS>`: seconds of inactivity before unloading a model from memory (default: 300). `-1` keeps models loaded for the lifetime of the process. `0` disables the cache, rebuilding the model on every request and holding one live model per concurrent request; it exists to pick up model files replaced under a running server, and makes indexing through the server far slower.
 - Backend flags: `--potion-code`, `--onnx-jina-cuda`, `--onnx-jina-rocm`, `--onnx-jina-coreml`, `--onnx-jina-openvino`, `--onnx-jina-directml`, or `--api`
 
 ### Diagnostics


### PR DESCRIPTION
Part of #117

Third of the three divergences in #117. The staleness half landed in #130. The MCP auto-watcher half (per-debounce-cycle model rebuild, `.vera`-only watch filter) is still in flight and not touched here. This PR is the `vera serve` half only.

## The bug

`--idle-timeout` defaulted to `"0"`, `0` mapped to `None`, and `None` made both acquire paths in `crates/vera-serve/src/handlers.rs` bypass the cache and call `create_dynamic_provider` directly. Every request built a fresh ONNX session and tokenizer.

`vera serve` exists to hold a model in memory and answer requests, so the shipped default was the one setting under which it does not do that. Point `vera setup --api` at a local `vera serve`, index a repo, and each embedding batch is a separate HTTP request: thousands of session builds. There is no concurrency limit either, so N concurrent requests hold N live sessions at once.

The flag's help text justified the default as "same behaviour as `vera search`". That is not what `vera search` does. `vera search` builds one `SearchContext` per invocation, not one per query, so the two were never equivalent.

## Control, against the released binary

`vera serve` on the default config (CoreML, `jina-embeddings-v5-text-nano-retrieval`), three sequential single-string `POST /v1/embeddings`:

| binary | flags | req 1 | req 2 | req 3 |
|---|---|---|---|---|
| `master` @ `e3d79b3`, release | (default, `0`) | 0.49s | 0.28s | 0.26s |
| branch @ `50fd1c5`, debug | (default, `300`) | 1.08s | 0.05s | 0.04s |
| branch @ `50fd1c5`, debug | `--idle-timeout 0` | 1.06s | 1.04s | 1.05s |

The absolute numbers are not comparable across binaries (the branch was measured on a debug build, where tokenization is several times slower). The shape is: `master` is flat, because every request rebuilds. The branch amortizes to ~4% of the first request, and reproduces `master`'s flat profile exactly when `--idle-timeout 0` is asked for.

`50fd1c5`'s first request still cost a full load — 1.08s, the same as a `--idle-timeout 0` request — because `run_server` probe-loaded the embedding model to validate the config and then dropped it. Review caught that; `6e545d9` seeds the probe into its slot instead. Re-measured, same machine, all three runs back to back:

| binary | flags | req 1 | req 2 | req 3 |
|---|---|---|---|---|
| branch @ `6e545d9`, debug | (default, `300`) | 0.31s | 0.05s | 0.03s |
| branch @ `6e545d9`, debug | `--idle-timeout 0` | 1.59s | 1.18s | 1.37s |
| branch @ `6e545d9`, debug | (default, `300`), repeat | 0.06s | 0.06s | 0.04s |

This second batch was taken on a busy machine (load average ~60), so the absolute numbers are inflated against the first table and only the within-batch comparison is meaningful. It is the comparison that matters: a load costs 1.2-1.6s in these conditions, and the default's *first* request costs 0.06-0.31s. Before seeding, default req 1 ≈ per-request req 1. After it, default req 1 ≈ default req 2. The first request no longer loads anything.

Peak RSS is unchanged by the seeding, which was the risk — holding the embedding provider across the reranker probe could have stacked the two. Sampled every 20 ms from launch through the first request, two runs each, interleaved:

| build | peak at listen | peak through req 1 | settled |
|---|---|---|---|
| `50fd1c5` | 1177 MB / 1178 MB | 1177 MB / 1178 MB | 1039 MB |
| `6e545d9` | 1181 MB / 1181 MB | 1181 MB / 1181 MB | 1017 MB / 1019 MB |

+4 MB, i.e. noise: the ONNX arena is allocated once and reused rather than stacked.

Startup lines, same runs:

```
master:      vera serve: model cache disabled (per-request load)
branch:      vera serve: models unload after 300s of inactivity
branch (0):  vera serve: model cache disabled (--idle-timeout 0); every request rebuilds the model
```

## The default

Three options were on the table: a new default, redefining `0`, or leaving the default and fixing only the caching semantics.

Leaving it does not fix the reported bug, since the bug *is* the default. Redefining `0` as "keep loaded" would silently flip the behaviour of anyone who typed `--idle-timeout 0` deliberately, and would leave no way to express per-request loading at all.

So: **the default becomes `300`**, matching the flag's own stated units ("seconds of inactivity before a model is unloaded") and the convention local inference servers use for keep-alive. It holds the model across a whole index run, where batches arrive back to back, and releases the memory five minutes after the client goes away. `-1` still means "keep loaded indefinitely" and `0` still means "rebuild per request".

**What a user observes changing.** A plain `vera serve` now keeps one embedding session — resident from startup, since the config-validation probe is handed to the slot rather than dropped — and one reranker session once `/v1/rerank` has been called, for up to five minutes after the last request instead of releasing them at the end of each one. Peak RSS during a burst goes *down*, because concurrent requests share one session instead of holding one each; steady-state RSS between bursts goes *up*, because one session stays resident where previously none did.

**What breaks for anyone relying on per-request freshness.** Replacing the model files under a running server no longer takes effect on the next request; it takes effect after the idle timeout, or on restart. Anyone doing that must now pass `--idle-timeout 0`, which is documented on the flag and in `docs/features.md`. The same applies to anyone who wanted RSS back at baseline immediately after each request rather than five minutes later.

One undocumented input changed meaning: `--idle-timeout -5` previously fell through to `_ => None` and silently selected the most expensive mode. All negatives now mean "keep loaded", which is what `-1` already documented.

## Two related defects, folded in

Both live in the same cache and are fixed by the same restructuring, so they are in this PR rather than a follow-up.

**A failed reranker load was cached for the process lifetime.** `load_reranker` swallows every error into `None`, and *both* `acquire_embedding` and `acquire_reranker` populated the single shared entry via `load_fresh`. An `/v1/embeddings` request arriving during a transient reranker failure wrote `reranker: None`, and every later `/v1/rerank` returned 503 forever while `/v1/health` kept reporting `ok`. Under `--idle-timeout -1` the eviction task never runs, so nothing ever cleared it.

**The cache mutex was held across the model load.** A cold start blocked every waiting request, including requests for the other model. Serializing loads of the *same* model is the right trade, since the alternative is N parallel ONNX sessions; loading the *reranker* inside the lock an embeddings request is waiting on is not.

The fix for both is the same shape: `crates/vera-serve/src/provider_cache.rs` gives each model its own `ModelSlot` with its own lock and its own residency state, and `get_or_load` stores only a model the loader actually produced. A loader returning "unavailable" leaves the slot empty, so the next request retries. `AppState` now carries `embedding` and `reranker` slots instead of one `CachedProviders` pair.

Not folded in: a concurrency limit on in-flight requests. Under the new default, concurrent requests share one session, so the unbounded-session pathology only remains on the explicit `--idle-timeout 0` path. That is now documented on the flag rather than silently true of the default.

## What this does not fix

**A client disconnecting during a cold load discards the build** — https://github.com/VeraTools/Vera/issues/139, raised by cubic in review and retained here deliberately.

`get_or_load` awaits the loader inline while holding the slot lock, so when axum drops a handler future mid-load the partial model never reaches the slot and the next request rebuilds from scratch. Measured on this branch: a client disconnecting 1.1 s into a 1.30 s reranker load leaves the next client paying `time=1.427886s`, a full rebuild, where a disconnect after the build completes gives that client `time=0.051060s`.

The peak-memory half of the finding as originally raised did **not** reproduce, and #139 records that: a burst of six cancelled clients peaks at 477-510 MB over baseline against 660-661 MB for a burst that completes, and 683 MB for a single session. Loads serialise on the slot mutex, so an abandoned build is dropped rather than accumulated. The cost is wasted work, not resident memory.

It is out of scope here because the fix changes `get_or_load`'s contract rather than adding to it — the loader is `FnOnce() -> Fut` with the future owned by the caller, so letting a load outlive its initiator means the slot owns it, which forces the error type to be shared and needs a decision about what happens when every subscriber disconnects. This PR's claim is per-slot caching and it already folds in three defects.

Exposure is bounded: it needs a disconnect during a cold load, which under the new default is one build per slot per server lifetime rather than one per request, and the embedding slot is seeded at startup so it is only cold after an idle eviction.

## Interaction with #100

#100 (the reranker is built on every search, including searches that skip reranking) has no open PR as of this writing; a fix is in progress. It targets `SearchContext` in `vera-core`. `vera serve` does not construct a `SearchContext` at all: it calls `create_dynamic_reranker` directly. So there is no code overlap and no merge conflict expected.

There is a design overlap worth naming. This PR makes the reranker load lazily on the serve side, on the first `/v1/rerank`, which is the serve-side version of what #100 does for search. The one eager reranker build left in `vera serve` is the startup probe at `crates/vera-serve/src/lib.rs:95`, which builds a reranker and drops it purely to set `reranker_available` for `/v1/health` and the 503 fast path. That is once per process, not once per request, so it is not the pathology here and is left alone. If #100 lands a cheap config-only availability check, that probe is the natural next caller.

Review asked for that probe to be seeded into the reranker slot rather than dropped. Declined, measured: the reranker costs 668 MB resident (1314.8 MB before its first `/v1/rerank`, 1982.8 MB after), and a `vera serve` behind `vera setup --api` for an index run never calls `/v1/rerank` at all. Seeding it would hold 668 MB for nothing on the main use case, permanently under `--idle-timeout -1`. The embedding probe *is* seeded, which is the half that pays for itself.

## Changes

- `crates/vera-serve/src/provider_cache.rs` — new. `CacheMode` (`PerRequest` / `Idle(d)` / `Forever`) and its mapping from the `--idle-timeout` seconds value; `ModelSlot<T>` with per-slot locking, load-on-first-use, and idle eviction that spares a model a request still holds.
- `crates/vera-serve/src/provider_cache.rs:101` — `ModelSlot::seed`, so an already-loaded model can be put into a slot without going through the loader.
- `crates/vera-serve/src/provider_cache.rs:113` — `evict_if_idle` restarts a held model's idle clock instead of only sparing it, so the timeout measures inactivity after the last request rather than since it started.
- `crates/vera-serve/src/handlers.rs:24-86` — `acquire_embedding` and `acquire_reranker` each go to their own slot. `load_fresh` and the duplicated cache bodies are gone.
- `crates/vera-serve/src/lib.rs:34-47` — `AppState` holds two slots instead of one `CachedProviders` pair and an `Option<Duration>`.
- `crates/vera-serve/src/lib.rs:63-144` — `run_server` takes a `CacheMode`; the startup embedding probe is seeded into its slot rather than dropped; the eviction task evicts each slot independently and names which model it unloaded.
- `crates/vera-cli/src/cli.rs:72-79` — `long_about` describes the loading and unloading that now happens, instead of claiming both models load once at startup.
- `crates/vera-cli/src/cli.rs:112-117` — default `300`, `allow_negative_numbers` so the documented `-1` parses, and help text that describes what `0` actually costs instead of comparing it to `vera search`.
- `crates/vera-cli/src/commands/serve.rs:15` — the seconds-to-mode mapping moves into `vera-serve`, where it is unit-tested.
- `docs/features.md:278-283` — the flag documentation, that every negative value keeps models loaded, and which model is resident when.

## Tests

Fifteen tests in `provider_cache.rs`, asserting **construction counts** rather than response codes. The real models need ONNX Runtime and downloaded assets, so a test built on them would skip silently on a machine without them; the slot is generic, so the tests drive it with a counting stand-in.

Coverage: reuse across requests, per-request mode still rebuilding, concurrent cold requests collapsing to one build, an unavailable model not poisoning the slot, an errored load not poisoning it either, one slot's cold load not blocking the other, idle eviction and rebuild, eviction sparing a held model, eviction not firing inside the idle window, `Forever`/`PerRequest` never evicting, a seeded model being served without a load, `PerRequest` ignoring a seed, a seeded model staying evictable, the idle clock restarting when the last request releases a model, and the seconds-to-mode mapping.

One CLI parse test, `crates/vera-cli/src/main.rs:889`, pins both accepted spellings of `--idle-timeout -1`, the `300` default, `0`, and the two hyphenated inputs that must still be rejected.

### Reinjection

Each half of the fix was reverted in turn and the tests re-run. All five outputs below were re-captured at `6e545d9`, not carried over from the earlier revision.

**1. Remove the cache hit** (`get_or_load` always calls the loader), i.e. the reported bug:

```
test provider_cache::tests::cached_mode_builds_the_model_once_across_requests ... FAILED
test provider_cache::tests::concurrent_cold_requests_share_one_build ... FAILED
test provider_cache::tests::a_model_within_its_idle_window_is_not_evicted ... FAILED
test provider_cache::tests::an_unavailable_model_is_not_cached_and_a_later_load_succeeds ... FAILED
test provider_cache::tests::a_failed_load_is_not_cached_and_a_later_load_succeeds ... FAILED
test provider_cache::tests::a_seeded_model_is_served_without_loading ... FAILED
assertion `left == right` failed
  left: 2
 right: 1
test result: FAILED. 9 passed; 6 failed
```

**2. Cache the unavailable result** (an "already known unavailable" flag short-circuiting later calls, since the post-fix slot has nowhere to store a `None` resident), i.e. the poisoned-reranker defect:

```
test provider_cache::tests::an_unavailable_model_is_not_cached_and_a_later_load_succeeds ... FAILED
panicked at crates/vera-serve/src/provider_cache.rs:237:27:
  retried after the failed load
test result: FAILED. 14 passed; 1 failed
```

**3. One lock covering every model** (a process-wide mutex taken before the slot lock), i.e. the pre-fix `Arc<AsyncMutex<Option<CachedProviders>>>`:

```
test provider_cache::tests::one_slots_cold_load_does_not_block_the_other_slot ... FAILED
panicked at crates/vera-serve/src/provider_cache.rs:343:10:
  embedding acquire must not wait on the reranker load: Elapsed(())
test result: FAILED. 14 passed; 1 failed
```

**4. Make `seed` a no-op**, i.e. the doubled startup load review caught:

```
test provider_cache::tests::a_seeded_model_is_served_without_loading ... FAILED
test provider_cache::tests::a_seeded_model_is_evicted_when_idle_like_a_loaded_one ... FAILED
assertion `left == right` failed
  left: 1
 right: 9
assertion failed: slot.evict_if_idle().await
test result: FAILED. 0 passed; 2 failed; 13 filtered out
```

`left: 1` is the loader having run: a model built when one was already in hand.

**5. Drop `allow_negative_numbers`**, i.e. the documented `-1` being unreachable:

```
---- tests::cli_parses_a_negative_idle_timeout_in_the_documented_form stdout ----
panicked at crates/vera-cli/src/main.rs:895:37:
["vera", "serve", "--idle-timeout", "-1"] must parse: error: unexpected argument '-1' found
test result: FAILED. 0 passed; 1 failed; 97 filtered out
```

That is the same error the released-shape binary printed before the fix, quoted in the review thread.

**6. Spare a held model without restarting its idle clock**, i.e. an eviction firing the instant a long request finishes:

```
test provider_cache::tests::the_idle_clock_restarts_when_the_last_request_releases_the_model ... FAILED
panicked at crates/vera-serve/src/provider_cache.rs:396:9:
  releasing the model must start a fresh idle window, not evict at once
test result: FAILED. 0 passed; 1 failed; 15 filtered out
```

## Verification

At `e5ca97c`:

```
cargo fmt --check                                              clean
cargo build --workspace                                        clean
cargo test -p vera-serve                                       16 passed; 0 failed
cargo test -p vera-core --lib                                  793 passed; 0 failed
cargo test -p vera-cli --bin vera                              98 passed; 0 failed
cargo clippy -p vera-core --lib | grep -cE "^warning: [a-z]"   5 (unchanged, all pre-existing)
```

All 5 clippy warnings resolve to `crates/vera-core/src/local_models/{cuda.rs,mod.rs,ort.rs}`, the documented pre-existing set; `cargo clippy -p vera-serve -p vera-cli --bin vera` adds none of its own.

## Review rounds

**Round one** — five bot threads, four adopted and one declined.

- **`long_about` contradicted the flag.** Real, and already false on master. Fixed, along with the same claim in `lib.rs` and `docs/features.md`.
- **`--idle-timeout -1` did not parse.** Real, reproduced against the binary: `error: unexpected argument '-1' found`. Only the `=` form worked, so the value documented on the flag and in `docs/features.md` was unreachable in the spelling everyone would type. Fixed with `allow_negative_numbers`, with a parse test covering the inputs that must still be rejected.
- **The startup probe was dropped and reloaded.** Real, measured above. Adopted for the embedding model; declined for the reranker, on the 668 MB measurement in the #100 section.
- **No test for the errored load path.** Real gap; `acquire_embedding` reaches `get_or_load` through `Err` where the reranker reaches it through `Ok(None)`, and only the latter was covered.
- **Declined: negative-cache repeated failing reranker loads.** The scenario named is caught at startup — `acquire_reranker` short-circuits on `reranker_available`, and eight concurrent `/v1/rerank` against a server with no reranker all returned 503 in under a millisecond, flat across concurrency. What does reach the slot is a *transient* failure, and retrying it is the second defect this PR fixes; implementing the suggestion fails `a_failed_load_is_not_cached_and_a_later_load_succeeds`. **CodeRabbit withdrew this finding** after verifying the short-circuit.

**Round two**, on `6e545d9` — five more, three adopted, one declined, one confirmed and deferred.

- **The idle clock never restarted.** Real, and a defect in this PR's own cache: `last_used` is stamped at acquisition only, so a request outliving the idle window was spared by the `strong_count` guard and then evicted on the very next tick. Fixed in `e5ca97c`, reinjection 6 above.
- **`docs/features.md` claimed the seeded model "stays resident from then on".** A false statement I wrote in `6e545d9`: a seeded model is an ordinary resident and is evicted like one, which this branch's own `a_seeded_model_is_evicted_when_idle_like_a_loaded_one` asserts. Fixed, along with saying outright that the reranker probe is discarded and reloaded for serving.
- **Only `-1` was documented as "keep loaded".** Every negative value maps to `Forever`; `docs/features.md:278` now says so.
- **Declined: convert the startup `eprintln!`s to `tracing`.** `6e545d9` added none, and the split is complete rather than accidental — 15 of 15 lifecycle messages in `lib.rs` use `eprintln!`, 4 of 4 request-path errors in `handlers.rs` use `tracing`. Converting only this PR's five would make them the file's only exception. Offered to file the whole-file conversion separately.
**Round three**, on `e5ca97c` — four more from cubic, two adopted and two declined on measurements.

- **`--help` still said the reranker loads "on its first use".** Startup builds it too and discards it, so the text understated startup cost and both bots flagged the line. I had declined the `cli.rs` half of this in round two on weak reasoning; fixed in `ef8673e`.
- **The idle-timeout flag documented only `-1`.** Same wording problem `docs/features.md` was corrected for, left in the place users actually read. Fixed.
- **Declined: the idle clock's tick granularity.** Real mechanism, wrong consequence — eviction can only fire at a poll where `elapsed() >= timeout`, and every poll while held refreshes `last_used` at `(timeout/4).max(1s)` cadence. Measured across four release phases: a released model survived a full window each time. The true bound is `[3/4 · timeout, timeout]`, not "almost immediately"; this also corrects an overstatement of mine in round two.
- **Declined: seeding holds the embedding across the reranker probe.** That was my own worry, measured before shipping: peak RSS 1177/1178 MB before seeding against 1181/1181 MB after, two runs each interleaved. +4 MB, and settled RSS is lower.

- **Half-confirmed and deferred: a client disconnecting during a cold load.** The duplicated build is real and measured; the peak-memory spike the finding predicted is not, and a cancelled burst in fact peaks *below* a completing one. Filed as https://github.com/VeraTools/Vera/issues/139 with the reproduction and both sets of numbers, and retained here — see "What this does not fix" above. Left unresolved, since this declines the ask rather than satisfying it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Models now load and cache independently for embeddings and reranking.
  - Added configurable caching modes for per-request loading, idle-time caching, or process-lifetime residency.
  - Idle model eviction now occurs independently and safely during active requests.

- **Bug Fixes**
  - Improved provider loading reliability with retries and clearer unavailable-provider handling.

- **Documentation**
  - Updated the default idle timeout to 300 seconds and clarified timeout behavior, including per-request loading and lifetime residency.
  - Clarified eager embedding loading and lazy reranker loading.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Caches each model in `vera serve` per slot and sets `--idle-timeout` default to 300s. Previously the default rebuilt ONNX sessions on every request; now the embedding stays resident per idle policy, the reranker loads on first use, and the first request is fast by seeding the startup probe.

- Review focus:
  - New `crates/vera-serve/src/provider_cache.rs`: `CacheMode` (`PerRequest`/`Idle(d)`/`Forever`) and `ModelSlot<T>` with per-slot locking, load-on-first-use, and independent idle eviction that logs the unloaded model.
  - Handlers acquire embedding and reranker from separate slots; transiently unavailable reranker loads are not cached.
  - Startup: embedding probe is seeded into its slot; reranker is only probed for availability and loads on first `/v1/rerank`.
  - CLI: `--idle-timeout` now defaults to 300; `--idle-timeout -1` is accepted as documented (`allow_negative_numbers`); seconds-to-mode mapping moved into `vera-serve`; help/long_about and `docs/features.md` updated. Tests cover CLI parsing and cache behavior.

- Rollout/migration:
  - To keep per-request rebuilds, run `vera serve --idle-timeout 0`.
  - Replacing model files under a running server now takes effect after the idle timeout or on restart.
  - Use `--idle-timeout -1` to keep models loaded for the process lifetime.

<sup>Written for commit 6e545d963e9163e7a685e12f7aa8011468b3bdca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/VeraTools/Vera/pull/134?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


