### PR TITLE
fix(retrieval): pick deep-search follow-up symbols deterministically

### DIFF
--- a/crates/vera-core/src/retrieval/iterative_search.rs
+++ b/crates/vera-core/src/retrieval/iterative_search.rs
@@ -13,6 +13,29 @@ use crate::types::{SearchFilters, SearchResult};
 use super::query_utils::result_key;
 use super::search_service::{SearchContext, SearchTimings};
 
+/// Follow-up symbols for the next hop: deduped, generic noise names skipped,
+/// capped at five, in first-appearance order of the ranked initial results.
+/// A `HashSet` round-trip here used to make the choice process-random whenever
+/// more than five distinct symbols qualified, so two runs of the identical
+/// query could search different second hops and return different results.
+fn follow_up_symbols_from(initial_results: &[SearchResult]) -> Vec<String> {
+    let mut seen = HashSet::new();
+    initial_results
+        .iter()
+        .filter_map(|r| r.symbol_name.clone())
+        .filter(|name| {
+            let lower = name.to_ascii_lowercase();
+            // Skip generic names that would produce noisy results.
+            !matches!(
+                lower.as_str(),
+                "main" | "new" | "default" | "test" | "init" | "run" | "setup"
+            )
+        })
+        .filter(|name| seen.insert(name.clone()))
+        .take(5)
+        .collect()
+}
+
 /// Run an iterative (multi-hop) search.
 ///
 /// 1. Execute the initial query via `context.search`.
@@ -50,22 +73,10 @@ pub async fn execute_iterative_search_with_context(
         }
     }
 
-    // Extract symbol names from initial results for follow-up queries.
-    let follow_up_symbols: Vec<String> = initial_results
-        .iter()
-        .filter_map(|r| r.symbol_name.clone())
-        .filter(|name| {
-            let lower = name.to_ascii_lowercase();
-            // Skip generic names that would produce noisy results.
-            !matches!(
-                lower.as_str(),
-                "main" | "new" | "default" | "test" | "init" | "run" | "setup"
-            )
-        })
-        .collect::<HashSet<_>>()
-        .into_iter()
-        .take(5)
-        .collect();
+    // Extract symbol names from initial results for follow-up queries, keeping
+    // ranked first-appearance order so the same query picks the same symbols
+    // in every process.
+    let follow_up_symbols = follow_up_symbols_from(&initial_results);
 
     for symbol in &follow_up_symbols {
         let (hop_results, _) = context
@@ -89,4 +100,68 @@ pub async fn execute_iterative_search_with_context(
 
     merged.truncate(result_limit);
     Ok((merged, timings))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn result_with_symbol(name: &str) -> SearchResult {
+        SearchResult {
+            file_path: format!("src/{name}.rs"),
+            line_start: 1,
+            line_end: 10,
+            content: format!("fn {name}() {{}}"),
+            language: crate::types::Language::Rust,
+            score: 1.0,
+            symbol_name: Some(name.to_string()),
+            symbol_type: None,
+        }
+    }
+
+    /// More than five qualifying symbols must select the first five in ranked
+    /// order, not a process-random subset (the old HashSet round-trip).
+    #[test]
+    fn follow_up_symbols_take_first_five_in_ranked_order() {
+        let results: Vec<_> = ["s1", "s2", "s3", "s4", "s5", "s6", "s7"]
+            .iter()
+            .map(|n| result_with_symbol(n))
+            .collect();
+
+        assert_eq!(
+            follow_up_symbols_from(&results),
+            vec!["s1", "s2", "s3", "s4", "s5"]
+        );
+    }
+
+    /// Duplicates and generic noise names are dropped without disturbing the
+    /// order of the survivors.
+    #[test]
+    fn follow_up_symbols_dedupe_and_skip_generic_names() {
+        let mut results = vec![
+            result_with_symbol("verify_token"),
+            result_with_symbol("main"),
+            result_with_symbol("session_store"),
+            result_with_symbol("verify_token"),
+        ];
+        // `main` sits between the two keepers: removing it must not reorder
+        // what is left.
+        results.insert(2, result_with_symbol("init"));
+
+        assert_eq!(
+            follow_up_symbols_from(&results),
+            vec!["verify_token", "session_store"]
+        );
+    }
+
+    /// A fixture with five or fewer qualifying symbols passes through intact.
+    #[test]
+    fn follow_up_symbols_keep_everything_at_or_under_the_cap() {
+        let results: Vec<_> = ["alpha", "beta"]
+            .iter()
+            .map(|n| result_with_symbol(n))
+            .collect();
+
+        assert_eq!(follow_up_symbols_from(&results), vec!["alpha", "beta"]);
+    }
 }


### PR DESCRIPTION
Closes #145.

## Problem

The follow-up symbols for deep search's second hop were deduped through a `HashSet` and capped with `.take(5)`. Whenever the initial results carried more than five distinct qualifying symbol names, the selection was process-random: two runs of the identical query could issue different second-hop searches and return genuinely different results (not just reordering). This also fed RAG fusion's fallback path, where different symbols mean different fused content.

## Fix

Dedupe while preserving first-appearance order of the ranked initial results (`HashSet` as seen-set only), then take five. Relevance order now decides instead of hash seeds. The selection logic is extracted into a pure `follow_up_symbols_from(&[SearchResult])` so it can be tested without a `SearchContext`.

## Verification

Ran locally on this branch:

- New tests (order under the cap; >5 cap takes first five in ranked order; dedupe + generic-name filtering):
  - **Against the old HashSet round-trip (reverted helper, tests kept):** all three fail (reinjection check).
  - **With the fix:** 3 passed.
- Full module suite: `cargo test -p vera-core --lib iterative_search` — 3 passed, 0 failed.
- `cargo fmt -p vera-core --check`: clean.
- `cargo clippy -p vera-core --lib`: only the 5 pre-existing warnings documented in CLAUDE.md.

Not run: end-to-end multi-hop deep search against a live index (the pure function pins the exact selection contract; the hop loop is unchanged apart from consuming its deterministic output).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make deep-search follow-up symbol selection deterministic. Old behavior deduped via a HashSet and took 5, yielding process-random symbols when >5 qualified; new behavior preserves first-appearance order of ranked results, then takes the first 5. This stabilizes second-hop queries and downstream fusion content.

- Extracts selection into a pure function follow_up_symbols_from that dedupes in order and skips generic names (e.g., main, init), then caps at five; `execute_iterative_search_with_context` now uses it.
- Adds unit tests covering order under the cap, >5 cap behavior, and dedupe plus generic-name filtering.
- Changes confined to `crates/vera-core/src/retrieval/iterative_search.rs`; no API or config changes.

<sup>Written for commit c7aa256c73ec0cf7abcabbd9b626e9ca52f9c9da. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/VeraTools/Vera/pull/146?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved iterative search to identify relevant follow-up symbols in a consistent ranked order.
  * Removed duplicate and overly generic symbol names from follow-up results.
  * Limited follow-up suggestions to a maximum of five items.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->