### PR TITLE
fix(cli): agent install no longer fails after installing when stdin is not a TTY

### DIFF
--- a/crates/vera-cli/src/commands/agent.rs
+++ b/crates/vera-cli/src/commands/agent.rs
@@ -2,7 +2,7 @@
 
 use std::collections::BTreeSet;
 use std::fs;
-use std::io::Write;
+use std::io::{IsTerminal, Write};
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, bail};
@@ -1539,6 +1539,19 @@ fn offer_agents_md_snippet(selected_clients: &[AgentClient]) -> anyhow::Result<(
     }
 
     if existing.iter().any(|config| config.mentions_vera) {
+        return Ok(());
+    }
+
+    // Prompts need a terminal; without one every `cliclack` call fails with a
+    // bare "not connected". The install itself is already complete at this
+    // point, so a scripted run must not exit non-zero over an optional snippet
+    // offer — skip it instead (the same decision `setup.rs` makes up front).
+    let interactive = std::io::stdin().is_terminal();
+    if !interactive {
+        cliclack::log::info(format!(
+            "No agent config file mentions Vera; run `vera agent install` in a terminal to add usage instructions to {preferred_name}.",
+            preferred_name = preferred_config_filename(selected_clients),
+        ))?;
         return Ok(());
     }
 


### PR DESCRIPTION
Closes #153.

## Problem

`install()` called `offer_agents_md_snippet` whenever `!json_output`, with no terminal gate. A scripted `vera agent install --client claude --scope global < /dev/null` in a repo whose AGENTS.md does not mention Vera reached `cliclack::confirm` and failed with the bare "Error: not connected" — after the skill files were already installed. Exit 1 recorded for an install that succeeded. Same class as #40, which fixed it for `vera setup`.

## Fix

The optional AGENTS.md snippet offer is gated on `std::io::stdin().is_terminal()`, mirroring `setup.rs`. Non-interactive runs keep the silent `refresh_existing_vera_snippets` pass, log an informational line pointing at a terminal run, and return `Ok` — the install's success is no longer held hostage by an optional prompt.

## Verification

Executed against the built binary on the same scratch repo/home, stdin from `/dev/null`:

| Build | Result |
|-------|--------|
| Fix reverted (control) | `Error: not connected`, **exit 1**, skills installed |
| With fix | skills installed, skip hint logged, **exit 0** |

- `cargo test -p vera-cli --bin vera agent::`: 19 passed, 0 failed.
- `cargo fmt --check`: clean. `cargo clippy -p vera-cli --all-targets`: no new warnings.

No unit test added for the gate itself: the function reads process stdin and cwd, which cannot be redirected safely under parallel test execution (the repo avoids `set_current_dir` in tests). The end-to-end binary check above is the regression evidence, and it is exactly the scenario from the issue.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents non-interactive `vera agent install` runs from exiting 1 after completing installation. Previously, when stdin was not a TTY and no Vera mention existed in AGENTS.md, the command installed skills and then failed on the snippet prompt; now it skips the prompt without a TTY, logs a hint, and exits 0.

- Gates the optional AGENTS.md snippet offer on `std::io::stdin().is_terminal()`, mirroring `setup.rs`.
- Non-interactive runs still refresh existing snippets, print an info line with the preferred config filename, and succeed.
- Verified by manual execution; existing `vera-cli` tests pass. No unit test added for the gate due to process-stdin constraints.

<sup>Written for commit 0b65df4afc6d71d0f8c158e07275cad1927b6fb3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/VeraTools/Vera/pull/154?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved agent skill installation in non-interactive environments by skipping terminal-dependent prompts.
  * Added an informational message when prompts are unavailable.
  * Interactive installations continue to work as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->