### PR TITLE
fix(cli): uninstall exits non-zero when installed skills could not be removed

### DIFF
--- a/crates/vera-cli/src/commands/uninstall.rs
+++ b/crates/vera-cli/src/commands/uninstall.rs
@@ -87,6 +87,7 @@ fn run_at(
     for error in &skill_removal.failures {
         writeln!(stderr, "  {error:#}")?;
     }
+    let complete = skill_removal.failures.is_empty();
     let removed_skills: Vec<&str> = skill_removal
         .reports
         .iter()
@@ -141,17 +142,46 @@ fn run_at(
             "{}",
             serde_json::json!({
                 "uninstalled": true,
+                "complete": complete,
                 "removed": removed,
                 "skills": removed_skills,
             })
         )?;
     } else {
         writeln!(stderr)?;
-        writeln!(stderr, "Vera has been uninstalled.")?;
+        if complete {
+            writeln!(stderr, "Vera has been uninstalled.")?;
+        } else {
+            writeln!(
+                stderr,
+                "Vera was partially uninstalled: {} installed skill{} could not be removed.",
+                skill_removal.failures.len(),
+                if skill_removal.failures.len() == 1 {
+                    ""
+                } else {
+                    "s"
+                }
+            )?;
+        }
         writeln!(
             stderr,
             "Per-project indexes (.vera/ in each project) were not removed."
         )?;
+    }
+
+    // A locked skill directory must be observable in the exit code: automation
+    // auditing cleanup via status would otherwise see success while Vera skills
+    // remain installed and active for agents.
+    if !complete {
+        anyhow::bail!(
+            "failed to remove {} installed skill{}; see errors above",
+            skill_removal.failures.len(),
+            if skill_removal.failures.len() == 1 {
+                ""
+            } else {
+                "s"
+            }
+        );
     }
 
     Ok(())
@@ -198,10 +228,12 @@ mod tests {
         path
     }
 
-    fn uninstall(roots: &Roots, json_output: bool) -> (String, String) {
+    type UninstallOutput = (Result<(), anyhow::Error>, String, String);
+
+    fn uninstall(roots: &Roots, json_output: bool) -> UninstallOutput {
         let mut stdout = Vec::new();
         let mut stderr = Vec::new();
-        run_at(
+        let result = run_at(
             &roots.home,
             &roots.vera_home,
             &roots.cwd,
@@ -209,9 +241,9 @@ mod tests {
             json_output,
             &mut stdout,
             &mut stderr,
-        )
-        .unwrap();
+        );
         (
+            result,
             String::from_utf8(stdout).unwrap(),
             String::from_utf8(stderr).unwrap(),
         )
@@ -222,7 +254,8 @@ mod tests {
         let roots = roots();
         let skill = install_claude_global_skill(&roots.home);
 
-        let (stdout, _) = uninstall(&roots, true);
+        let (result, stdout, _) = uninstall(&roots, true);
+        result.unwrap();
 
         // Strict parse: this is what `json.load` and `serde_json::from_str` do,
         // and it fails with trailing input if a second document is printed.
@@ -241,7 +274,8 @@ mod tests {
     fn uninstall_json_claims_only_categories_that_were_removed() {
         let roots = roots();
 
-        let (stdout, _) = uninstall(&roots, true);
+        let (result, stdout, _) = uninstall(&roots, true);
+        result.unwrap();
 
         let document: serde_json::Value = serde_json::from_str(&stdout).unwrap();
         assert_eq!(document["removed"], serde_json::json!([]));
@@ -254,7 +288,7 @@ mod tests {
         let skill = install_claude_global_skill(&roots.home);
         let not_installed = roots.home.join(".gemini").join("skills").join("vera");
 
-        let (stdout, _) = uninstall(&roots, false);
+        let (_, stdout, _) = uninstall(&roots, false);
 
         assert!(stdout.contains("Removed Vera skill from:"), "{stdout}");
         assert!(stdout.contains(&skill.display().to_string()), "{stdout}");
@@ -292,7 +326,10 @@ mod tests {
         let claude = install_claude_global_skill(&roots.home);
         let locked = install_unremovable_gemini_global_skill(&roots.home);
 
-        let (stdout, _) = uninstall(&roots, true);
+        let (result, stdout, _) = uninstall(&roots, true);
+        // The locked gemini skill makes the run partial: success must be
+        // observable as an error, and the document must say so.
+        assert!(result.is_err(), "partial removal must not report success");
         let claude_was_deleted = !claude.exists();
         allow_cleanup(&locked);
 
@@ -301,6 +338,11 @@ mod tests {
             "fixture does not discriminate: the earlier skill was never deleted"
         );
         let document: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+        assert_eq!(
+            document["complete"],
+            serde_json::json!(false),
+            "partial removal must set complete: false: {stdout}"
+        );
         assert_eq!(
             document["skills"],
             serde_json::json!([claude.display().to_string()]),
@@ -320,7 +362,7 @@ mod tests {
         let claude = install_claude_global_skill(&roots.home);
         let locked = install_unremovable_gemini_global_skill(&roots.home);
 
-        let (stdout, stderr) = uninstall(&roots, false);
+        let (_, stdout, stderr) = uninstall(&roots, false);
         let claude_was_deleted = !claude.exists();
         allow_cleanup(&locked);
 
@@ -348,7 +390,9 @@ mod tests {
         let roots = roots();
         let locked = install_unremovable_gemini_global_skill(&roots.home);
 
-        let (stdout, stderr) = uninstall(&roots, false);
+        let (result, stdout, stderr) = uninstall(&roots, false);
+        // The locked skill makes the run partial; success must not be reported.
+        assert!(result.is_err(), "partial removal must not report success");
         allow_cleanup(&locked);
 
         assert!(
@@ -381,7 +425,9 @@ mod tests {
         let roots = roots();
         let locked = install_uninspectable_claude_global_skill(&roots.home);
 
-        let (stdout, stderr) = uninstall(&roots, false);
+        let (result, stdout, stderr) = uninstall(&roots, false);
+        // The locked skill makes the run partial; success must not be reported.
+        assert!(result.is_err(), "partial removal must not report success");
         allow_cleanup(&locked);
         let skill_survived = locked.join("SKILL.md").exists();
 
@@ -404,7 +450,7 @@ mod tests {
     fn uninstall_human_output_reports_nothing_when_no_skills_are_installed() {
         let roots = roots();
 
-        let (stdout, stderr) = uninstall(&roots, false);
+        let (_, stdout, stderr) = uninstall(&roots, false);
 
         assert_eq!(stdout.trim(), "No Vera skill installations found.");
         assert!(stderr.contains("Vera has been uninstalled."));

--- a/crates/vera-cli/src/commands/uninstall.rs
+++ b/crates/vera-cli/src/commands/uninstall.rs
@@ -74,11 +74,17 @@ fn run_at(
     let mut removed = Vec::new();
 
     // 1. Remove agent skill files (all clients, all scopes).
+    // A location-resolution error means installed skills may exist that we
+    // never even looked at: it must count as an incomplete uninstall, not be
+    // swapped for an empty success.
     let skill_removal = match agent::remove_all_skills(cwd, home) {
         Ok(removal) => removal,
         Err(e) => {
             tracing::warn!("failed to resolve agent skill locations: {e:#}");
-            agent::SkillRemoval::default()
+            agent::SkillRemoval {
+                reports: Vec::new(),
+                failures: vec![e.context("failed to resolve agent skill locations")],
+            }
         }
     };
     // Uninstall continues past a skill that cannot be deleted, so the failure is


### PR DESCRIPTION
Closes #149.

## Problem

`vera uninstall` printed skill-removal failures to stderr but still returned `Ok(())` and printed an unconditional "Vera has been uninstalled." A skill directory locked by permissions (this file's own `install_unremovable_gemini_global_skill` fixture) survived on disk while exit status and summary claimed success. Automation doing `vera uninstall && rm -rf ~/.claude`, or auditing cleanup via exit status, saw a complete removal that never happened — the mirror of `agent::do_remove`, which already turns failures into errors.

## Fix

- `run_at` returns an error when `skill_removal.failures` is non-empty, so the process exits non-zero.
- The `--json` document gains `"complete": false` for partial removals.
- The human summary says "Vera was partially uninstalled: N installed skill(s) could not be removed" instead of the unconditional success line.

## Verification

Ran locally on this branch:

- Existing locked-fixture tests updated to assert the new contract:
  - `uninstall_json_reports_skills_removed_before_a_later_removal_failed` now asserts `result.is_err()` **and** `document["complete"] == false` while still pinning that the earlier skill's removal is reported.
  - `uninstall_human_output_does_not_claim_nothing_was_installed_when_removal_failed` and `uninstall_does_not_report_an_uninspectable_skill_as_absent` now assert `result.is_err()`.
  - All success-path tests unchanged and passing (8 passed total).
- **Reinjection check:** with the error propagation disabled (`if false && !complete`), 3 tests fail — the exit-code contract is actually enforced by the suite.
- `cargo fmt --check`: clean. `cargo clippy -p vera-cli --all-targets`: no new warnings.

Not run: a real permission-locked uninstall outside the test fixtures (the fixtures are the same mechanism the file already used).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
vera uninstall now exits non-zero when any installed skill could not be removed or when skill locations cannot be resolved. Previously it printed failures but still exited 0 and claimed success; now partial uninstalls are explicit in both exit status and output.

- Behavior changes
  - Process exits non-zero if any skill removal fails or if resolving agent skill locations fails.
  - `--json` adds "complete": false for partial uninstalls; "uninstalled": true remains.
  - Human summary changes to "Vera was partially uninstalled: N installed skill(s) could not be removed." Success path unchanged.

- Migration
  - Update automation to treat a non-zero uninstall exit as a partial uninstall and avoid chaining cleanup that assumes success.
  - If consuming `--json`, check "complete" instead of inferring success from "uninstalled".

<sup>Written for commit 895b64655c664dd88ba4271fefba72de3d398a68. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/VeraTools/Vera/pull/150?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Uninstallation results now indicate whether all agent skills were removed.
  * JSON output includes a completion status.
  * Human-readable output reports when removal is only partially complete.

* **Bug Fixes**
  * Uninstallation now returns an error if any skill removal fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->