### PR TITLE
fix(retrieval): stop slice panic when ']' precedes '[' in completion replies

### DIFF
--- a/crates/vera-core/src/retrieval/completion_client.rs
+++ b/crates/vera-core/src/retrieval/completion_client.rs
@@ -277,8 +277,14 @@ fn parse_query_candidates(raw: &str, limit: usize) -> Result<Vec<String>> {
     }
 
     // Try extracting a JSON array from within the response (e.g. fenced code blocks).
-    if let Some((start, end)) = raw.find('[').zip(raw.rfind(']')) {
-        let candidate = &raw[start..=end];
+    // `find` and `rfind` resolve independently: a reply whose last `]` precedes its
+    // first `[` must fall through to the error below, not panic on the slice.
+    if let Some(candidate) = raw
+        .find('[')
+        .zip(raw.rfind(']'))
+        .filter(|(start, end)| end >= start)
+        .and_then(|(start, end)| raw.get(start..=end))
+    {
         if let Ok(value) = serde_json::from_str::<serde_json::Value>(candidate) {
             if let Some(parsed) = json_value_to_queries(&value) {
                 return Ok(normalize_query_list(parsed, limit));
@@ -378,6 +384,14 @@ mod tests {
     #[test]
     fn non_json_returns_error() {
         let raw = "1. auth token refresh\n2) jwt expiry handling";
+        assert!(parse_query_candidates(raw, 4).is_err());
+    }
+
+    /// A reply whose last `]` sits before its first `[` used to panic on
+    /// `&raw[start..=end]`; it must return the normal parse error instead.
+    #[test]
+    fn closing_bracket_before_opening_bracket_returns_error() {
+        let raw = "array done] here comes [\"q1\"";
         assert!(parse_query_candidates(raw, 4).is_err());
     }
 


### PR DESCRIPTION
Closes #143.

## Problem

`parse_query_candidates` extracted a JSON array from a free-form completion by locating the first `[` and last `]` independently, then slicing `&raw[start..=end]`. When a reply's last `]` precedes its first `[` (truncated output, prose mentioning an array), the slice panicked instead of returning the `Err` the surrounding defensive parser is designed to produce, killing the whole deep-search command.

## Fix

Slice through `str::get` with an explicit `end >= start` ordering guard; anything that does not form a valid range falls through to the existing "not a JSON array" error, which callers already treat as the fallback-to-iterative-search signal.

## Verification

Ran locally on this branch (`cargo test -p vera-core --lib completion_client`):

- New test `closing_bracket_before_opening_bracket_returns_error`:
  - **Without the fix (reverted, test kept):** fails with the real production panic — `byte range starts at 23 but ends at 11` (reinjection check).
  - **With the fix:** passes; returns `Err` as intended.
- Full module suite: 6 passed, 0 failed.
- `cargo fmt -p vera-core --check`: clean.
- `cargo clippy -p vera-core --lib`: only the 5 pre-existing warnings documented in CLAUDE.md (`pip_package_for_ep`, `CUDA_RUNTIME_LIBRARY_PREFIXES`, `parse_cuda_major_from_runtime_library_entry`, unused import, unused variable).

Not run: end-to-end deep search against a live completion endpoint (the unit test pins the exact panic input; the surrounding fallback path is unchanged).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents a panic when parsing completion replies where a closing bracket appears before an opening bracket. Previously `parse_query_candidates` sliced between the first `[` and last `]`, which could panic; now it guards the range and uses `str::get`, returning the normal parse error so deep-search falls back as intended.

- Change is scoped to `parse_query_candidates`; successful parse behavior is unchanged.
- Adds a unit test that reproduces the prior panic and verifies the error path.
- No migrations or config changes.

<sup>Written for commit 54e6b6176b836cf174e5adb78994d83c6bb9b8f9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/VeraTools/Vera/pull/144?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of malformed response data.
  * Prevented errors when JSON brackets appear in an invalid order.
  * Added coverage for this edge case to improve reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->