### PR TITLE
feat(eval): configurable model lanes, task slicing, and full provenance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4139,6 +4139,7 @@ dependencies = [
  "clap",
  "serde",
  "serde_json",
+ "sha2",
  "tempfile",
  "tokio",
  "toml",

--- a/benchmarks/scripts/bench_common.py
+++ b/benchmarks/scripts/bench_common.py
@@ -8,7 +8,9 @@ each ground-truth entry consumed at most once.
 """
 
 import json
+import hashlib
 import math
+import os
 import subprocess
 from pathlib import Path
 
@@ -16,13 +18,49 @@ REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 TASKS_DIR = REPO_ROOT / "eval" / "tasks"
 
 
-def load_tasks() -> list[dict]:
+def load_tasks(
+    task_ids: set[str] | None = None,
+    categories: set[str] | None = None,
+) -> list[dict]:
     """Load all benchmark tasks from eval/tasks/*.json."""
     tasks = []
     for task_file in sorted(TASKS_DIR.glob("*.json")):
         with open(task_file) as f:
             tasks.extend(json.load(f))
-    return tasks
+    task_ids = task_ids or set()
+    categories = {category.replace("-", "_").lower() for category in (categories or set())}
+    filtered = [
+        task
+        for task in tasks
+        if (not task_ids or task["id"] in task_ids)
+        and (not categories or task["category"] in categories)
+    ]
+    unknown_ids = sorted(task_ids - {task["id"] for task in tasks})
+    if unknown_ids:
+        raise ValueError(f"unknown task ID(s): {', '.join(unknown_ids)}")
+    if not filtered and (task_ids or categories):
+        raise ValueError("no benchmark tasks match the requested filters")
+    return filtered
+
+
+def task_set_identity(tasks: list[dict]) -> dict[str, str | int]:
+    """Hash sorted task IDs without including ground truth or task content."""
+    task_ids = sorted(task["id"] for task in tasks)
+    serialized_ids = ("\n".join(task_ids) + "\n") if task_ids else ""
+    digest = hashlib.sha256(serialized_ids.encode()).hexdigest()
+    return {"count": len(task_ids), "task_ids_sha256": digest}
+
+
+def environment_summary(env: dict[str, str]) -> dict[str, str]:
+    """Return the benchmark environment with credential values redacted."""
+    summary = {}
+    for key, value in sorted({**os.environ, **env}.items()):
+        if key.startswith(("EMBEDDING_", "RERANKER_", "VERA_")):
+            if any(secret in key for secret in ("KEY", "TOKEN", "SECRET")):
+                summary[key] = "<redacted>"
+            else:
+                summary[key] = value
+    return summary
 
 
 def load_secrets() -> dict[str, str]:

--- a/benchmarks/scripts/run_vera_benchmarks.py
+++ b/benchmarks/scripts/run_vera_benchmarks.py
@@ -9,7 +9,7 @@ Modes:
   - bm25-only       : BM25 keyword search only (no embedding API)
 
 Usage:
-    python3 benchmarks/scripts/run_vera_benchmarks.py [--mode MODE] [--runs N]
+    python3 benchmarks/scripts/run_vera_benchmarks.py [--modes MODE ...] [--runs N]
 
 Requires:
     - Vera binary built (cargo build --release)
@@ -25,6 +25,8 @@ from bench_common import (
     is_match,
     load_secrets,
     load_tasks,
+    task_set_identity,
+    environment_summary,
     matched_relevances,
     mrr,
     ndcg_at_k,
@@ -207,7 +209,16 @@ def run_benchmark(
 
     if not available_tasks:
         print("  ✗ No available tasks (no repos indexed)", file=sys.stderr)
-        return {"tool_name": f"vera-{mode}", "mode": mode, "per_task": [], "per_category": {}, "aggregate": {}}
+        return {
+            "tool_name": f"vera-{mode}",
+            "mode": mode,
+            "task_set": task_set_identity([]),
+            "environment": environment_summary(env),
+            "command": ["vera", "--json", "search", "<task-query>", "--limit", "20"],
+            "per_task": [],
+            "per_category": {},
+            "aggregate": {},
+        }
 
     print(f"  Running {len(available_tasks)} tasks (skipped {len(tasks) - len(available_tasks)} for unindexed repos)")
 
@@ -273,6 +284,16 @@ def run_benchmark(
     return {
         "tool_name": f"vera-{mode}",
         "mode": mode,
+        "task_set": task_set_identity(available_tasks),
+        "environment": environment_summary(env),
+        "command": [
+            "vera",
+            "--json",
+            "search",
+            "<task-query>",
+            "--limit",
+            "20",
+        ],
         "per_task": per_task,
         "per_category": per_category,
         "aggregate": aggregate,
@@ -484,6 +505,11 @@ def verify_assertions(vera_results: dict[str, dict]) -> list[tuple[str, bool, st
     norerank = vera_results.get("hybrid-norerank", {}).get("aggregate", {}).get("retrieval", {})
     hybrid_perf = vera_results.get("hybrid", {}).get("aggregate", {}).get("performance", {})
 
+    # A sliced run may intentionally omit one of the comparison lanes. Do not
+    # turn an in-scope partial benchmark into a false failure.
+    if "hybrid" not in vera_results or "bm25-only" not in vera_results:
+        return []
+
     # 1. Hybrid MRR@10 > BM25-only MRR@10
     h_mrr = hybrid.get("mrr", 0)
     b_mrr = bm25.get("mrr", 0)
@@ -513,6 +539,9 @@ def verify_assertions(vera_results: dict[str, dict]) -> list[tuple[str, bool, st
         h_mrr > v_mrr,
         f"hybrid={h_mrr:.4f}, vector-only-baseline={v_mrr:.4f}",
     ))
+
+    if "hybrid-norerank" not in vera_results:
+        return checks
 
     # 3. Reranked Precision@3 > unreranked Precision@3
     h_p3 = hybrid.get("precision_at_3", 0)
@@ -544,12 +573,13 @@ def verify_assertions(vera_results: dict[str, dict]) -> list[tuple[str, bool, st
     hybrid_p95 = hybrid_perf.get("latency_p95_ms", 9999)
     hybrid_queries = hybrid_perf.get("total_queries", 0)
     # Use BM25 for the <500ms target (local computation), report both
-    checks.append((
-        "p95 query latency < 500ms on 20+ queries (local computation)",
-        bm25_p95 < 500 and bm25_queries >= 17,
-        f"bm25_p95={bm25_p95:.1f}ms ({bm25_queries} queries), "
-        f"hybrid_p95={hybrid_p95:.1f}ms ({hybrid_queries} queries, includes API round trips)",
-    ))
+    if bm25_queries >= 17:
+        checks.append((
+            "p95 query latency < 500ms on 20+ queries (local computation)",
+            bm25_p95 < 500,
+            f"bm25_p95={bm25_p95:.1f}ms ({bm25_queries} queries), "
+            f"hybrid_p95={hybrid_p95:.1f}ms ({hybrid_queries} queries, includes API round trips)",
+        ))
 
     return checks
 
@@ -565,6 +595,18 @@ def main():
     )
     parser.add_argument(
         "--runs", type=int, default=1, help="Number of timing runs per mode"
+    )
+    parser.add_argument(
+        "--task-id",
+        action="append",
+        default=[],
+        help="Task ID to include; repeat or use comma-separated values",
+    )
+    parser.add_argument(
+        "--category",
+        action="append",
+        default=[],
+        help="Task category to include; repeat or use comma-separated values",
     )
     parser.add_argument(
         "--skip-index",
@@ -586,7 +628,23 @@ def main():
 
     # Load credentials
     secrets = load_secrets()
-    tasks = load_tasks()
+    task_ids = {
+        task_id.strip()
+        for value in args.task_id
+        for task_id in value.split(",")
+        if task_id.strip()
+    }
+    categories = {
+        category.strip()
+        for value in args.category
+        for category in value.split(",")
+        if category.strip()
+    }
+    try:
+        tasks = load_tasks(task_ids=task_ids, categories=categories)
+    except ValueError as error:
+        print(f"Error: {error}", file=sys.stderr)
+        sys.exit(2)
     repos = sorted(set(t["repo"] for t in tasks))
 
     print(f"Vera version: {binary_version(VERA_BIN)}")
@@ -646,6 +704,9 @@ def main():
         "vera_version": binary_version(VERA_BIN),
         "git_sha": git_sha(),
         "timestamp": time.strftime("%Y-%m-%dT%H:%M:%S%z"),
+        "task_set": task_set_identity(tasks),
+        "environment": environment_summary(secrets),
+        "command": sys.argv,
         "modes": vera_results,
         "index_stats": index_stats,
         "assertion_checks": [

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -6,6 +6,56 @@ This page tracks the v1.0 full-pipeline results and ablations first, then older 
 
 The v1.0.0-rc run used the full 1,251-task Semble suite across 63 repos on the `vera-cuda` lane: hybrid BM25+vector retrieval, RRF fusion, and a local ONNX cross-encoder reranker on CUDA, measured 2026-08-16 against the v1.0.0 release candidate. The older "BM25 scoped filters" full-suite row (`nDCG@10` 0.7267, measured in May 2026) was a BM25-only lane using an older harness. Cross-date comparisons are approximate.
 
+### Model Lanes And Partial Runs
+
+`vera-eval` keeps the historical lanes `vera-bm25`, `vera-cuda`, `vera-cpu`, and `vera-potion`. Use `--task-id` and `--category` to select a task slice without changing the task files or ground truth:
+
+```bash
+cargo run -p vera-eval -- run --tool vera-bm25 \
+  --task-id symbol-lookup-001,symbol-lookup-002 \
+  --category symbol_lookup --json-only
+```
+
+For candidate models, pass a JSON or TOML file with one or more lanes. Each lane records its backend, model source, pooling, prefixes, dimensions, maximum length, reranking choice, and optional revision. The evaluator emits one report per lane, or a JSON array when more than one lane is requested.
+
+JSON example:
+
+```json
+{
+  "lanes": [
+    {
+      "name": "bitnet-270m",
+      "backend": "custom-onnx",
+      "repo": "microsoft/bitnet-embedding-270m",
+      "onnx_file": "onnx/model.onnx",
+      "tokenizer_file": "tokenizer.json",
+      "pooling": "last-token",
+      "query_prefix": "Represent this query for searching relevant code:",
+      "document_prefix": "Represent this code for retrieval:",
+      "dim": 640,
+      "max_length": 512,
+      "rerank": false,
+      "revision": "<commit-or-tag>"
+    },
+    {
+      "name": "potion-control",
+      "backend": "potion",
+      "rerank": false
+    }
+  ]
+}
+```
+
+The `custom-onnx` backend defaults to CPU; set `execution_provider` to `cuda`, `rocm`, `coreml`, `openvino`, or another supported provider when needed. `repo` downloads from Hugging Face and `dir` points at an existing local model directory. API lanes use `model_id`, `query_prefix`, and `environment` for endpoint settings. Every report includes the resolved lane contract, Vera Git SHA, timestamp, command and redacted environment summary, corpus SHAs, and a SHA-256 identity of the selected task IDs.
+
+The lower-level Python runner supports the same task controls for its existing retrieval modes:
+
+```bash
+python3 benchmarks/scripts/run_vera_benchmarks.py \
+  --modes bm25-only hybrid-norerank \
+  --task-id intent-001,intent-002 --category intent --skip-index
+```
+
 ### Main Results
 
 | Variant | nDCG@10 | Recall@1 | Recall@5 | Mean search latency |

--- a/eval/Cargo.toml
+++ b/eval/Cargo.toml
@@ -16,6 +16,7 @@ toml = "1.1"
 clap = { version = "4", features = ["derive"] }
 anyhow = "1"
 chrono = { version = "0.4", features = ["serde"] }
+sha2 = "0.11"
 tokio.workspace = true
 vera-core.workspace = true
 

--- a/eval/src/lanes.rs
+++ b/eval/src/lanes.rs
@@ -1,0 +1,724 @@
+//! Benchmark lane specifications and their runtime configuration.
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::collections::{BTreeMap, HashSet};
+use std::ffi::OsString;
+use std::path::{Path, PathBuf};
+use std::str::FromStr;
+
+use crate::types::{BenchmarkTask, LaneProvenance, TaskSetIdentity};
+use vera_core::config::{InferenceBackend, OnnxExecutionProvider};
+use vera_core::local_models::{
+    LOCAL_EMBEDDING_DIM_ENV, LOCAL_EMBEDDING_DIR_ENV, LOCAL_EMBEDDING_DOCUMENT_PREFIX_ENV,
+    LOCAL_EMBEDDING_MAX_LENGTH_ENV, LOCAL_EMBEDDING_ONNX_DATA_FILE_ENV,
+    LOCAL_EMBEDDING_ONNX_FILE_ENV, LOCAL_EMBEDDING_POOLING_ENV, LOCAL_EMBEDDING_QUERY_PREFIX_ENV,
+    LOCAL_EMBEDDING_REPO_ENV, LOCAL_EMBEDDING_TOKENIZER_FILE_ENV, LocalEmbeddingModelConfig,
+    LocalEmbeddingSource, POTION_CODE_REPO,
+};
+
+const LOCAL_MODEL_ENV_KEYS: &[&str] = &[
+    LOCAL_EMBEDDING_REPO_ENV,
+    LOCAL_EMBEDDING_DIR_ENV,
+    LOCAL_EMBEDDING_ONNX_FILE_ENV,
+    LOCAL_EMBEDDING_ONNX_DATA_FILE_ENV,
+    LOCAL_EMBEDDING_TOKENIZER_FILE_ENV,
+    LOCAL_EMBEDDING_DIM_ENV,
+    LOCAL_EMBEDDING_POOLING_ENV,
+    LOCAL_EMBEDDING_MAX_LENGTH_ENV,
+    LOCAL_EMBEDDING_QUERY_PREFIX_ENV,
+    LOCAL_EMBEDDING_DOCUMENT_PREFIX_ENV,
+];
+
+const PROVENANCE_ENV_KEYS: &[&str] = &[
+    "VERA_BACKEND",
+    "VERA_LOCAL",
+    "EMBEDDING_MODEL_BASE_URL",
+    "EMBEDDING_MODEL_ID",
+    "EMBEDDING_MODEL_API_KEY",
+    "EMBEDDING_QUERY_PREFIX",
+    "RERANKER_MODEL_BASE_URL",
+    "RERANKER_MODEL_ID",
+    "RERANKER_MODEL_API_KEY",
+    "VERA_MAX_RERANK_BATCH",
+];
+
+/// One benchmark lane. The same shape can be supplied in JSON or TOML.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LaneSpec {
+    /// Stable name used in reports and output filenames.
+    pub name: String,
+    /// `api`, `potion`, `onnx-jina-*`, `custom-onnx`, or the legacy `bm25`.
+    pub backend: String,
+    /// API model identifier, when using the API backend.
+    #[serde(default)]
+    pub model_id: Option<String>,
+    /// Hugging Face model repository for local ONNX models.
+    #[serde(default, alias = "model_repo")]
+    pub repo: Option<String>,
+    /// Local directory containing the ONNX model and tokenizer.
+    #[serde(default, alias = "model_dir")]
+    pub dir: Option<PathBuf>,
+    /// Declared model revision. The current local model downloader resolves
+    /// the repository's default revision; this value is recorded for audit.
+    #[serde(default)]
+    pub revision: Option<String>,
+    /// ONNX execution provider for `custom-onnx`; defaults to CPU.
+    #[serde(default, alias = "provider")]
+    pub execution_provider: Option<String>,
+    /// Relative ONNX file inside the repository or directory.
+    #[serde(default)]
+    pub onnx_file: Option<String>,
+    /// Relative ONNX external-data file. Set `no_onnx_data` for models
+    /// without an external-data sidecar.
+    #[serde(default)]
+    pub onnx_data_file: Option<String>,
+    #[serde(default)]
+    pub no_onnx_data: bool,
+    /// Relative tokenizer file inside the repository or directory.
+    #[serde(default)]
+    pub tokenizer_file: Option<String>,
+    /// Token pooling mode: `mean`, `cls`, or `last-token`.
+    #[serde(default)]
+    pub pooling: Option<String>,
+    #[serde(default)]
+    pub query_prefix: Option<String>,
+    #[serde(default)]
+    pub document_prefix: Option<String>,
+    #[serde(default)]
+    pub dim: Option<usize>,
+    #[serde(default)]
+    pub max_length: Option<usize>,
+    /// Whether to enable Vera's reranker for this lane.
+    #[serde(default = "default_rerank")]
+    pub rerank: bool,
+    /// Additional environment overrides, useful for API endpoints and keys.
+    /// Secret values are redacted in report provenance.
+    #[serde(default, alias = "env")]
+    pub environment: BTreeMap<String, String>,
+}
+
+fn default_rerank() -> bool {
+    true
+}
+
+#[derive(Debug, Deserialize)]
+struct LaneFile {
+    lanes: Vec<LaneSpec>,
+}
+
+/// A resolved lane with the backend understood by `vera-core`.
+#[derive(Debug, Clone)]
+pub struct ResolvedLane {
+    pub spec: LaneSpec,
+    pub backend: Option<InferenceBackend>,
+}
+
+impl ResolvedLane {
+    pub fn name(&self) -> &str {
+        &self.spec.name
+    }
+
+    pub fn is_bm25(&self) -> bool {
+        self.backend.is_none()
+    }
+
+    pub fn rerank(&self) -> bool {
+        self.spec.rerank && !matches!(self.backend, Some(InferenceBackend::PotionCode))
+    }
+
+    /// Resolve the effective model settings after [`LaneEnvGuard`] is active.
+    pub fn provenance(&self) -> Result<LaneProvenance> {
+        let backend = self.spec.backend.trim().to_ascii_lowercase();
+        if self.is_bm25() {
+            return Ok(LaneProvenance {
+                name: self.spec.name.clone(),
+                backend,
+                execution_provider: None,
+                model_id: None,
+                model_repo: None,
+                model_dir: None,
+                model_revision: self.spec.revision.clone(),
+                onnx_file: None,
+                onnx_data_file: None,
+                tokenizer_file: None,
+                pooling: None,
+                query_prefix: None,
+                document_prefix: None,
+                dim: None,
+                max_length: None,
+                rerank: false,
+            });
+        }
+
+        if matches!(self.backend, Some(InferenceBackend::PotionCode)) {
+            return Ok(LaneProvenance {
+                name: self.spec.name.clone(),
+                backend,
+                execution_provider: None,
+                model_id: Some(POTION_CODE_REPO.to_string()),
+                model_repo: Some(POTION_CODE_REPO.to_string()),
+                model_dir: None,
+                model_revision: self.spec.revision.clone(),
+                onnx_file: None,
+                onnx_data_file: None,
+                tokenizer_file: None,
+                pooling: None,
+                query_prefix: None,
+                document_prefix: None,
+                dim: Some(vera_core::local_models::POTION_CODE_DIM),
+                max_length: Some(vera_core::local_models::POTION_CODE_MAX_LENGTH),
+                rerank: false,
+            });
+        }
+
+        if matches!(self.backend, Some(InferenceBackend::Api)) {
+            return Ok(LaneProvenance {
+                name: self.spec.name.clone(),
+                backend,
+                execution_provider: None,
+                model_id: std::env::var("EMBEDDING_MODEL_ID")
+                    .ok()
+                    .or_else(|| self.spec.model_id.clone()),
+                model_repo: self.spec.repo.clone(),
+                model_dir: self
+                    .spec
+                    .dir
+                    .as_ref()
+                    .map(|path| path.display().to_string()),
+                model_revision: self.spec.revision.clone(),
+                onnx_file: None,
+                onnx_data_file: None,
+                tokenizer_file: None,
+                pooling: None,
+                query_prefix: self
+                    .spec
+                    .query_prefix
+                    .clone()
+                    .or_else(|| std::env::var("EMBEDDING_QUERY_PREFIX").ok()),
+                document_prefix: None,
+                dim: self.spec.dim,
+                max_length: self.spec.max_length,
+                rerank: self.rerank(),
+            });
+        }
+
+        let mut model = LocalEmbeddingModelConfig::from_env()
+            .context("failed to resolve local embedding model provenance")?;
+        if let Some(provider) = self.backend.and_then(InferenceBackend::execution_provider) {
+            model.adjust_for_gpu(provider);
+        }
+        let (model_repo, model_dir) = match &model.source {
+            LocalEmbeddingSource::HuggingFace { repo } => (Some(repo.clone()), None),
+            LocalEmbeddingSource::Directory { path } => (None, Some(path.display().to_string())),
+        };
+        let onnx_file = model.onnx_file.clone();
+        let onnx_data_file = model.onnx_data_file.clone();
+        Ok(LaneProvenance {
+            name: self.spec.name.clone(),
+            backend,
+            execution_provider: self
+                .backend
+                .and_then(InferenceBackend::execution_provider)
+                .map(|provider| provider.to_string()),
+            model_id: Some(model.display_name()),
+            model_repo,
+            model_dir,
+            model_revision: self.spec.revision.clone(),
+            onnx_file: Some(onnx_file),
+            onnx_data_file,
+            tokenizer_file: Some(model.tokenizer_file),
+            pooling: Some(model.pooling.to_string()),
+            query_prefix: model.query_prefix,
+            document_prefix: model.document_prefix,
+            dim: Some(model.embedding_dim),
+            max_length: Some(model.max_length),
+            rerank: self.rerank(),
+        })
+    }
+
+    pub fn config_map(&self, provenance: &LaneProvenance) -> BTreeMap<String, String> {
+        let mut config = BTreeMap::new();
+        config.insert("lane.name".to_string(), provenance.name.clone());
+        config.insert("lane.backend".to_string(), provenance.backend.clone());
+        config.insert("lane.rerank".to_string(), provenance.rerank.to_string());
+        insert_optional(
+            &mut config,
+            "lane.execution_provider",
+            &provenance.execution_provider,
+        );
+        insert_optional(&mut config, "lane.model_id", &provenance.model_id);
+        insert_optional(&mut config, "lane.model_repo", &provenance.model_repo);
+        insert_optional(&mut config, "lane.model_dir", &provenance.model_dir);
+        insert_optional(
+            &mut config,
+            "lane.model_revision",
+            &provenance.model_revision,
+        );
+        insert_optional(&mut config, "lane.onnx_file", &provenance.onnx_file);
+        insert_optional(
+            &mut config,
+            "lane.onnx_data_file",
+            &provenance.onnx_data_file,
+        );
+        insert_optional(
+            &mut config,
+            "lane.tokenizer_file",
+            &provenance.tokenizer_file,
+        );
+        insert_optional(&mut config, "lane.pooling", &provenance.pooling);
+        insert_optional(&mut config, "lane.query_prefix", &provenance.query_prefix);
+        insert_optional(
+            &mut config,
+            "lane.document_prefix",
+            &provenance.document_prefix,
+        );
+        if let Some(dim) = provenance.dim {
+            config.insert("lane.dim".to_string(), dim.to_string());
+        }
+        if let Some(max_length) = provenance.max_length {
+            config.insert("lane.max_length".to_string(), max_length.to_string());
+        }
+        config
+    }
+}
+
+fn insert_optional(map: &mut BTreeMap<String, String>, key: &str, value: &Option<String>) {
+    if let Some(value) = value {
+        map.insert(key.to_string(), value.clone());
+    }
+}
+
+/// Load lanes from a JSON or TOML file.
+pub fn load_file(path: &Path) -> Result<Vec<LaneSpec>> {
+    let content = std::fs::read_to_string(path)
+        .with_context(|| format!("failed to read lane spec {}", path.display()))?;
+    let extension = path.extension().and_then(|value| value.to_str());
+    let lanes = match extension {
+        Some("toml") => {
+            toml::from_str::<LaneFile>(&content)
+                .with_context(|| format!("failed to parse lane TOML {}", path.display()))?
+                .lanes
+        }
+        _ => match serde_json::from_str::<LaneFile>(&content) {
+            Ok(file) => file.lanes,
+            Err(wrapper_error) => {
+                serde_json::from_str::<Vec<LaneSpec>>(&content).with_context(|| {
+                    format!(
+                        "failed to parse lane JSON {}: {wrapper_error}",
+                        path.display()
+                    )
+                })?
+            }
+        },
+    };
+    if lanes.is_empty() {
+        anyhow::bail!("lane spec {} does not contain any lanes", path.display());
+    }
+    Ok(lanes)
+}
+
+/// Resolve a spec into the backend enum and validate unsupported combinations.
+pub fn resolve(spec: LaneSpec) -> Result<ResolvedLane> {
+    if spec.name.trim().is_empty() {
+        anyhow::bail!("lane name cannot be empty");
+    }
+    if spec.repo.is_some() && spec.dir.is_some() {
+        anyhow::bail!("lane '{}' cannot set both repo and dir", spec.name);
+    }
+
+    let backend_name = spec.backend.trim().to_ascii_lowercase();
+    let backend = match backend_name.as_str() {
+        "bm25" => None,
+        "api" => {
+            reject_local_fields(&spec, "api")?;
+            if spec.repo.is_some() || spec.dir.is_some() {
+                anyhow::bail!("lane '{}' API backend cannot set repo or dir", spec.name);
+            }
+            Some(InferenceBackend::Api)
+        }
+        "potion" | "potion-code" | "potion-code-cpu" | "potion-cpu" => {
+            reject_local_fields(&spec, "potion")?;
+            Some(InferenceBackend::PotionCode)
+        }
+        "custom-onnx" => {
+            if spec.repo.is_none() && spec.dir.is_none() {
+                anyhow::bail!(
+                    "lane '{}' custom-onnx backend requires repo or dir",
+                    spec.name
+                );
+            }
+            let provider = parse_execution_provider(spec.execution_provider.as_deref())?;
+            Some(InferenceBackend::OnnxJina(provider))
+        }
+        value if value.starts_with("onnx-jina-") => {
+            let backend = InferenceBackend::from_str(value).map_err(anyhow::Error::msg)?;
+            if spec.execution_provider.is_some() {
+                anyhow::bail!(
+                    "lane '{}' already selects an execution provider in backend '{}'; omit execution_provider",
+                    spec.name,
+                    spec.backend
+                );
+            }
+            Some(backend)
+        }
+        other => anyhow::bail!(
+            "unknown lane backend '{other}' for '{}'; expected api, potion, onnx-jina-*, custom-onnx, or bm25",
+            spec.name
+        ),
+    };
+
+    Ok(ResolvedLane { spec, backend })
+}
+
+fn reject_local_fields(spec: &LaneSpec, backend: &str) -> Result<()> {
+    let has_local_model_fields = spec.pooling.is_some()
+        || spec.document_prefix.is_some()
+        || spec.dim.is_some()
+        || spec.max_length.is_some()
+        || spec.onnx_file.is_some()
+        || spec.onnx_data_file.is_some()
+        || spec.no_onnx_data
+        || spec.tokenizer_file.is_some();
+    if has_local_model_fields {
+        anyhow::bail!(
+            "lane '{}' backend '{backend}' only supports model_id and query_prefix; local ONNX fields require custom-onnx or onnx-jina-*",
+            spec.name
+        );
+    }
+    Ok(())
+}
+
+fn parse_execution_provider(value: Option<&str>) -> Result<OnnxExecutionProvider> {
+    let value = value.unwrap_or("cpu");
+    let backend = if value.starts_with("onnx-jina-") {
+        value.to_string()
+    } else {
+        format!("onnx-jina-{value}")
+    };
+    match InferenceBackend::from_str(&backend).map_err(anyhow::Error::msg)? {
+        InferenceBackend::OnnxJina(provider) => Ok(provider),
+        _ => unreachable!("onnx-jina backend parser returned a non-ONNX backend"),
+    }
+}
+
+/// Keep the four historical Vera lanes as named presets.
+pub fn preset(name: &str) -> Option<LaneSpec> {
+    let (backend, rerank) = match name {
+        "vera-bm25" => ("bm25", false),
+        "vera-cuda" => ("onnx-jina-cuda", true),
+        "vera-cpu" => ("onnx-jina-cpu", true),
+        "vera-potion" => ("potion", false),
+        _ => return None,
+    };
+    Some(LaneSpec {
+        name: name.to_string(),
+        backend: backend.to_string(),
+        model_id: None,
+        repo: None,
+        dir: None,
+        revision: None,
+        execution_provider: None,
+        onnx_file: None,
+        onnx_data_file: None,
+        no_onnx_data: false,
+        tokenizer_file: None,
+        pooling: None,
+        query_prefix: None,
+        document_prefix: None,
+        dim: None,
+        max_length: None,
+        rerank,
+        environment: BTreeMap::new(),
+    })
+}
+
+/// Resolve named presets or a lane spec file, rejecting duplicate names.
+pub fn resolve_specs(specs: Vec<LaneSpec>) -> Result<Vec<ResolvedLane>> {
+    let mut names = HashSet::new();
+    specs
+        .into_iter()
+        .map(resolve)
+        .collect::<Result<Vec<_>>>()
+        .and_then(|lanes| {
+            for lane in &lanes {
+                if !names.insert(lane.name().to_string()) {
+                    anyhow::bail!("duplicate lane name '{}'", lane.name());
+                }
+            }
+            Ok(lanes)
+        })
+}
+
+/// Apply one lane's model settings to Vera's environment. The guard restores
+/// the caller's environment when the lane completes.
+pub fn apply_environment(lane: &ResolvedLane) -> LaneEnvGuard {
+    let mut keys: Vec<String> = LOCAL_MODEL_ENV_KEYS
+        .iter()
+        .chain(PROVENANCE_ENV_KEYS.iter())
+        .map(|key| (*key).to_string())
+        .chain(lane.spec.environment.keys().cloned())
+        .collect();
+    keys.sort();
+    keys.dedup();
+    let guard = LaneEnvGuard::new(keys);
+
+    for (key, value) in &lane.spec.environment {
+        set_env(key, Some(value));
+    }
+
+    let backend_name = lane.spec.backend.trim().to_ascii_lowercase();
+    let backend_value = lane.spec.backend.trim().to_string();
+    set_env("VERA_BACKEND", Some(&backend_value));
+    set_env(
+        "VERA_LOCAL",
+        Some(if lane.backend.is_some_and(InferenceBackend::is_local) {
+            "1"
+        } else {
+            "0"
+        }),
+    );
+
+    if lane.backend.is_some_and(InferenceBackend::is_onnx)
+        && (backend_name == "custom-onnx" || has_local_model_overrides(lane))
+    {
+        for key in LOCAL_MODEL_ENV_KEYS {
+            set_env(key, None);
+        }
+        if let Some(repo) = lane.spec.repo.as_deref() {
+            set_env(LOCAL_EMBEDDING_REPO_ENV, Some(repo));
+        }
+        if let Some(dir) = lane.spec.dir.as_ref() {
+            set_env(LOCAL_EMBEDDING_DIR_ENV, Some(&dir.display().to_string()));
+        }
+        set_env(
+            LOCAL_EMBEDDING_ONNX_FILE_ENV,
+            lane.spec.onnx_file.as_deref(),
+        );
+        if lane.spec.no_onnx_data {
+            set_env(LOCAL_EMBEDDING_ONNX_DATA_FILE_ENV, Some(""));
+        } else {
+            set_env(
+                LOCAL_EMBEDDING_ONNX_DATA_FILE_ENV,
+                lane.spec.onnx_data_file.as_deref(),
+            );
+        }
+        set_env(
+            LOCAL_EMBEDDING_TOKENIZER_FILE_ENV,
+            lane.spec.tokenizer_file.as_deref(),
+        );
+        set_env(
+            LOCAL_EMBEDDING_DIM_ENV,
+            lane.spec.dim.map(|value| value.to_string()).as_deref(),
+        );
+        set_env(LOCAL_EMBEDDING_POOLING_ENV, lane.spec.pooling.as_deref());
+        set_env(
+            LOCAL_EMBEDDING_MAX_LENGTH_ENV,
+            lane.spec
+                .max_length
+                .map(|value| value.to_string())
+                .as_deref(),
+        );
+        set_env(
+            LOCAL_EMBEDDING_QUERY_PREFIX_ENV,
+            lane.spec.query_prefix.as_deref(),
+        );
+        set_env(
+            LOCAL_EMBEDDING_DOCUMENT_PREFIX_ENV,
+            lane.spec.document_prefix.as_deref(),
+        );
+    } else if lane.backend == Some(InferenceBackend::Api) {
+        if let Some(model_id) = lane.spec.model_id.as_deref() {
+            set_env("EMBEDDING_MODEL_ID", Some(model_id));
+        }
+        if lane.spec.query_prefix.is_some() {
+            set_env("EMBEDDING_QUERY_PREFIX", lane.spec.query_prefix.as_deref());
+        }
+    }
+
+    guard
+}
+
+fn has_local_model_overrides(lane: &ResolvedLane) -> bool {
+    lane.spec.repo.is_some()
+        || lane.spec.dir.is_some()
+        || lane.spec.onnx_file.is_some()
+        || lane.spec.onnx_data_file.is_some()
+        || lane.spec.no_onnx_data
+        || lane.spec.tokenizer_file.is_some()
+        || lane.spec.pooling.is_some()
+        || lane.spec.query_prefix.is_some()
+        || lane.spec.document_prefix.is_some()
+        || lane.spec.dim.is_some()
+        || lane.spec.max_length.is_some()
+}
+
+pub struct LaneEnvGuard {
+    values: Vec<(String, Option<OsString>)>,
+}
+
+impl LaneEnvGuard {
+    fn new(keys: Vec<String>) -> Self {
+        Self {
+            values: keys
+                .into_iter()
+                .map(|key| {
+                    let value = std::env::var_os(&key);
+                    (key, value)
+                })
+                .collect(),
+        }
+    }
+}
+
+impl Drop for LaneEnvGuard {
+    fn drop(&mut self) {
+        for (key, value) in &self.values {
+            set_env_os(key, value.as_ref());
+        }
+    }
+}
+
+fn set_env(key: &str, value: Option<&str>) {
+    set_env_os(key, value.map(OsString::from).as_ref());
+}
+
+fn set_env_os(key: &str, value: Option<&OsString>) {
+    unsafe {
+        match value {
+            Some(value) => std::env::set_var(key, value),
+            None => std::env::remove_var(key),
+        }
+    }
+}
+
+/// Summarize relevant runtime environment without emitting credentials.
+pub fn environment_summary(lane: &ResolvedLane) -> BTreeMap<String, String> {
+    let keys: HashSet<&str> = PROVENANCE_ENV_KEYS
+        .iter()
+        .copied()
+        .chain(lane.spec.environment.keys().map(String::as_str))
+        .chain(LOCAL_MODEL_ENV_KEYS.iter().copied())
+        .collect();
+    environment_summary_for_keys(keys)
+}
+
+/// Summarize the evaluator's relevant process environment for non-model lanes.
+pub fn process_environment_summary() -> BTreeMap<String, String> {
+    environment_summary_for_keys(
+        PROVENANCE_ENV_KEYS
+            .iter()
+            .copied()
+            .chain(LOCAL_MODEL_ENV_KEYS.iter().copied())
+            .collect(),
+    )
+}
+
+fn environment_summary_for_keys(keys: HashSet<&str>) -> BTreeMap<String, String> {
+    let mut summary = BTreeMap::new();
+    for key in keys {
+        let value = std::env::var(key).unwrap_or_else(|_| "<unset>".to_string());
+        let value = if key.contains("KEY") || key.contains("TOKEN") || key.contains("SECRET") {
+            if value == "<unset>" {
+                value
+            } else {
+                "<redacted>".to_string()
+            }
+        } else {
+            value
+        };
+        summary.insert(key.to_string(), value);
+    }
+    summary
+}
+
+/// Hash the sorted task IDs, not their ground truth, so slicing never changes
+/// the benchmark definition.
+pub fn task_set_identity(tasks: &[BenchmarkTask]) -> TaskSetIdentity {
+    let mut ids: Vec<&str> = tasks.iter().map(|task| task.id.as_str()).collect();
+    ids.sort_unstable();
+    let mut hasher = Sha256::new();
+    for id in &ids {
+        hasher.update(id.as_bytes());
+        hasher.update(b"\n");
+    }
+    let digest = hasher.finalize();
+    TaskSetIdentity {
+        count: ids.len(),
+        task_ids_sha256: digest.iter().map(|byte| format!("{byte:02x}")).collect(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn presets_keep_legacy_lane_names() {
+        for name in ["vera-bm25", "vera-cuda", "vera-cpu", "vera-potion"] {
+            let lane = resolve(preset(name).unwrap()).unwrap();
+            assert_eq!(lane.name(), name);
+        }
+    }
+
+    #[test]
+    fn custom_onnx_defaults_to_cpu() {
+        let lane = resolve(LaneSpec {
+            name: "candidate".to_string(),
+            backend: "custom-onnx".to_string(),
+            repo: Some("org/model".to_string()),
+            rerank: false,
+            ..preset("vera-cpu").unwrap()
+        })
+        .unwrap();
+        assert_eq!(
+            lane.backend,
+            Some(InferenceBackend::OnnxJina(OnnxExecutionProvider::Cpu))
+        );
+    }
+
+    #[test]
+    fn task_identity_ignores_ground_truth_and_order() {
+        let mut a = BenchmarkTask {
+            id: "b".to_string(),
+            query: String::new(),
+            category: crate::types::TaskCategory::Intent,
+            repo: "repo".to_string(),
+            ground_truth: Vec::new(),
+            description: String::new(),
+        };
+        let mut b = a.clone();
+        b.id = "a".to_string();
+        let first = task_set_identity(&[a.clone(), b.clone()]);
+        a.ground_truth.push(crate::types::GroundTruthEntry {
+            file_path: "different".to_string(),
+            line_start: 1,
+            line_end: 1,
+            relevance: 1,
+        });
+        let second = task_set_identity(&[b, a]);
+        assert_eq!(first.count, 2);
+        assert_eq!(first.task_ids_sha256, second.task_ids_sha256);
+    }
+
+    #[test]
+    fn parses_json_wrapper_and_toml_shape() {
+        let dir = tempfile::tempdir().unwrap();
+        let json_path = dir.path().join("lanes.json");
+        std::fs::write(
+            &json_path,
+            r#"{"lanes":[{"name":"cpu","backend":"onnx-jina-cpu","rerank":false}]}"#,
+        )
+        .unwrap();
+        assert_eq!(load_file(&json_path).unwrap().len(), 1);
+
+        let toml_path = dir.path().join("lanes.toml");
+        std::fs::write(
+            &toml_path,
+            "[[lanes]]\nname = \"cpu\"\nbackend = \"onnx-jina-cpu\"\nrerank = false\n",
+        )
+        .unwrap();
+        assert_eq!(load_file(&toml_path).unwrap().len(), 1);
+    }
+}

--- a/eval/src/lanes.rs
+++ b/eval/src/lanes.rs
@@ -125,7 +125,11 @@ impl ResolvedLane {
     }
 
     pub fn rerank(&self) -> bool {
-        self.spec.rerank && !matches!(self.backend, Some(InferenceBackend::PotionCode))
+        self.spec.rerank
+            && matches!(
+                self.backend,
+                Some(InferenceBackend::Api | InferenceBackend::OnnxJina(_))
+            )
     }
 
     /// Resolve the effective model settings after [`LaneEnvGuard`] is active.
@@ -330,7 +334,13 @@ pub fn resolve(spec: LaneSpec) -> Result<ResolvedLane> {
 
     let backend_name = spec.backend.trim().to_ascii_lowercase();
     let backend = match backend_name.as_str() {
-        "bm25" => None,
+        "bm25" => {
+            reject_local_fields(&spec, "bm25")?;
+            if spec.repo.is_some() || spec.dir.is_some() {
+                anyhow::bail!("lane '{}' BM25 backend cannot set repo or dir", spec.name);
+            }
+            None
+        }
         "api" => {
             reject_local_fields(&spec, "api")?;
             if spec.repo.is_some() || spec.dir.is_some() {
@@ -391,7 +401,8 @@ fn reject_local_fields(spec: &LaneSpec, backend: &str) -> Result<()> {
 }
 
 fn parse_execution_provider(value: Option<&str>) -> Result<OnnxExecutionProvider> {
-    let value = value.unwrap_or("cpu");
+    let value = value.map(str::trim).map(str::to_ascii_lowercase);
+    let value = value.as_deref().unwrap_or("cpu");
     let backend = if value.starts_with("onnx-jina-") {
         value.to_string()
     } else {

--- a/eval/src/main.rs
+++ b/eval/src/main.rs
@@ -270,9 +270,9 @@ fn run_lane(
     lane: &lanes::ResolvedLane,
 ) -> Result<types::EvalReport> {
     let _env = lanes::apply_environment(lane);
+    let corpus = load_verified_corpus(corpus_path)?;
+    let tasks = filter_tasks_to_corpus(tasks, &corpus.repo_paths)?;
     let (mut report, evaluated_tasks) = if lane.is_bm25() {
-        let corpus = load_verified_corpus(corpus_path)?;
-        let tasks = filter_tasks_to_corpus(tasks, &corpus.repo_paths)?;
         let vera = vera_adapter::VeraBm25Adapter::new()?;
         let report = runner::run_benchmark_scoped(
             &vera,
@@ -283,8 +283,6 @@ fn run_lane(
         );
         (report, tasks)
     } else {
-        let corpus = load_verified_corpus(corpus_path)?;
-        let tasks = filter_tasks_to_corpus(tasks, &corpus.repo_paths)?;
         let backend = lane.backend.expect("non-BM25 lane must have a backend");
         let vera =
             vera_adapter::VeraFullAdapter::new_with_options(backend, lane.rerank(), lane.name())?;

--- a/eval/src/main.rs
+++ b/eval/src/main.rs
@@ -7,6 +7,7 @@
 //!   vera-eval run [--tasks-dir <path>] [--output <path>] [--tool <name>]
 //!   vera-eval verify-corpus [--corpus <path>]
 
+mod lanes;
 mod loader;
 mod metrics;
 mod output;
@@ -15,10 +16,10 @@ mod types;
 mod vera_adapter;
 
 use anyhow::{Context, Result};
-use clap::{Parser, Subcommand};
-use std::collections::HashMap;
+use clap::{ArgAction, Parser, Subcommand};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::path::{Path, PathBuf};
-use vera_core::config::{InferenceBackend, OnnxExecutionProvider};
+use std::process::Command;
 
 #[derive(Parser)]
 #[command(name = "vera-eval", about = "Vera evaluation harness")]
@@ -48,6 +49,18 @@ enum Commands {
         #[arg(long, default_value = "vera-bm25")]
         tool: String,
 
+        /// JSON or TOML file containing one or more model lanes.
+        #[arg(long = "lane-spec", alias = "lanes")]
+        lane_spec: Option<PathBuf>,
+
+        /// Run only these task IDs. Repeat the flag or separate IDs with commas.
+        #[arg(long = "task-id", value_delimiter = ',', action = ArgAction::Append)]
+        task_ids: Vec<String>,
+
+        /// Run only these task categories. Repeat the flag or separate values with commas.
+        #[arg(long = "category", value_delimiter = ',', action = ArgAction::Append)]
+        categories: Vec<String>,
+
         /// Suppress human-readable summary (JSON only).
         #[arg(long)]
         json_only: bool,
@@ -69,17 +82,33 @@ fn main() -> Result<()> {
             corpus,
             output,
             tool,
+            lane_spec,
+            task_ids,
+            categories,
             json_only,
-        } => cmd_run(&tasks_dir, &corpus, output.as_deref(), &tool, json_only),
+        } => cmd_run(
+            &tasks_dir,
+            &corpus,
+            output.as_deref(),
+            &tool,
+            lane_spec.as_deref(),
+            &task_ids,
+            &categories,
+            json_only,
+        ),
         Commands::VerifyCorpus { corpus } => cmd_verify_corpus(&corpus),
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn cmd_run(
     tasks_dir: &Path,
     corpus_path: &Path,
     output_path: Option<&Path>,
     tool_name: &str,
+    lane_spec_path: Option<&Path>,
+    task_ids: &[String],
+    categories: &[String],
     json_only: bool,
 ) -> Result<()> {
     // Load tasks
@@ -90,22 +119,49 @@ fn cmd_run(
         anyhow::bail!("No benchmark tasks found in {}", tasks_dir.display());
     }
 
+    let tasks = filter_tasks(tasks, task_ids, categories)?;
+
     eprintln!("Loaded {} benchmark tasks", tasks.len());
 
-    let report = run_report(tasks, corpus_path, tool_name)?;
+    let reports = if let Some(path) = lane_spec_path {
+        if tool_name != "vera-bm25" {
+            anyhow::bail!("--lane-spec cannot be combined with --tool {tool_name}");
+        }
+        let specs = lanes::load_file(path)?;
+        let resolved = lanes::resolve_specs(specs)?;
+        resolved
+            .iter()
+            .map(|lane| run_lane(tasks.clone(), corpus_path, lane))
+            .collect::<Result<Vec<_>>>()?
+    } else if let Some(spec) = lanes::preset(tool_name) {
+        let lane = lanes::resolve(spec)?;
+        vec![run_lane(tasks, corpus_path, &lane)?]
+    } else if matches!(tool_name, "mock-perfect" | "mock-partial") {
+        vec![run_mock(tasks, tool_name)?]
+    } else {
+        anyhow::bail!(
+            "Unknown tool '{}'. Available: vera-bm25, vera-cuda, vera-cpu, vera-potion, mock-perfect, mock-partial; or pass --lane-spec.",
+            tool_name
+        );
+    };
 
     // Output JSON
     if let Some(path) = output_path {
-        output::write_json_report(&report, path)?;
+        output::write_json_reports(&reports, path)?;
         eprintln!("JSON report written to {}", path.display());
     } else if json_only {
-        let json = output::report_to_json(&report)?;
+        let json = output::reports_to_json(&reports)?;
         println!("{json}");
     }
 
     // Print human-readable summary
     if !json_only {
-        output::print_summary(&report, &mut std::io::stderr())?;
+        for (index, report) in reports.iter().enumerate() {
+            if index > 0 {
+                eprintln!("\n{}\n", "=".repeat(80));
+            }
+            output::print_summary(report, &mut std::io::stderr())?;
+        }
     }
 
     Ok(())
@@ -208,66 +264,127 @@ fn filter_tasks_to_corpus(
     Ok(filtered)
 }
 
-fn run_report(
+fn run_lane(
     tasks: Vec<types::BenchmarkTask>,
     corpus_path: &Path,
-    tool_name: &str,
+    lane: &lanes::ResolvedLane,
 ) -> Result<types::EvalReport> {
-    Ok(match tool_name {
-        "mock-perfect" => {
-            let mock = runner::MockAdapter::perfect();
-            runner::run_benchmark_with_mock(&mock, &tasks)
-        }
-        "mock-partial" => {
-            let mock = runner::MockAdapter::partial(0.7);
-            runner::run_benchmark_with_mock(&mock, &tasks)
-        }
-        "vera-bm25" => {
-            let corpus = load_verified_corpus(corpus_path)?;
-            let tasks = filter_tasks_to_corpus(tasks, &corpus.repo_paths)?;
-            let vera = vera_adapter::VeraBm25Adapter::new()?;
-            runner::run_benchmark_scoped(
-                &vera,
-                &tasks,
-                &corpus.repo_paths,
-                &corpus.repo_shas,
-                &corpus.benchmark_roots,
-            )
-        }
-        "vera-cuda" => run_full_adapter(
-            tasks,
-            corpus_path,
-            InferenceBackend::OnnxJina(OnnxExecutionProvider::Cuda),
-        )?,
-        "vera-cpu" => run_full_adapter(
-            tasks,
-            corpus_path,
-            InferenceBackend::OnnxJina(OnnxExecutionProvider::Cpu),
-        )?,
-        "vera-potion" => run_full_adapter(tasks, corpus_path, InferenceBackend::PotionCode)?,
-        other => {
-            anyhow::bail!(
-                "Unknown tool '{}'. Available: vera-bm25, vera-cuda, vera-cpu, vera-potion, mock-perfect, mock-partial.",
-                other
-            );
-        }
-    })
+    let _env = lanes::apply_environment(lane);
+    let (mut report, evaluated_tasks) = if lane.is_bm25() {
+        let corpus = load_verified_corpus(corpus_path)?;
+        let tasks = filter_tasks_to_corpus(tasks, &corpus.repo_paths)?;
+        let vera = vera_adapter::VeraBm25Adapter::new()?;
+        let report = runner::run_benchmark_scoped(
+            &vera,
+            &tasks,
+            &corpus.repo_paths,
+            &corpus.repo_shas,
+            &corpus.benchmark_roots,
+        );
+        (report, tasks)
+    } else {
+        let corpus = load_verified_corpus(corpus_path)?;
+        let tasks = filter_tasks_to_corpus(tasks, &corpus.repo_paths)?;
+        let backend = lane.backend.expect("non-BM25 lane must have a backend");
+        let vera =
+            vera_adapter::VeraFullAdapter::new_with_options(backend, lane.rerank(), lane.name())?;
+        let report = runner::run_benchmark_scoped(
+            &vera,
+            &tasks,
+            &corpus.repo_paths,
+            &corpus.repo_shas,
+            &corpus.benchmark_roots,
+        );
+        (report, tasks)
+    };
+
+    let provenance = lane.provenance()?;
+    runner::attach_provenance(
+        &mut report,
+        Some(provenance.clone()),
+        lanes::task_set_identity(&evaluated_tasks),
+        lane.config_map(&provenance),
+        lanes::environment_summary(lane),
+        vera_git_sha(),
+        std::env::args().collect(),
+    );
+    Ok(report)
 }
 
-/// Run the full Vera pipeline (embedding + reranking) with the given backend.
-fn run_full_adapter(
+fn run_mock(tasks: Vec<types::BenchmarkTask>, tool_name: &str) -> Result<types::EvalReport> {
+    let mut report = match tool_name {
+        "mock-perfect" => runner::run_benchmark_with_mock(&runner::MockAdapter::perfect(), &tasks),
+        "mock-partial" => {
+            runner::run_benchmark_with_mock(&runner::MockAdapter::partial(0.7), &tasks)
+        }
+        _ => unreachable!("mock tool validated by caller"),
+    };
+    runner::attach_provenance(
+        &mut report,
+        None,
+        lanes::task_set_identity(&tasks),
+        BTreeMap::new(),
+        lanes::process_environment_summary(),
+        vera_git_sha(),
+        std::env::args().collect(),
+    );
+    Ok(report)
+}
+
+fn filter_tasks(
     tasks: Vec<types::BenchmarkTask>,
-    corpus_path: &Path,
-    backend: InferenceBackend,
-) -> Result<types::EvalReport> {
-    let corpus = load_verified_corpus(corpus_path)?;
-    let tasks = filter_tasks_to_corpus(tasks, &corpus.repo_paths)?;
-    let vera = vera_adapter::VeraFullAdapter::new(backend)?;
-    Ok(runner::run_benchmark_scoped(
-        &vera,
-        &tasks,
-        &corpus.repo_paths,
-        &corpus.repo_shas,
-        &corpus.benchmark_roots,
-    ))
+    task_ids: &[String],
+    categories: &[String],
+) -> Result<Vec<types::BenchmarkTask>> {
+    if task_ids.is_empty() && categories.is_empty() {
+        return Ok(tasks);
+    }
+
+    let requested_ids: HashSet<&str> = task_ids.iter().map(String::as_str).collect();
+    let requested_categories = categories
+        .iter()
+        .map(|category| parse_category(category))
+        .collect::<Result<HashSet<_>>>()?;
+    let known_ids: HashSet<&str> = tasks.iter().map(|task| task.id.as_str()).collect();
+    let unknown_ids: Vec<_> = requested_ids.difference(&known_ids).copied().collect();
+    if !unknown_ids.is_empty() {
+        anyhow::bail!("unknown task ID(s): {}", unknown_ids.join(", "));
+    }
+
+    let filtered: Vec<_> = tasks
+        .into_iter()
+        .filter(|task| {
+            let id_match = requested_ids.is_empty() || requested_ids.contains(task.id.as_str());
+            let category_match =
+                requested_categories.is_empty() || requested_categories.contains(&task.category);
+            id_match && category_match
+        })
+        .collect();
+    if filtered.is_empty() {
+        anyhow::bail!("No benchmark tasks match the requested filters");
+    }
+    Ok(filtered)
+}
+
+fn parse_category(value: &str) -> Result<types::TaskCategory> {
+    match value.trim().to_ascii_lowercase().replace('-', "_").as_str() {
+        "symbol_lookup" => Ok(types::TaskCategory::SymbolLookup),
+        "intent" => Ok(types::TaskCategory::Intent),
+        "cross_file" => Ok(types::TaskCategory::CrossFile),
+        "config" => Ok(types::TaskCategory::Config),
+        "disambiguation" => Ok(types::TaskCategory::Disambiguation),
+        other => anyhow::bail!(
+            "unknown task category '{other}'; expected symbol_lookup, intent, cross_file, config, or disambiguation"
+        ),
+    }
+}
+
+fn vera_git_sha() -> Option<String> {
+    let output = Command::new("git")
+        .args(["rev-parse", "HEAD"])
+        .output()
+        .ok()
+        .filter(|output| output.status.success())?;
+    let sha = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    (!sha.is_empty()).then_some(sha)
 }

--- a/eval/src/output.rs
+++ b/eval/src/output.rs
@@ -8,9 +8,9 @@ use std::path::Path;
 
 use crate::types::EvalReport;
 
-/// Write the evaluation report as JSON to a file.
-pub fn write_json_report(report: &EvalReport, path: &Path) -> Result<()> {
-    let json = serde_json::to_string_pretty(report)?;
+/// Write one report as an object or multiple reports as an array.
+pub fn write_json_reports(reports: &[EvalReport], path: &Path) -> Result<()> {
+    let json = reports_to_json(reports)?;
     std::fs::write(path, &json)?;
     Ok(())
 }
@@ -18,6 +18,14 @@ pub fn write_json_report(report: &EvalReport, path: &Path) -> Result<()> {
 /// Serialize the evaluation report to a JSON string.
 pub fn report_to_json(report: &EvalReport) -> Result<String> {
     Ok(serde_json::to_string_pretty(report)?)
+}
+
+/// Serialize one report as an object or multiple reports as an array.
+pub fn reports_to_json(reports: &[EvalReport]) -> Result<String> {
+    match reports {
+        [report] => report_to_json(report),
+        _ => Ok(serde_json::to_string_pretty(reports)?),
+    }
 }
 
 /// Print a human-readable summary of the evaluation report.
@@ -210,6 +218,11 @@ mod tests {
                 corpus_version: 1,
                 repo_shas: HashMap::from([("ripgrep".to_string(), "abc123".to_string())]),
                 config: HashMap::new(),
+                lane: None,
+                task_set: None,
+                vera_git_sha: None,
+                command: Vec::new(),
+                environment: Default::default(),
             },
             per_task: vec![TaskEvaluation {
                 task_id: "test-001".to_string(),
@@ -303,13 +316,21 @@ mod tests {
     }
 
     #[test]
-    fn test_write_json_report() {
+    fn test_write_json_reports() {
         let report = sample_report();
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("report.json");
-        write_json_report(&report, &path).unwrap();
+        write_json_reports(std::slice::from_ref(&report), &path).unwrap();
 
         let content = std::fs::read_to_string(&path).unwrap();
         let _: EvalReport = serde_json::from_str(&content).unwrap();
+    }
+
+    #[test]
+    fn test_multiple_reports_are_written_as_an_array() {
+        let report = sample_report();
+        let json = reports_to_json(&[report.clone(), report]).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.as_array().unwrap().len(), 2);
     }
 }

--- a/eval/src/runner.rs
+++ b/eval/src/runner.rs
@@ -3,13 +3,13 @@
 //! Provides a `ToolAdapter` trait that tool integrations implement,
 //! plus a mock adapter for harness self-testing.
 
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::time::Instant;
 
 use crate::metrics;
 use crate::types::{
-    AggregateMetrics, BenchmarkTask, EvalReport, PerformanceMetrics, RetrievalResult,
-    TaskEvaluation, TaskResult, VersionInfo,
+    AggregateMetrics, BenchmarkTask, EvalReport, LaneProvenance, PerformanceMetrics,
+    RetrievalResult, TaskEvaluation, TaskResult, TaskSetIdentity, VersionInfo,
 };
 
 /// Trait for tool adapters that execute search queries.
@@ -47,6 +47,24 @@ pub fn run_benchmark(
     corpus_shas: &HashMap<String, String>,
 ) -> EvalReport {
     run_benchmark_scoped(adapter, tasks, repo_paths, corpus_shas, &HashMap::new())
+}
+
+/// Add invocation metadata to a completed report.
+pub fn attach_provenance(
+    report: &mut EvalReport,
+    lane: Option<LaneProvenance>,
+    task_set: TaskSetIdentity,
+    config: BTreeMap<String, String>,
+    environment: BTreeMap<String, String>,
+    vera_git_sha: Option<String>,
+    command: Vec<String>,
+) {
+    report.version_info.lane = lane;
+    report.version_info.task_set = Some(task_set);
+    report.version_info.environment = environment;
+    report.version_info.vera_git_sha = vera_git_sha;
+    report.version_info.command = command;
+    report.version_info.config.extend(config);
 }
 
 /// Run benchmark with optional per-repo path scopes (benchmark_root).
@@ -108,6 +126,11 @@ pub fn run_benchmark_scoped(
             corpus_version: 1,
             repo_shas: corpus_shas.clone(),
             config: HashMap::new(),
+            lane: None,
+            task_set: None,
+            vera_git_sha: None,
+            command: Vec::new(),
+            environment: BTreeMap::new(),
         },
         per_task,
         per_category,
@@ -261,6 +284,11 @@ pub fn run_benchmark_with_mock(mock: &MockAdapter, tasks: &[BenchmarkTask]) -> E
                 ("accuracy".to_string(), mock.accuracy.to_string()),
                 ("noise_results".to_string(), mock.noise_results.to_string()),
             ]),
+            lane: None,
+            task_set: None,
+            vera_git_sha: None,
+            command: Vec::new(),
+            environment: BTreeMap::new(),
         },
         per_task,
         per_category,

--- a/eval/src/types.rs
+++ b/eval/src/types.rs
@@ -4,7 +4,7 @@
 //! and the overall evaluation report.
 
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 
 /// A single benchmark task: a query with ground truth expectations.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -176,6 +176,62 @@ pub struct VersionInfo {
     /// Configuration parameters (key -> value).
     #[serde(default)]
     pub config: HashMap<String, String>,
+    /// Resolved model lane configuration.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub lane: Option<LaneProvenance>,
+    /// Identity of the task slice evaluated by this report.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub task_set: Option<TaskSetIdentity>,
+    /// Vera source revision used for the run.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub vera_git_sha: Option<String>,
+    /// Process arguments used to invoke the evaluator.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub command: Vec<String>,
+    /// Relevant environment values after lane overrides, with secrets redacted.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub environment: BTreeMap<String, String>,
+}
+
+/// Resolved configuration for one benchmark lane.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LaneProvenance {
+    pub name: String,
+    pub backend: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub execution_provider: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model_repo: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model_dir: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model_revision: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub onnx_file: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub onnx_data_file: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tokenizer_file: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pooling: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub query_prefix: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub document_prefix: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub dim: Option<usize>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_length: Option<usize>,
+    pub rerank: bool,
+}
+
+/// Stable identity for the selected task IDs.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TaskSetIdentity {
+    pub count: usize,
+    pub task_ids_sha256: String,
 }
 
 /// Corpus manifest parsed from corpus.toml.

--- a/eval/src/vera_adapter.rs
+++ b/eval/src/vera_adapter.rs
@@ -204,19 +204,29 @@ pub struct VeraFullAdapter {
     runtime: Runtime,
     config: VeraConfig,
     backend: InferenceBackend,
+    name: String,
     search_context: SearchContext,
 }
 
 impl VeraFullAdapter {
-    pub fn new(backend: InferenceBackend) -> anyhow::Result<Self> {
+    pub fn new_with_options(
+        backend: InferenceBackend,
+        reranking_enabled: bool,
+        name: impl Into<String>,
+    ) -> anyhow::Result<Self> {
         let mut config = VeraConfig::default();
+        config.retrieval.reranking_enabled = reranking_enabled;
         config.adjust_for_backend(backend);
         let runtime = Runtime::new()?;
         let search_context = runtime.block_on(SearchContext::new(&config, backend));
+        if search_context.embedding_provider().is_none() {
+            anyhow::bail!("failed to initialize the embedding provider for backend {backend}");
+        }
         Ok(Self {
             runtime,
             config,
             backend,
+            name: name.into(),
             search_context,
         })
     }
@@ -224,7 +234,7 @@ impl VeraFullAdapter {
 
 impl ToolAdapter for VeraFullAdapter {
     fn name(&self) -> &str {
-        "vera-full"
+        &self.name
     }
 
     fn version(&self) -> String {


### PR DESCRIPTION
## Summary
- Lane specs via JSON/TOML (`--lane-spec` / `--lanes`): each lane declares backend (api, potion, onnx-jina-*, custom-onnx, bm25), model source (repo/dir + revision), pooling, query/document prefixes, dim, max_length, and rerank on/off. The four existing lanes (vera-bm25, vera-cuda, vera-cpu, vera-potion) remain as named presets.
- Task slicing with repeatable `--task-id` / `--category` filters; unknown or empty selections fail loudly. Task-set identity is a SHA-256 over sorted task IDs, so slicing never touches ground truth.
- Every report now carries full provenance per lane: model id/repo/revision, backend, execution provider, pooling, prefixes, dims, max_length, rerank flag, Vera git SHA, command, and redacted environment.
- Benchmark Python scripts gained the same task slicing and provenance; partial runs skip assertions that need unavailable modes.

This is plumbing for candidate screening (Harrier/BitNet vs current controls); it changes no ranking behavior and follows the benchmark-integrity rules (no ground-truth inspection, no per-task tuning).

## Test plan
- `cargo test -p vera-eval` (40 passed)
- `cargo clippy -p vera-eval --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- Python: py_compile + task-filter/deterministic-hash smoke test
- Full corpus run intentionally not executed here; requires the benchmark corpus and candidate model assets.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Configurable model lanes, deterministic task slicing, and full per-run provenance for `vera-eval`, with matching Python benchmark updates. Enables auditable partial runs and candidate model screening without touching tasks or ground truth.

- Adds `--lane-spec`/`--lanes` (JSON/TOML) to define lanes (backend, model source/revision, pooling, prefixes, dim, max_length, rerank). Preserves presets: `vera-bm25`, `vera-cuda`, `vera-cpu`, `vera-potion`.
- Adds `--task-id` and `--category` filters; unknown/empty selections fail. Task-set identity is a SHA-256 over sorted task IDs (no ground-truth inspection).
- Each report now records lane provenance, `vera_git_sha`, command, and a redacted environment summary; JSON output becomes an array when multiple lanes are requested. Human-readable summaries print per lane.
- Python benchmarks gain the same task filters and provenance; assertions that require omitted lanes are skipped during partial runs.
- Validation and behavior fixes: reject local-model fields on `bm25`/`api` lanes, normalize `execution_provider` names, only report rerank=true for rerank-capable backends, and avoid duplicate corpus-loading paths.

**Migration**
- If you parse the JSON report, handle either a single object or an array when multiple lanes are run.
- Update Python runner usage to `--modes` (plural). Optional: adopt `--task-id`/`--category`.
- Remove local ONNX fields from `bm25`/`api` lanes (now error). For `custom-onnx`, set the provider via `execution_provider` (e.g., `cuda`, `rocm`), or use `onnx-jina-*` backends directly.
- If you rely on assertions from the Python runner, note that sliced runs may skip checks when comparison lanes are not present.

<sup>Written for commit 6e57472d90f58be3f0d0efd1eeef58f1b36fd88e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/VeraTools/Vera/pull/141?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable benchmark lanes for BM25, model-based, mock, and custom backends.
  * Added task-ID and category filtering, including multi-select command-line options.
  * Added support for running and exporting multiple benchmark reports.
  * Reports now include task-set identity, lane configuration, command, revision, and redacted environment details.
  * Added JSON/TOML lane configuration and validation.

* **Documentation**
  * Expanded benchmark documentation with lane setup, partial runs, filtering, and report guidance.

* **Bug Fixes**
  * Improved validation for unknown tasks, empty results, missing providers, and unavailable benchmark lanes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->