### PR TITLE
fix(core): re-root git scope paths onto the indexed directory

### DIFF
--- a/crates/vera-core/src/git_scope.rs
+++ b/crates/vera-core/src/git_scope.rs
@@ -1,7 +1,7 @@
 //! Git-aware path scoping for changed-file workflows.
 
 use std::collections::HashSet;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use anyhow::{Context, Result, bail};
@@ -17,26 +17,92 @@ pub enum GitScope {
     Base(String),
 }
 
-/// Resolve a git scope to an exact set of repository-relative paths.
-pub fn resolve_scope(repo_root: &Path, scope: &GitScope) -> Result<HashSet<String>> {
-    ensure_git_repo(repo_root)?;
+/// Resolve a git scope to an exact set of paths relative to `index_root`.
+///
+/// The index stores paths relative to the directory that was indexed, which is
+/// not necessarily the git repository root. Every git command therefore runs at
+/// the repository root, so all output shares one base, and the result is
+/// re-rooted onto the index root before it is returned.
+pub fn resolve_scope(index_root: &Path, scope: &GitScope) -> Result<HashSet<String>> {
+    let layout = RepoLayout::resolve(index_root)?;
+    let toplevel = layout.toplevel.as_path();
 
-    match scope {
-        GitScope::Changed => resolve_changed_files(repo_root),
+    let files = match scope {
+        GitScope::Changed => resolve_changed_files(toplevel)?,
         GitScope::Since(rev) => {
             validate_revision(rev)?;
-            resolve_diff_files(repo_root, rev)
+            resolve_diff_files(toplevel, rev)?
         }
         GitScope::Base(rev) => {
             validate_revision(rev)?;
-            let merge_base = run_git(repo_root, &["merge-base", "HEAD", rev])?;
+            let merge_base = run_git(toplevel, &["merge-base", "HEAD", rev])?;
             let merge_base = merge_base.trim();
             if merge_base.is_empty() {
                 bail!("git merge-base returned an empty revision for {rev}");
             }
-            resolve_diff_files(repo_root, merge_base)
+            resolve_diff_files(toplevel, merge_base)?
         }
+    };
+
+    let mut files = layout.reroot(files);
+    add_platform_path_variants(&mut files);
+    Ok(files)
+}
+
+/// Where the indexed directory sits inside the git repository containing it.
+struct RepoLayout {
+    /// Absolute path to the repository root. Every git command runs here so
+    /// that no output depends on `diff.relative` or on git's per-command choice
+    /// of base.
+    toplevel: PathBuf,
+    /// The index root relative to the repository root, `/`-separated and ending
+    /// in `/`. Empty when the index root *is* the repository root.
+    prefix: String,
+}
+
+impl RepoLayout {
+    fn resolve(index_root: &Path) -> Result<Self> {
+        // Two calls rather than one multi-flag call: `git rev-parse` separates
+        // its answers by newline, and a repository path may contain one.
+        let toplevel = run_git(index_root, &["rev-parse", "--show-toplevel"])
+            .context("failed to verify git repository for changed-file scope")?;
+        let toplevel = strip_trailing_newline(&toplevel);
+        if toplevel.is_empty() {
+            bail!(
+                "git found no work tree for {} (a bare repository has no files to scope)",
+                index_root.display()
+            );
+        }
+
+        let prefix = run_git(index_root, &["rev-parse", "--show-prefix"])
+            .context("failed to locate the indexed directory inside its git repository")?;
+
+        Ok(Self {
+            toplevel: PathBuf::from(toplevel),
+            prefix: strip_trailing_newline(&prefix).to_string(),
+        })
     }
+
+    /// Translate repository-root-relative paths to index-root-relative ones,
+    /// dropping the files that live outside the indexed directory.
+    fn reroot(&self, paths: HashSet<String>) -> HashSet<String> {
+        if self.prefix.is_empty() {
+            return paths;
+        }
+        paths
+            .into_iter()
+            .filter_map(|path| {
+                path.strip_prefix(&self.prefix)
+                    .filter(|rest| !rest.is_empty())
+                    .map(ToOwned::to_owned)
+            })
+            .collect()
+    }
+}
+
+/// `git rev-parse` terminates its answer with a line ending.
+fn strip_trailing_newline(output: &str) -> &str {
+    output.trim_end_matches(['\r', '\n'])
 }
 
 /// Reject revisions that git would parse as options (e.g. `--output=...`).
@@ -49,13 +115,7 @@ fn validate_revision(rev: &str) -> Result<()> {
     Ok(())
 }
 
-fn ensure_git_repo(repo_root: &Path) -> Result<()> {
-    let _ = run_git(repo_root, &["rev-parse", "--show-toplevel"])
-        .context("failed to verify git repository for changed-file scope")?;
-    Ok(())
-}
-
-fn resolve_changed_files(repo_root: &Path) -> Result<HashSet<String>> {
+fn resolve_changed_files(toplevel: &Path) -> Result<HashSet<String>> {
     let mut files = HashSet::new();
     for args in [
         vec![
@@ -69,15 +129,14 @@ fn resolve_changed_files(repo_root: &Path) -> Result<HashSet<String>> {
         vec!["diff", "--name-only", "-z", "--diff-filter=ACMRTUXB", "--"],
         vec!["ls-files", "--others", "--exclude-standard", "-z", "--"],
     ] {
-        files.extend(parse_git_paths(&run_git(repo_root, &args)?));
+        files.extend(parse_git_paths(&run_git(toplevel, &args)?));
     }
-    add_platform_path_variants(&mut files);
     Ok(files)
 }
 
-fn resolve_diff_files(repo_root: &Path, revision: &str) -> Result<HashSet<String>> {
+fn resolve_diff_files(toplevel: &Path, revision: &str) -> Result<HashSet<String>> {
     let output = run_git(
-        repo_root,
+        toplevel,
         &[
             "diff",
             "--name-only",
@@ -87,15 +146,13 @@ fn resolve_diff_files(repo_root: &Path, revision: &str) -> Result<HashSet<String
             "--",
         ],
     )?;
-    let mut files = parse_git_paths(&output);
-    add_platform_path_variants(&mut files);
-    Ok(files)
+    Ok(parse_git_paths(&output))
 }
 
-fn run_git(repo_root: &Path, args: &[&str]) -> Result<String> {
+fn run_git(cwd: &Path, args: &[&str]) -> Result<String> {
     let output = Command::new("git")
         .args(args)
-        .current_dir(repo_root)
+        .current_dir(cwd)
         .output()
         .with_context(|| format!("failed to run git {}", args.join(" ")))?;
 
@@ -227,10 +284,161 @@ mod tests {
         assert!(base.is_err());
     }
 
+    #[test]
+    fn reroot_drops_paths_outside_the_indexed_directory() {
+        let layout = RepoLayout {
+            toplevel: PathBuf::from("/repo"),
+            prefix: "pkg/".to_string(),
+        };
+
+        let rerooted = layout.reroot(HashSet::from([
+            "pkg/src/main.rs".to_string(),
+            "pkg".to_string(),
+            "pkgsuffix/sibling.rs".to_string(),
+            "other/elsewhere.rs".to_string(),
+            "README.md".to_string(),
+        ]));
+
+        assert_eq!(sorted_slash_paths(&rerooted), ["src/main.rs"]);
+    }
+
+    #[test]
+    fn resolve_changed_scope_from_a_subdirectory_index_root_reroots_every_half() {
+        let repo = init_monorepo();
+        let index_root = repo.path().join("pkg");
+
+        // One file per half of `resolve_changed_files`, so a half left on the
+        // repository-root base is a missing member rather than an empty set.
+        std::fs::write(
+            index_root.join("src/tracked.rs"),
+            "fn tracked() { println!(\"modified\"); }\n",
+        )
+        .unwrap();
+        std::fs::write(index_root.join("src/staged.rs"), "fn staged() {}\n").unwrap();
+        git(repo.path(), &["add", "pkg/src/staged.rs"]).unwrap();
+        std::fs::write(index_root.join("src/untracked.rs"), "fn untracked() {}\n").unwrap();
+
+        // Changed, but outside the indexed directory.
+        std::fs::write(
+            repo.path().join("other/elsewhere.rs"),
+            "fn elsewhere() { println!(\"modified\"); }\n",
+        )
+        .unwrap();
+        std::fs::write(repo.path().join("README.md"), "changed\n").unwrap();
+
+        let paths = resolve_scope(&index_root, &GitScope::Changed).unwrap();
+
+        assert_eq!(
+            sorted_slash_paths(&paths),
+            ["src/staged.rs", "src/tracked.rs", "src/untracked.rs"]
+        );
+    }
+
+    #[test]
+    fn resolve_since_scope_from_a_subdirectory_index_root_reroots_paths() {
+        let repo = init_monorepo();
+        let index_root = repo.path().join("pkg");
+        let head = run_git(repo.path(), &["rev-parse", "HEAD"]).unwrap();
+        std::fs::write(
+            index_root.join("src/tracked.rs"),
+            "fn tracked() { println!(\"changed\"); }\n",
+        )
+        .unwrap();
+        std::fs::write(
+            repo.path().join("other/elsewhere.rs"),
+            "fn elsewhere() { println!(\"changed\"); }\n",
+        )
+        .unwrap();
+        commit_all(repo.path(), "second commit");
+
+        let paths = resolve_scope(&index_root, &GitScope::Since(head.trim().to_string())).unwrap();
+
+        assert_eq!(sorted_slash_paths(&paths), ["src/tracked.rs"]);
+    }
+
+    #[test]
+    fn resolve_base_scope_from_a_subdirectory_index_root_reroots_paths() {
+        let repo = init_monorepo();
+        let index_root = repo.path().join("pkg");
+        run_git(repo.path(), &["checkout", "-b", "feature"]).unwrap();
+        std::fs::write(
+            index_root.join("src/tracked.rs"),
+            "fn tracked() { println!(\"feature\"); }\n",
+        )
+        .unwrap();
+        std::fs::write(
+            repo.path().join("other/elsewhere.rs"),
+            "fn elsewhere() { println!(\"feature\"); }\n",
+        )
+        .unwrap();
+        commit_all(repo.path(), "feature commit");
+
+        let paths = resolve_scope(&index_root, &GitScope::Base("HEAD~1".to_string())).unwrap();
+
+        assert_eq!(sorted_slash_paths(&paths), ["src/tracked.rs"]);
+    }
+
+    #[test]
+    fn resolve_changed_scope_at_the_repository_root_keeps_subdirectory_prefixes() {
+        let repo = init_monorepo();
+        std::fs::write(
+            repo.path().join("pkg/src/tracked.rs"),
+            "fn tracked() { println!(\"modified\"); }\n",
+        )
+        .unwrap();
+
+        let paths = resolve_scope(repo.path(), &GitScope::Changed).unwrap();
+
+        assert_eq!(sorted_slash_paths(&paths), ["pkg/src/tracked.rs"]);
+    }
+
+    #[test]
+    fn resolve_scope_outside_a_git_repository_reports_the_missing_repository() {
+        let dir = TempDir::new().unwrap();
+
+        let err = resolve_scope(dir.path(), &GitScope::Changed).unwrap_err();
+
+        let message = format!("{err:#}");
+        assert!(
+            message.contains("failed to verify git repository for changed-file scope"),
+            "{message}"
+        );
+    }
+
+    /// Windows keeps a `\`-spelled variant of every path alongside the `/` one;
+    /// compare only the canonical spelling.
+    fn sorted_slash_paths(paths: &HashSet<String>) -> Vec<String> {
+        let mut sorted: Vec<String> = paths
+            .iter()
+            .filter(|path| !path.contains('\\'))
+            .cloned()
+            .collect();
+        sorted.sort();
+        sorted
+    }
+
     fn init_repo() -> TempDir {
         let repo = TempDir::new().unwrap();
         git(repo.path(), &["init"]).unwrap();
         std::fs::write(repo.path().join("tracked.rs"), "fn tracked() {}\n").unwrap();
+        commit_all(repo.path(), "initial commit");
+        repo
+    }
+
+    /// A repository whose root sits one level above the directory that gets
+    /// indexed, plus a sibling directory that must never enter the scope.
+    fn init_monorepo() -> TempDir {
+        let repo = TempDir::new().unwrap();
+        git(repo.path(), &["init"]).unwrap();
+        std::fs::create_dir_all(repo.path().join("pkg/src")).unwrap();
+        std::fs::create_dir_all(repo.path().join("other")).unwrap();
+        std::fs::write(repo.path().join("pkg/src/tracked.rs"), "fn tracked() {}\n").unwrap();
+        std::fs::write(
+            repo.path().join("other/elsewhere.rs"),
+            "fn elsewhere() {}\n",
+        )
+        .unwrap();
+        std::fs::write(repo.path().join("README.md"), "initial\n").unwrap();
         commit_all(repo.path(), "initial commit");
         repo
     }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -62,7 +62,7 @@ All stored in `.vera/` at the project root.
 - `config.rs`: `RetrievalConfig`, `IndexConfig` defaults
 - `local_models.rs`: Manages local embedding presets, custom ONNX embedding configs, and ORT/model assets under the Vera data directory (XDG-compliant)
 - `discovery/`: File discovery with gitignore support, binary/size filtering
-- `git_scope.rs`: Resolves `--changed`, `--since`, and `--base` into exact repository-relative paths
+- `git_scope.rs`: Resolves `--changed`, `--since`, and `--base` into exact paths relative to the indexed directory, which may sit below the git repository root
 - `chunk_text.rs`: Line-boundary text splitting for byte-budget enforcement
 
 ## vera-cli

--- a/docs/features.md
+++ b/docs/features.md
@@ -47,7 +47,7 @@ When a task is limited to modified files or a PR diff, scope the search before b
 - `--since <rev>`: files changed since a specific revision
 - `--base <rev>`: files changed since `merge-base(HEAD, <rev>)`
 
-These flags work with `vera search`, `vera grep`, and `vera overview`.
+These flags work with `vera search`, `vera grep`, and `vera overview`. Git state is read from the repository containing the indexed directory, and the result is limited to files inside that directory, so indexing a package inside a monorepo scopes to that package rather than to the whole repository.
 
 ### Query-Aware Ranking
 


### PR DESCRIPTION
Git state and the index disagreed about what a path is relative to. Every git command ran with the index root as its working directory, and the three commands behind `--changed` do not share one base there, so the scope set was built from a mix of two bases and the index could match only one of them.

Fixes #102

## Root cause

`ensure_git_repo` (`crates/vera-core/src/git_scope.rs:52-56` on master) ran `git rev-parse --show-toplevel` and discarded the output. Succeeding only proves that a repository exists at or above the index root, not that the index root *is* the root. Every later command then ran with `current_dir` = index root (`resolve_changed_files`, `git_scope.rs:58-76`; `resolve_diff_files`, `git_scope.rs:78-93`), and their bases differ.

Measured, not read. Repository root at `mono/`, indexed directory `mono/pkg`, run from `mono/pkg` with git 2.50.1:

| command | output | base |
|---|---|---|
| `git diff --name-only` | `pkg/src/main.rs` | repository root |
| `git diff --name-only --cached` | `pkg/src/untouched.rs` | repository root |
| `git ls-files --others --exclude-standard` | `src/created.rs` | working directory |
| `git rev-parse --show-toplevel` | `.../mono` | |
| `git rev-parse --show-prefix` | `pkg/` | |

The index stores paths relative to the directory that was indexed, and `SearchFilters::matches_file` (`crates/vera-core/src/types.rs:98-101`) does exact `HashSet` membership. So the two `diff` halves never match, the `ls-files` half always does, and the two symptoms in the issue follow directly: `--since` / `--base` are entirely `diff`, so they come back empty; `--changed` keeps its untracked third and silently drops the rest.

The base is not even stable per command. `git -c diff.relative=true diff --name-only` run from `mono/pkg` prints `src/main.rs`, and the same command run from `mono/` prints `pkg/src/main.rs`, so a user config flips which half is broken.

## The fix

Resolve the layout once, up front, in `RepoLayout::resolve`:

- keep the toplevel that `--show-toplevel` already returned, and run **every** git command there, so no output depends on `diff.relative` or on a per-command choice of base;
- take the index root's own position from `git rev-parse --show-prefix`, which is exactly the repository-root-relative path of the working directory, `/`-separated, with a trailing `/`, empty at the root;
- strip that prefix from every returned path and drop what does not carry it.

`--show-prefix` is used rather than arithmetic on the two paths because git computes it from the working directory it actually resolved. On macOS a `TempDir` under `/var/...` has a toplevel of `/private/var/...`, and a subtraction of the two strings would produce a wrong prefix where git produces an empty one.

Paths outside the indexed directory are dropped rather than reported: nothing indexed them, so no result can carry them. `add_platform_path_variants` moved to after the re-rooting, since git's prefix is `/`-separated and the `\` variants must be derived from the final paths.

### Boundaries

| case | behaviour |
|---|---|
| index root == repository root | prefix is empty, `reroot` returns the set untouched — byte-identical to master |
| index root below the repository root | prefix stripped; files outside the indexed directory dropped |
| index root not in any git repository | unchanged: fails on the toplevel lookup with the error it already had |
| bare repository (no work tree) | new explicit error rather than an empty toplevel used as a working directory |

## Reproduction, both binaries

Fixture: repository at `mono/`, `vera index .` run from `mono/pkg`, so `.vera/` sits in a subdirectory. Three files inside `pkg` are changed, one per half of `--changed`: `src/main.rs` modified, `src/untouched.rs` staged, `src/created.rs` untracked. Same index, same query, both binaries.

`vera grep` prints a fenced block per hit; only the header line of each block is reproduced below, so the sets are readable. `src/untouched.rs:1-2` is listed twice in every run including the unscoped one, on both binaries: two chunks share that range. That duplication is pre-existing and untouched here.

Unscoped control. All three files are indexed and reachable, and the two binaries agree exactly, so nothing below is an indexing difference:

```
$ vera grep "pub fn"                # released 1.0.0 and this branch, identical
src/created.rs:1-1
src/main.rs:1-1
src/untouched.rs:1-2
src/untouched.rs:1-2
```

Released `vera 1.0.0`:

```
$ vera grep "pub fn" --changed
src/created.rs:1-1                  # the untracked third only

$ vera grep "pub fn" --since HEAD
                                    # no output at all, exit 0, no error

$ vera overview --changed
  Files: 1    Chunks: 1
```

This branch, same fixture and same index:

```
$ vera grep "pub fn" --changed
src/created.rs:1-1
src/main.rs:1-1
src/untouched.rs:1-2
src/untouched.rs:1-2

$ vera grep "pub fn" --since HEAD
src/main.rs:1-1
src/untouched.rs:1-2
src/untouched.rs:1-2

$ vera overview --changed
  Files: 3    Chunks: 4
```

`--changed` now equals the unscoped set, which is correct here because all three changed files are inside `pkg`. `--since HEAD` correctly omits `src/created.rs`, which is untracked and so absent from the diff.

Index root == repository root, second fixture, `src/alpha.rs` modified. Identical on both binaries, which is the point:

```
released 1.0.0: vera grep "pub fn" --changed  ->  src/alpha.rs:1-1
this branch:    vera grep "pub fn" --changed  ->  src/alpha.rs:1-1
```

Index root outside any git repository, third fixture. Identical on both binaries, same exit code:

```
$ vera grep "pub fn" --changed ; echo "exit=$?"
Error: failed to verify git repository for changed-file scope: fatal: not a git repository (or any parent up to mount point /Volumes)
Stopping at filesystem boundary (GIT_DISCOVERY_ACROSS_FILESYSTEM not set).
exit=1
```

## Reinjection

The three new subdirectory tests were confirmed against the defect, not just against the fix. Restoring the pre-fix behaviour (git commands run at the index root, no re-rooting) makes them fail with the production symptom, and only those three:

```
---- resolve_changed_scope_from_a_subdirectory_index_root_reroots_every_half stdout ----
assertion `left == right` failed
  left: ["README.md", "other/elsewhere.rs", "pkg/src/staged.rs", "pkg/src/tracked.rs", "src/untracked.rs"]
 right: ["src/staged.rs", "src/tracked.rs", "src/untracked.rs"]

---- resolve_since_scope_from_a_subdirectory_index_root_reroots_paths stdout ----
assertion `left == right` failed
  left: ["other/elsewhere.rs", "pkg/src/tracked.rs"]
 right: ["src/tracked.rs"]

---- resolve_base_scope_from_a_subdirectory_index_root_reroots_paths stdout ----
assertion `left == right` failed
  left: ["other/elsewhere.rs", "pkg/src/tracked.rs"]
 right: ["src/tracked.rs"]

test result: FAILED. 10 passed; 3 failed
```

The `--changed` left-hand side is the bug in one line: of the five entries, only `src/untracked.rs` is on the base the index uses. The two `--since` / `--base` sets contain nothing on that base at all, which is why they returned empty rather than partial.

## Tests

Every scope test that could discriminate this bug needed a fixture whose index root is a *subdirectory* of the repository, so `init_monorepo` builds one: repository root holding `pkg/src/`, a sibling `other/`, and a root `README.md`. The sibling and the README are changed in each test, so a test that stopped dropping out-of-directory paths would fail too.

- `resolve_changed_scope_from_a_subdirectory_index_root_reroots_every_half` — one changed file per half of `resolve_changed_files` (modified, staged, untracked), so a single half left on the wrong base is a missing member rather than an empty set. Asserts the exact sorted set, which pins count, identity and the absence of `pkg/`-prefixed and out-of-directory entries in one comparison.
- `resolve_since_scope_from_a_subdirectory_index_root_reroots_paths`, `resolve_base_scope_from_a_subdirectory_index_root_reroots_paths` — same shape for the two diff scopes.
- `resolve_changed_scope_at_the_repository_root_keeps_subdirectory_prefixes` — the unchanged class. Indexing at the repository root must *keep* `pkg/src/tracked.rs` whole; it fails if re-rooting ever strips at the root.
- `reroot_drops_paths_outside_the_indexed_directory` — pure, no git. Pins that the prefix is `pkg/` and not `pkg`: a sibling directory `pkgsuffix/sibling.rs` must be dropped, along with the bare `pkg` entry, `other/elsewhere.rs` and `README.md`.
- `resolve_scope_outside_a_git_repository_reports_the_missing_repository` — the error path stays an error and keeps its message.

Comparisons go through a `sorted_slash_paths` helper that skips the `\`-spelled duplicates `add_platform_path_variants` adds on Windows, so the same assertion holds on both platforms.

## Relationship to #112

No overlap and no conflict. #112 (`fix/index-path-containment`) validates a stored index path when it is joined onto the project root, in `path_containment.rs` and four `retrieval/` call sites. This PR touches `git_scope.rs` only and never joins a path onto anything: it re-roots one *relative* string base onto another and hands the result to `SearchFilters::exact_paths`, which does `HashSet` membership on relative strings. The two changes share no file, and the sets they produce meet only where a git-scoped path is compared against a stored path, both still relative. They rebase over each other cleanly.

Worth naming rather than leaving implicit: `reroot` is not a containment check and must not be read as one. It drops a path that does not carry the prefix, which happens to exclude `../`-shaped entries, but git never emits those from a toplevel working directory and the guarantee that a stored path stays inside the root is #112's, at the point of use.

## Verification

Run at `aa16a0a`:

- `cargo fmt --check`: clean
- `cargo test -p vera-core --lib`: 799 passed, 0 failed
- `cargo test -p vera-cli --bin vera`: 97 passed, 0 failed
- `cargo clippy -p vera-core --lib`: 5 warnings, the pre-existing set, none added
- `cargo build --release -p vera-cli`: clean; the end-to-end runs above are that binary

Not run: nothing on Windows. `add_platform_path_variants` and the `sorted_slash_paths` test helper are the only Windows-conditional code here and neither was executed on that platform.

Ranking is untouched, so the standing benchmark request does not apply: no file under `crates/vera-core/src/retrieval/` is modified, `git_scope.rs` produces the `exact_paths` filter set and nothing that feeds scoring, and an unscoped query returns the same results before and after (`vera grep "pub fn"` on the fixture above: identical four-hit, three-file set on both binaries).

## Note on the alternative

The issue offered two shapes, re-rooting and refusing the flags when the index root is not the repository root. This is the re-rooting one. Refusing is a smaller diff but turns a working layout into an error: indexing a package inside a monorepo is ordinary, and `--changed` there has a correct answer. If you would rather refuse, say so and I will cut it down.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Re-roots git-scoped paths onto the indexed directory and runs all git commands at the repository root to fix mixed-base path mismatches. Previously we ran git in the index root; `diff` produced repository-root paths and `ls-files` produced working-directory paths, so `--since`/`--base` often returned nothing and `--changed` only untracked files.

- Resolve layout once via `git rev-parse --show-toplevel` and `--show-prefix`; run all git at the repository root, then strip the prefix to return index-root-relative paths and drop paths outside the indexed directory.
- `resolve_scope` now takes the `index_root` and re-roots results; flags and external behavior are unchanged.
- Bare repositories now return a clear error; non-repo paths keep the existing error.
- Move `add_platform_path_variants` after re-rooting; output stays relative to the indexed directory.
- Add subdirectory tests; behavior at the repository root is unchanged. Update `docs/architecture.md` and `docs/features.md` to reflect the new scoping behavior.

<sup>Written for commit aa16a0a9fd4f516cc4c53028312f72b4e498f330. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/VeraTools/Vera/pull/138?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

