### PR TITLE
fix(mcp): cap request frame size and drain oversize lines

### DIFF
--- a/crates/vera-mcp/src/server.rs
+++ b/crates/vera-mcp/src/server.rs
@@ -30,12 +30,24 @@ use crate::tools;
 /// The server processes messages one at a time (no concurrency) and never
 /// panics — all errors are returned as JSON-RPC error responses.
 pub fn run_server(reader: &mut dyn BufRead, writer: &mut dyn Write) {
+    run_server_with_frame_limit(reader, writer, MAX_FRAME_BYTES);
+}
+
+/// Maximum accepted request frame. Newline-delimited JSON has no inherent
+/// length bound, so an uncapped `read_line` lets one giant line from a buggy
+/// or hostile client grow memory until the process dies.
+const MAX_FRAME_BYTES: usize = 10 * 1024 * 1024;
+
+fn run_server_with_frame_limit(
+    reader: &mut dyn BufRead,
+    writer: &mut dyn Write,
+    max_frame_bytes: usize,
+) {
     let mut initialized = false;
-    let mut line = String::new();
 
     loop {
-        line.clear();
-        match reader.read_line(&mut line) {
+        let mut frame = Vec::with_capacity(1024);
+        match reader.read_until(b'\n', &mut frame) {
             Ok(0) => {
                 // EOF — client closed stdin.
                 tracing::info!("Client closed connection (EOF)");
@@ -47,6 +59,33 @@ pub fn run_server(reader: &mut dyn BufRead, writer: &mut dyn Write) {
                 break;
             }
         }
+
+        // An oversized frame is rejected and drained to its terminating
+        // newline (the first read may have stopped before it), then the server
+        // keeps serving instead of dying.
+        if frame.len() > max_frame_bytes {
+            tracing::warn!(
+                bytes = frame.len(),
+                limit = max_frame_bytes,
+                "Request frame exceeded the size limit"
+            );
+            while !frame.ends_with(b"\n") {
+                frame.clear();
+                match reader.read_until(b'\n', &mut frame) {
+                    Ok(0) | Err(_) => break,
+                    Ok(_) => {}
+                }
+            }
+            let err = RpcError::new(
+                Value::Null,
+                PARSE_ERROR,
+                format!("Request too large: exceeds {max_frame_bytes} bytes"),
+            );
+            write_message(writer, &err);
+            continue;
+        }
+
+        let line = String::from_utf8_lossy(&frame);
 
         let trimmed = line.trim();
         if trimmed.is_empty() {
@@ -451,5 +490,60 @@ mod tests {
         assert_eq!(responses.len(), 2);
         let result = &responses[1];
         assert_eq!(result["result"]["isError"], true);
+    }
+
+    /// An oversized frame must be answered with a parse error and drained to
+    /// its newline, after which the server still serves the next message.
+    #[test]
+    fn oversized_frame_is_rejected_and_server_keeps_serving() {
+        let oversized = format!("\"{}\"", "x".repeat(200));
+        let input = format!("{oversized}\n{{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"ping\"}}\n");
+        let mut reader = std::io::BufReader::new(Cursor::new(input));
+        let mut output = Vec::new();
+
+        run_server_with_frame_limit(&mut reader, &mut output, 64);
+
+        let output_str = String::from_utf8(output).unwrap();
+        let responses: Vec<Value> = output_str
+            .lines()
+            .filter(|l| !l.trim().is_empty())
+            .map(|l| serde_json::from_str(l).unwrap())
+            .collect();
+
+        assert_eq!(
+            responses.len(),
+            2,
+            "the next message must still be served: {output_str}"
+        );
+        assert_eq!(responses[0]["error"]["code"], PARSE_ERROR);
+        assert!(
+            responses[0]["error"]["message"]
+                .as_str()
+                .unwrap()
+                .contains("too large"),
+            "{output_str}"
+        );
+        // The follow-up ping was handled normally.
+        assert_eq!(responses[1]["id"], 1);
+        assert!(responses[1]["result"].is_object());
+    }
+
+    /// A frame at or under the limit is processed normally.
+    #[test]
+    fn frame_within_limit_is_served() {
+        let input = r#"{"jsonrpc":"2.0","id":1,"method":"ping"}
+"#;
+        let mut reader = std::io::BufReader::new(Cursor::new(input.to_string()));
+        let mut output = Vec::new();
+
+        run_server_with_frame_limit(&mut reader, &mut output, 64);
+
+        let responses: Vec<Value> = String::from_utf8(output)
+            .unwrap()
+            .lines()
+            .map(|l| serde_json::from_str(l).unwrap())
+            .collect();
+        assert_eq!(responses.len(), 1);
+        assert_eq!(responses[0]["id"], 1);
     }
 }

--- a/crates/vera-mcp/src/server.rs
+++ b/crates/vera-mcp/src/server.rs
@@ -121,8 +121,6 @@ fn run_server_with_frame_limit(
 
         // Strict decode: lossy replacement could silently alter bytes inside a
         // JSON string and let an altered request through.
-        // Strict decode: lossy replacement could silently alter bytes inside a
-        // JSON string and let an altered request through.
         let line = match String::from_utf8(frame) {
             Ok(line) => line,
             Err(_) => {

--- a/crates/vera-mcp/src/server.rs
+++ b/crates/vera-mcp/src/server.rs
@@ -119,7 +119,19 @@ fn run_server_with_frame_limit(
             continue;
         }
 
-        let line = String::from_utf8_lossy(&frame);
+        // Strict decode: lossy replacement could silently alter bytes inside a
+        // JSON string and let an altered request through.
+        // Strict decode: lossy replacement could silently alter bytes inside a
+        // JSON string and let an altered request through.
+        let line = match String::from_utf8(frame) {
+            Ok(line) => line,
+            Err(_) => {
+                tracing::warn!("Request frame is not valid UTF-8");
+                let err = RpcError::new(Value::Null, PARSE_ERROR, "Request is not valid UTF-8");
+                write_message(writer, &err);
+                continue;
+            }
+        };
 
         let trimmed = line.trim();
         if trimmed.is_empty() {
@@ -602,5 +614,39 @@ mod tests {
         assert_eq!(responses.len(), 2);
         assert_eq!(responses[0]["error"]["code"], PARSE_ERROR);
         assert_eq!(responses[1]["id"], 7);
+    }
+
+    /// A frame with invalid UTF-8 is a parse error, not a silently repaired one:
+    /// lossy decoding could alter bytes inside a JSON string and let an altered
+    /// request through.
+    #[test]
+    fn invalid_utf8_frame_is_rejected() {
+        let mut input = serde_json::to_vec(&serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 9,
+            "method": "ping"
+        }))
+        .unwrap();
+        // Corrupt bytes inside the frame.
+        input.splice(5..6, [0xFF, 0xFE]);
+        input.push(b'\n');
+        let mut reader = std::io::BufReader::new(Cursor::new(input));
+        let mut output = Vec::new();
+
+        run_server_with_frame_limit(&mut reader, &mut output, 1024);
+
+        let responses: Vec<Value> = String::from_utf8(output)
+            .unwrap()
+            .lines()
+            .map(|l| serde_json::from_str(l).unwrap())
+            .collect();
+        assert_eq!(responses.len(), 1);
+        assert_eq!(responses[0]["error"]["code"], PARSE_ERROR);
+        assert!(
+            responses[0]["error"]["message"]
+                .as_str()
+                .unwrap()
+                .contains("UTF-8")
+        );
     }
 }

--- a/crates/vera-mcp/src/server.rs
+++ b/crates/vera-mcp/src/server.rs
@@ -46,36 +46,70 @@ fn run_server_with_frame_limit(
     let mut initialized = false;
 
     loop {
+        // Read the frame in bounded chunks: `read_until` would buffer the
+        // entire line before any length check, so a newline-less stream could
+        // still grow memory without bound. Once the cap is exceeded, further
+        // input is drained through a fixed scratch buffer instead of appended.
         let mut frame = Vec::with_capacity(1024);
-        match reader.read_until(b'\n', &mut frame) {
-            Ok(0) => {
-                // EOF — client closed stdin.
-                tracing::info!("Client closed connection (EOF)");
+        let mut oversized = false;
+        let mut eof = false;
+        loop {
+            let (chunk, newline_at) = match reader.fill_buf() {
+                Ok(buf) => (buf, buf.iter().position(|&byte| byte == b'\n')),
+                Err(e) => {
+                    if e.kind() == std::io::ErrorKind::Interrupted {
+                        continue;
+                    }
+                    tracing::error!(error = %e, "Failed to read from stdin");
+                    return;
+                }
+            };
+            if chunk.is_empty() {
+                eof = true;
                 break;
             }
-            Ok(_) => {}
-            Err(e) => {
-                tracing::error!(error = %e, "Failed to read from stdin");
-                break;
+            match newline_at {
+                Some(pos) => {
+                    let total = frame.len() + pos + 1;
+                    if !oversized && total > max_frame_bytes {
+                        oversized = true;
+                        tracing::warn!(
+                            limit = max_frame_bytes,
+                            "Request frame exceeded the size limit; draining"
+                        );
+                    }
+                    if !oversized {
+                        frame.extend_from_slice(&chunk[..=pos]);
+                    }
+                    reader.consume(pos + 1);
+                    break;
+                }
+                None => {
+                    let buffered = chunk.len();
+                    if !oversized {
+                        frame.extend_from_slice(chunk);
+                        if frame.len() > max_frame_bytes {
+                            oversized = true;
+                            tracing::warn!(
+                                limit = max_frame_bytes,
+                                "Request frame exceeded the size limit; draining"
+                            );
+                        }
+                    }
+                    reader.consume(buffered);
+                }
             }
         }
 
-        // An oversized frame is rejected and drained to its terminating
-        // newline (the first read may have stopped before it), then the server
-        // keeps serving instead of dying.
-        if frame.len() > max_frame_bytes {
-            tracing::warn!(
-                bytes = frame.len(),
-                limit = max_frame_bytes,
-                "Request frame exceeded the size limit"
-            );
-            while !frame.ends_with(b"\n") {
-                frame.clear();
-                match reader.read_until(b'\n', &mut frame) {
-                    Ok(0) | Err(_) => break,
-                    Ok(_) => {}
-                }
-            }
+        if eof && frame.is_empty() && !oversized {
+            // EOF — client closed stdin.
+            tracing::info!("Client closed connection (EOF)");
+            break;
+        }
+
+        // An oversized frame is rejected and its remainder already drained,
+        // then the server keeps serving instead of dying.
+        if oversized {
             let err = RpcError::new(
                 Value::Null,
                 PARSE_ERROR,
@@ -545,5 +579,28 @@ mod tests {
             .collect();
         assert_eq!(responses.len(), 1);
         assert_eq!(responses[0]["id"], 1);
+    }
+
+    /// A frame whose terminating newline never arrives before EOF is still
+    /// rejected, and input after an oversized frame keeps being served.
+    #[test]
+    fn oversized_frame_without_trailing_newline_is_rejected_and_next_message_served() {
+        let input = format!(
+            "{}\n{{\"jsonrpc\":\"2.0\",\"id\":7,\"method\":\"ping\"}}\n",
+            "y".repeat(300)
+        );
+        let mut reader = std::io::BufReader::new(Cursor::new(input));
+        let mut output = Vec::new();
+
+        run_server_with_frame_limit(&mut reader, &mut output, 64);
+
+        let responses: Vec<Value> = String::from_utf8(output)
+            .unwrap()
+            .lines()
+            .map(|l| serde_json::from_str(l).unwrap())
+            .collect();
+        assert_eq!(responses.len(), 2);
+        assert_eq!(responses[0]["error"]["code"], PARSE_ERROR);
+        assert_eq!(responses[1]["id"], 7);
     }
 }


### PR DESCRIPTION
Closes #151.

## Problem

`run_server` framed requests with `BufRead::read_line`, which has no length bound. One newline-less stream of arbitrary size (buggy or hostile client, or a client piping a file) grew the `String` indefinitely until the process was OOM-killed — taking the agent session's tool server down. The module doc promises "never panics — all errors are returned as JSON-RPC error responses"; resource exhaustion bypassed that guarantee entirely.

## Fix

- Frames are read with `read_until(b'\n')` against a 10 MB cap (`MAX_FRAME_BYTES`).
- An oversized frame is answered with a JSON-RPC `PARSE_ERROR` ("Request too large: exceeds N bytes"), drained to its terminating newline (the first read may have stopped before it), and the loop continues serving.
- The limit is injectable via `run_server_with_frame_limit` so tests exercise the rejection path without a 10 MB fixture; production `run_server` passes the constant.

## Verification

Ran locally on this branch:

- New test `oversized_frame_is_rejected_and_server_keeps_serving` (200-byte frame against a 64-byte test limit, followed by a valid ping):
  - **Cap disabled (reinjection):** fails — the error message is a generic parse error without "too large".
  - **With the fix:** passes — oversized frame gets `PARSE_ERROR`/"too large", and the follow-up ping is served normally (`id: 1`, result object).
- New test `frame_within_limit_is_served` pins that normal frames are unaffected.
- Full server module suite: 15 passed, 0 failed; whole vera-mcp lib: 52 passed.
- `cargo fmt --check`: clean. `cargo clippy -p vera-mcp --all-targets`: no new warnings.

Not run: a live stdio session with an MCP client; the framing change is covered by the existing `run_session` tests plus the two new ones.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Caps MCP request frame size at 10 MB, drains oversized frames, and rejects non‑UTF‑8 to prevent OOMs and silent request mutation. Old: unbounded read_line and lossy UTF‑8 decoding; New: frames over the cap or invalid UTF‑8 return JSON‑RPC PARSE_ERROR and the server keeps serving.

- Assemble frames from fill_buf chunks; enforce the limit during read and drain the remainder after the cap. Peak memory is bounded to the limit plus one BufReader buffer.
- run_server delegates to run_server_with_frame_limit(MAX_FRAME_BYTES); the limit is injectable for tests.
- Tests cover oversize rejection (with and without trailing newline), invalid UTF‑8, and normal frames; removes a duplicated strict‑decode comment.

<sup>Written for commit 06b44a9598a6fc1017407e4cca7be37dc47406a6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/VeraTools/Vera/pull/152?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Oversized messages are now rejected safely with a clear parse error.
  * Processing continues normally after an oversized message is received.
  * Messages at the maximum supported size are accepted as expected.
  * Message handling now enforces a 10 MiB default size limit.
  * Oversized input is fully cleared before subsequent messages are processed.
  * Invalid UTF-8 messages now return a parse error instead of being silently altered.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->