### PR TITLE
fix(storage): read commands no longer fabricate an empty metadata.db

### DIFF
--- a/crates/vera-cli/src/commands/update.rs
+++ b/crates/vera-cli/src/commands/update.rs
@@ -59,7 +59,9 @@ pub fn run(path: &str, json_output: bool, options: CommandOptions) -> anyhow::Re
 
     // Check metadata mismatch
     let metadata_path = repo_path.join(".vera").join("metadata.db");
-    if let Ok(metadata_store) = vera_core::storage::metadata::MetadataStore::open(&metadata_path) {
+    if let Ok(metadata_store) =
+        vera_core::storage::metadata::MetadataStore::open_existing(&metadata_path)
+    {
         if let (Some(s_model), Some(s_dim)) = (
             metadata_store.get_index_meta("model_name").unwrap_or(None),
             metadata_store

--- a/crates/vera-cli/src/helpers.rs
+++ b/crates/vera-cli/src/helpers.rs
@@ -174,7 +174,10 @@ pub fn prepare_indexed_repo(
     let cwd = std::env::current_dir()
         .map_err(|e| anyhow::anyhow!("failed to get current directory: {e}"))?;
     let index_dir = vera_core::indexing::index_dir(&cwd);
-    if !index_dir.exists() {
+    // Presence of `.vera/` alone is not validity: after a crash mid-index or a
+    // deleted db the directory exists but holds no metadata. Read commands must
+    // say "no index" rather than fabricate an empty one further down.
+    if !index_dir.join("metadata.db").is_file() {
         anyhow::bail!(
             "no index found in current directory.\n\
              Hint: run `vera index <path>` first to create an index."

--- a/crates/vera-core/src/retrieval/bm25.rs
+++ b/crates/vera-core/src/retrieval/bm25.rs
@@ -36,8 +36,8 @@ pub fn search_bm25(index_dir: &Path, query: &str, limit: usize) -> Result<Vec<Se
     let metadata_path = index_dir.join("metadata.db");
 
     let bm25_index = Bm25Index::open(&bm25_dir).context("failed to open BM25 index for search")?;
-    let metadata_store =
-        MetadataStore::open(&metadata_path).context("failed to open metadata store for search")?;
+    let metadata_store = MetadataStore::open_existing(&metadata_path)
+        .context("failed to open metadata store for search")?;
 
     search_bm25_with_stores(&bm25_index, &metadata_store, query, limit)
 }

--- a/crates/vera-core/src/retrieval/exact_matches.rs
+++ b/crates/vera-core/src/retrieval/exact_matches.rs
@@ -29,7 +29,7 @@ pub(crate) fn augment_exact_match_candidates(
     filters: &SearchFilters,
 ) -> Result<Vec<SearchResult>> {
     let metadata_path = index_dir.join("metadata.db");
-    let Ok(store) = MetadataStore::open(&metadata_path) else {
+    let Ok(store) = MetadataStore::open_existing(&metadata_path) else {
         return Ok(apply_query_ranking_with_filters(
             query, results, stage, filters,
         ));

--- a/crates/vera-core/src/retrieval/hybrid.rs
+++ b/crates/vera-core/src/retrieval/hybrid.rs
@@ -111,7 +111,7 @@ pub async fn search_hybrid(
         let result = Bm25Index::open(&bm25_dir)
             .context("failed to open BM25 index for search")
             .and_then(|index| {
-                let store = MetadataStore::open(&metadata_path)
+                let store = MetadataStore::open_existing(&metadata_path)
                     .context("failed to open metadata store for BM25 search")?;
                 search_bm25_with_stores_and_filters(
                     &index,
@@ -137,8 +137,8 @@ pub async fn search_hybrid(
     let vector_start = Instant::now();
     let vector_outcome = match VectorStore::open(&index_dir.join("vectors.db"), stored_dim) {
         Ok(vector_store) => {
-            let vector_store_result =
-                MetadataStore::open(&vector_metadata_path).context("failed to open metadata store");
+            let vector_store_result = MetadataStore::open_existing(&vector_metadata_path)
+                .context("failed to open metadata store");
             match vector_store_result {
                 Ok(vector_metadata) => {
                     match search_vector_with_stores_timed(

--- a/crates/vera-core/src/retrieval/references.rs
+++ b/crates/vera-core/src/retrieval/references.rs
@@ -25,7 +25,7 @@ pub fn search_callers(
     }
 
     let metadata_path = index_dir.join("metadata.db");
-    let store = MetadataStore::open(&metadata_path)?;
+    let store = MetadataStore::open_existing(&metadata_path)?;
     let repo_root = canonical_project_root(index_dir)?;
     let callers = store.find_callers(symbol)?;
     let mut results = Vec::new();

--- a/crates/vera-core/src/retrieval/regex_search.rs
+++ b/crates/vera-core/src/retrieval/regex_search.rs
@@ -39,7 +39,7 @@ pub fn search_regex(
         .map_err(|e| anyhow::anyhow!("Invalid regex pattern: {e}"))?;
 
     let metadata_path = index_dir.join("metadata.db");
-    let store = MetadataStore::open(&metadata_path)?;
+    let store = MetadataStore::open_existing(&metadata_path)?;
     let mut files = store.indexed_files()?;
     sort_files_by_scan_priority(&mut files, filters);
 

--- a/crates/vera-core/src/retrieval/search_service.rs
+++ b/crates/vera-core/src/retrieval/search_service.rs
@@ -225,7 +225,9 @@ impl SearchContext {
 
         // Check metadata mismatch
         let metadata_path = index_dir.join("metadata.db");
-        if let Ok(metadata_store) = crate::storage::metadata::MetadataStore::open(&metadata_path) {
+        if let Ok(metadata_store) =
+            crate::storage::metadata::MetadataStore::open_existing(&metadata_path)
+        {
             if let (Some(s_model), Some(s_dim)) = (
                 metadata_store.get_index_meta("model_name").unwrap_or(None),
                 metadata_store
@@ -466,7 +468,7 @@ fn run_bm25_only(
     let bm25_start = Instant::now();
     let bm25_index =
         Bm25Index::open(&index_dir.join("bm25")).context("failed to open BM25 index for search")?;
-    let metadata_store = MetadataStore::open(&index_dir.join("metadata.db"))
+    let metadata_store = MetadataStore::open_existing(&index_dir.join("metadata.db"))
         .context("failed to open metadata store for search")?;
     let results = search_bm25_with_stores_and_filters(
         &bm25_index,

--- a/crates/vera-core/src/retrieval/structural.rs
+++ b/crates/vera-core/src/retrieval/structural.rs
@@ -56,7 +56,7 @@ pub fn search_structural(
     }
 
     let metadata_path = index_dir.join("metadata.db");
-    let store = MetadataStore::open(&metadata_path)?;
+    let store = MetadataStore::open_existing(&metadata_path)?;
     let repo_root = canonical_project_root(index_dir)?;
     let filters = structural_filters(filters);
 

--- a/crates/vera-core/src/retrieval/type_relations.rs
+++ b/crates/vera-core/src/retrieval/type_relations.rs
@@ -26,7 +26,7 @@ pub fn search_explicit_implementations(
     }
 
     let metadata_path = index_dir.join("metadata.db");
-    let store = MetadataStore::open(&metadata_path)?;
+    let store = MetadataStore::open_existing(&metadata_path)?;
     let repo_root = canonical_project_root(index_dir)?;
     let symbol = super::structural::normalize_impl_target(symbol);
     let relations = store.find_type_relations(&symbol)?;

--- a/crates/vera-core/src/stats.rs
+++ b/crates/vera-core/src/stats.rs
@@ -115,7 +115,7 @@ pub fn collect_stats(repo_path: &Path) -> Result<IndexStats> {
     // Open metadata store.
     let metadata_path = idx_dir.join("metadata.db");
     let metadata_store =
-        MetadataStore::open(&metadata_path).context("failed to open metadata store")?;
+        MetadataStore::open_existing(&metadata_path).context("failed to open metadata store")?;
 
     // Collect counts.
     let file_count = metadata_store
@@ -182,7 +182,8 @@ pub fn collect_overview_filtered(
     }
 
     let metadata_path = idx_dir.join("metadata.db");
-    let store = MetadataStore::open(&metadata_path).context("failed to open metadata store")?;
+    let store =
+        MetadataStore::open_existing(&metadata_path).context("failed to open metadata store")?;
 
     let index_size_bytes = compute_dir_size(&idx_dir)?;
     let index_size_human = format_bytes(index_size_bytes);
@@ -468,7 +469,8 @@ fn open_metadata(repo_path: &Path) -> Result<MetadataStore> {
             idx_dir.display()
         );
     }
-    MetadataStore::open(&idx_dir.join("metadata.db")).context("failed to open metadata store")
+    MetadataStore::open_existing(&idx_dir.join("metadata.db"))
+        .context("failed to open metadata store")
 }
 
 /// Find all call sites that reference a given symbol name.

--- a/crates/vera-core/src/storage/metadata.rs
+++ b/crates/vera-core/src/storage/metadata.rs
@@ -158,6 +158,21 @@ impl MetadataStore {
         Ok(store)
     }
 
+    /// Open an existing metadata store for reading. Unlike [`Self::open`], a
+    /// missing database is an error, not something to fabricate: `Connection::open`
+    /// creates the file and `init_schema` then writes DDL, so a read command
+    /// against a crashed or half-written index used to report an empty index as
+    /// a success and leave a fresh db behind.
+    pub fn open_existing(db_path: &std::path::Path) -> Result<Self> {
+        if !db_path.is_file() {
+            anyhow::bail!(
+                "no index metadata found at {} (run `vera index <path>` to create it)",
+                db_path.display()
+            );
+        }
+        Self::open(db_path)
+    }
+
     /// Create an in-memory metadata store (useful for testing).
     pub fn open_in_memory() -> Result<Self> {
         let conn = Connection::open_in_memory().context("failed to open in-memory metadata db")?;
@@ -1199,6 +1214,34 @@ fn collect_rows<T>(
 
 #[cfg(test)]
 mod tests {
+
+    /// A missing database must be an error, and the failed open must not leave
+    /// a fabricated (empty, schema-stamped) db behind: reads repair nothing.
+    #[test]
+    fn open_existing_errors_on_missing_db_without_creating_it() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("metadata.db");
+
+        let result = MetadataStore::open_existing(&db_path);
+
+        assert!(result.is_err(), "missing db must not open");
+        assert!(
+            !db_path.exists(),
+            "a failed read-side open must not create the file"
+        );
+        let error = match result {
+            Err(error) => error,
+            Ok(_) => panic!("missing db must not open"),
+        };
+        assert!(
+            error.to_string().contains("no index metadata found"),
+            "error should point at re-indexing: {error:#}"
+        );
+
+        // The create-or-open path still fabricates when explicitly asked to.
+        MetadataStore::open(&db_path).unwrap();
+        assert!(db_path.exists());
+    }
     use super::*;
 
     fn sample_chunks() -> Vec<Chunk> {

--- a/crates/vera-core/src/storage/metadata.rs
+++ b/crates/vera-core/src/storage/metadata.rs
@@ -184,22 +184,40 @@ impl MetadataStore {
     /// Fail on a file that exists but was not written by `init_schema`
     /// (zero-byte leftover of a crashed create, truncated download).
     fn validate_schema(&self, db_path: &std::path::Path) -> Result<()> {
-        let tables: i64 = self
+        const REQUIRED_TABLES: &[&str] = &[
+            "chunks",
+            "file_hashes",
+            "file_index_state",
+            "index_metadata",
+            "references",
+            "type_relations",
+        ];
+        let mut statement = self
             .conn
-            .query_row(
-                "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table'",
-                [],
-                |row| row.get(0),
-            )
+            .prepare("SELECT name FROM sqlite_master WHERE type = 'table'")
             .with_context(|| {
                 format!(
                     "index metadata at {} is not a readable SQLite database",
                     db_path.display()
                 )
             })?;
-        if tables == 0 {
+        let present: Vec<String> = statement
+            .query_map([], |row| row.get::<_, String>(0))?
+            .collect::<std::result::Result<_, _>>()?;
+        drop(statement);
+
+        let missing: Vec<&str> = REQUIRED_TABLES
+            .iter()
+            .filter(|required| {
+                !present
+                    .iter()
+                    .any(|name| name.eq_ignore_ascii_case(required))
+            })
+            .copied()
+            .collect();
+        if let Some(first) = missing.first() {
             anyhow::bail!(
-                "index metadata at {} has no schema (the index is incomplete; run `vera index <path>` to rebuild it)",
+                "index metadata at {} is incomplete (missing table {first}; run `vera index <path>` to rebuild it)",
                 db_path.display()
             );
         }
@@ -1287,6 +1305,24 @@ mod tests {
         assert!(
             std::fs::read(&truncated).unwrap().is_empty(),
             "a failed open must not modify the file"
+        );
+
+        // A partial schema (some tables, not all) is also incomplete: reads
+        // must demand a rebuild rather than fail deep inside a query.
+        std::fs::write(&truncated, b"").unwrap();
+        {
+            let conn = Connection::open(&truncated).unwrap();
+            conn.execute_batch("CREATE TABLE chunks (id TEXT PRIMARY KEY);")
+                .unwrap();
+        }
+        let result = MetadataStore::open_existing(&truncated);
+        assert!(result.is_err(), "partial schema must not open");
+        assert!(
+            result
+                .err()
+                .map(|e| e.to_string().contains("incomplete"))
+                .unwrap_or(false),
+            "error should say the index is incomplete"
         );
     }
     use super::*;

--- a/crates/vera-core/src/storage/metadata.rs
+++ b/crates/vera-core/src/storage/metadata.rs
@@ -163,6 +163,10 @@ impl MetadataStore {
     /// creates the file and `init_schema` then writes DDL, so a read command
     /// against a crashed or half-written index used to report an empty index as
     /// a success and leave a fresh db behind.
+    ///
+    /// The connection is read-only and no schema is written; the required
+    /// tables are validated instead, so a zero-byte or truncated file fails as
+    /// broken rather than masquerading as an empty index.
     pub fn open_existing(db_path: &std::path::Path) -> Result<Self> {
         if !db_path.is_file() {
             anyhow::bail!(
@@ -170,7 +174,36 @@ impl MetadataStore {
                 db_path.display()
             );
         }
-        Self::open(db_path)
+        let conn = Connection::open_with_flags(db_path, rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY)
+            .with_context(|| format!("failed to open metadata db: {}", db_path.display()))?;
+        let store = Self { conn };
+        store.validate_schema(db_path)?;
+        Ok(store)
+    }
+
+    /// Fail on a file that exists but was not written by `init_schema`
+    /// (zero-byte leftover of a crashed create, truncated download).
+    fn validate_schema(&self, db_path: &std::path::Path) -> Result<()> {
+        let tables: i64 = self
+            .conn
+            .query_row(
+                "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table'",
+                [],
+                |row| row.get(0),
+            )
+            .with_context(|| {
+                format!(
+                    "index metadata at {} is not a readable SQLite database",
+                    db_path.display()
+                )
+            })?;
+        if tables == 0 {
+            anyhow::bail!(
+                "index metadata at {} has no schema (the index is incomplete; run `vera index <path>` to rebuild it)",
+                db_path.display()
+            );
+        }
+        Ok(())
     }
 
     /// Create an in-memory metadata store (useful for testing).
@@ -1241,6 +1274,20 @@ mod tests {
         // The create-or-open path still fabricates when explicitly asked to.
         MetadataStore::open(&db_path).unwrap();
         assert!(db_path.exists());
+
+        // A real store opens read-only and serves reads.
+        MetadataStore::open_existing(&db_path).unwrap();
+
+        // A zero-byte leftover of a crashed create exists but has no schema:
+        // it must fail without being modified.
+        let truncated = dir.path().join("truncated.db");
+        std::fs::write(&truncated, b"").unwrap();
+        let result = MetadataStore::open_existing(&truncated);
+        assert!(result.is_err(), "schema-less db must not open");
+        assert!(
+            std::fs::read(&truncated).unwrap().is_empty(),
+            "a failed open must not modify the file"
+        );
     }
     use super::*;
 


### PR DESCRIPTION
Closes #155.

## Problem

`Connection::open` creates the file and `init_schema` stamps DDL + WAL pragmas on every open, read or write. Every read-side guard only checked that `.vera/` exists — never `metadata.db` — so after a crash mid-`store_index` (or a deleted db), any read command fabricated a fresh empty database: `vera stats` reported all-zero stats with exit 0, `vera references foo` reported "no callers found", and the read left a schema-stamped db behind unannounced. Read-path repair leaking into disk state, plus success recorded for an index that does not exist.

## Fix

- `MetadataStore::open_existing`: errors with a re-index hint when the database file is absent; otherwise delegates to `open`.
- All production read paths switched to it: `stats` (`collect_stats`, `collect_overview_filtered`, symbol lookups), references, structural, regex search, BM25 search, hybrid vector metadata, exact matches, the search-service staleness check, and `vera update`'s pre-read.
- The indexing pipeline's write path keeps create-or-open semantics.
- The CLI's "no index found" guard (`prepare_indexed_repo`) now checks `metadata.db` so users see the friendly hint instead of a storage-layer error.

## Verification

Ran locally on this branch:

- New unit test `open_existing_errors_on_missing_db_without_creating_it`:
  - **Existence check disabled (reinjection):** fails — the open succeeds and fabricates the db.
  - **With the fix:** passes — error names "no index metadata found", and no file is created; also pins that explicit `open` still creates.
- Full vera-core lib suite: **899 passed**, 0 failed.
- Executed end to end: in a directory containing only `.vera/`, `vera stats` exits **1** with "no index metadata found ... run \`vera index <path>\`" and leaves `.vera/` empty. On master it exited **0** with all-zero stats and created `metadata.db`.

Not run: live hybrid/vector searches against a real model backend (the touched call sites are store-open plumbing; behavior beyond the missing-db case is unchanged).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Read commands no longer create an empty `metadata.db`. Previously reads created-or-opened and returned empty results with exit 0; now reads open the store read-only, validate all required tables, and error with a re-index hint without creating or modifying files.

- Add `MetadataStore::open_existing`: uses read-only flags and validates the full schema (rejects zero-byte/truncated and partial schemas; error names the first missing table).
- Switch all read paths to it: stats and all retrieval paths (BM25, hybrid, regex, structural, references, type relations, exact matches), search-service checks, and `vera update` pre-read.
- Keep create-or-open on the write path; explicit `open` still creates the database.
- CLI guard now checks for `metadata.db` and shows “run `vera index <path>`” instead of a storage-layer error.
- Verified: unit test ensures failed opens don’t create files and catches partial schemas; end-to-end `vera stats` in a `.vera/`-only directory exits non-zero and leaves the directory untouched.

<sup>Written for commit 78a95f933a86e0fb7f7a0cf37284ab2484f76dff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/VeraTools/Vera/pull/156?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Search, statistics, and validation workflows no longer create missing metadata databases automatically.
  - Missing, empty, invalid, or incomplete index metadata is now reported clearly instead of being treated as available.
  - Existing search fallback behavior remains unchanged when metadata cannot be opened.

- **Reliability**
  - Read-only operations now avoid creating or modifying metadata files.
  - Metadata validation ensures required database structures are present before use.
  - Index detection now requires valid metadata files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->