### PR TITLE
fix(cli): treat empty and whitespace-only env vars as absent in doctor

### DIFF
--- a/crates/vera-cli/src/commands/doctor.rs
+++ b/crates/vera-cli/src/commands/doctor.rs
@@ -208,9 +208,21 @@ fn failed_check_names(checks: &[DoctorCheck]) -> Vec<&'static str> {
 }
 
 fn check_env_group(name: &'static str, keys: &[&'static str]) -> DoctorCheck {
+    check_env_group_with(name, keys, |key| std::env::var(key).ok())
+}
+
+/// Presence with validity: unset and empty/whitespace-only both count as
+/// absent, matching `setup::read_api_env_var`. An `EMBEDDING_MODEL_API_KEY=""`
+/// leftover in a shellrc used to score as present and earn an ok verdict for a
+/// configuration that cannot work.
+fn check_env_group_with(
+    name: &'static str,
+    keys: &[&'static str],
+    get: impl Fn(&str) -> Option<String>,
+) -> DoctorCheck {
     let present = keys
         .iter()
-        .filter(|key| std::env::var_os(key).is_some())
+        .filter(|key| get(key).is_some_and(|value| !value.trim().is_empty()))
         .count();
 
     let status = match present {
@@ -706,5 +718,46 @@ mod tests {
             "a warning must not fail the run: version-check, config-file, \
              saved-backend and current-index all warn on a healthy machine"
         );
+    }
+
+    #[test]
+    fn empty_env_values_count_as_absent_not_present() {
+        let keys = ["BASE_URL", "MODEL_ID", "API_KEY"];
+        let env = |key: &str| -> Option<String> {
+            match key {
+                "BASE_URL" => Some("https://api.example.com".into()),
+                // Shellrc leftovers: set but empty / whitespace-only.
+                "MODEL_ID" => Some(String::new()),
+                "API_KEY" => Some("   ".into()),
+                _ => None,
+            }
+        };
+
+        let check = check_env_group_with("embedding-api", &keys, env);
+
+        assert!(
+            matches!(check.status, CheckStatus::Fail),
+            "one valid value out of three must fail, got {:?}: {}",
+            check.status,
+            check.detail
+        );
+        assert_eq!(check.detail, "1/3 variables present");
+    }
+
+    #[test]
+    fn all_valid_env_values_score_ok() {
+        let keys = ["BASE_URL", "MODEL_ID"];
+        let check = check_env_group_with("embedding-api", &keys, |key| {
+            Some(format!("value-for-{key}"))
+        });
+
+        assert!(matches!(check.status, CheckStatus::Ok));
+    }
+
+    #[test]
+    fn no_env_values_at_all_warns() {
+        let check = check_env_group_with("embedding-api", &["BASE_URL"], |_| None);
+
+        assert!(matches!(check.status, CheckStatus::Warn));
     }
 }


### PR DESCRIPTION
Closes #147.

## Problem

`check_env_group` scored API variables with `std::env::var_os(key).is_some()`, i.e. presence only. `EMBEDDING_MODEL_API_KEY=""` (a shellrc leftover after revoking a key) counted as present and earned doctor's strongest positive verdict for a configuration that every consumer treats as unset: `setup::read_api_env_var` explicitly trims and filters empties, and a provider built from an empty base URL fails at request time. The inverse also misled: a healthy `vera setup --api` install showed `warn 0/3 variables present` because doctor never looked at the saved `config.embedding_api`.

## Fix

Presence now requires a non-blank value (`trim()` + non-empty), matching `read_api_env_var` semantics. The decision is extracted into `check_env_group_with` taking an injected getter, so the new tests drive it through a closure instead of mutating process environment variables (keeping clear of #140).

Scope note: this fixes the validity half of #147. Reporting the saved `config.embedding_api` state in API mode is a larger UX change and is deliberately not attempted here; the issue can stay open or be split if that half is still wanted after this lands.

## Verification

Ran locally on this branch:

- New test `empty_env_values_count_as_absent_not_present`:
  - **Without the fix (presence-only logic restored, test kept):** fails — empty values scored present, status Ok instead of Fail (reinjection check).
  - **With the fix:** passes: one valid value out of three reports `Fail`, detail `1/3 variables present`.
- Plus `all_valid_env_values_score_ok` and `no_env_values_at_all_warns` pinning the unchanged Ok/Warn paths.
- `cargo test -p vera-cli --bin vera doctor::`: 6 passed, 0 failed.
- `cargo fmt --check`: clean.
- `cargo clippy -p vera-cli --bin vera`: no new warnings (only pre-existing).

Not run: end-to-end `vera doctor` against a real API backend.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Doctor now treats empty and whitespace-only environment variables as absent, aligning with `setup::read_api_env_var`. Previously any set variable (including "") counted as present, so misconfigured API envs could show Ok; now only non-blank values count, which can change verdicts to Warn/Fail.

- Extracts the presence check into `check_env_group_with(getter)` to allow injected lookups in tests.
- Updates env presence logic to `trim()` and require non-empty values; adds tests for empty values, all valid, and none set.
- Does not change reporting of saved `config.embedding_api` in API mode.

<sup>Written for commit 3ef4e4091eaab491b5aeb3b2d7239803eca098e7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/VeraTools/Vera/pull/148?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved API environment checks to correctly identify unset, empty, and whitespace-only values as missing.
  * Added validation coverage for partially configured, fully configured, and unconfigured environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->