### PR TITLE
fix(mcp): watcher picks up changes that land mid-update via a trailing cycle

### DIFF
--- a/crates/vera-mcp/src/watcher.rs
+++ b/crates/vera-mcp/src/watcher.rs
@@ -280,6 +280,10 @@ fn start_watching_with_runtime(
                     .compare_exchange(false, true, Ordering::SeqCst, Ordering::Relaxed)
                     .is_ok()
                 {
+                    // We own the trailing run; drop the flag we just set so it
+                    // does not schedule a second cycle on top. Events recorded
+                    // from here on re-set it and still get their own cycle.
+                    dirty_clone.store(false, Ordering::SeqCst);
                     let repo = repo_clone.clone();
                     let flag = updating_clone.clone();
                     let dirty_flag = dirty_clone.clone();

--- a/crates/vera-mcp/src/watcher.rs
+++ b/crates/vera-mcp/src/watcher.rs
@@ -261,8 +261,10 @@ fn start_watching_with_runtime(
             // Skip if already updating, but remember that changes arrived:
             // the running update's final scan happened before these events, so
             // dropping the batch here would leave the index stale until some
-            // unrelated future change. The runner re-runs once when it sees
-            // the flag.
+            // unrelated future change. Record the flag first, then try to take
+            // over the trailing run ourselves: if the active runner exited
+            // between our failed CAS and this point, nobody else will observe
+            // the dirty flag, so we must start the cycle here.
             if updating_clone
                 .compare_exchange(false, true, Ordering::SeqCst, Ordering::Relaxed)
                 .is_err()
@@ -273,6 +275,25 @@ fn start_watching_with_runtime(
                     eprintln!(
                         "[watch] update already running, changes will be picked up next cycle"
                     );
+                }
+                if updating_clone
+                    .compare_exchange(false, true, Ordering::SeqCst, Ordering::Relaxed)
+                    .is_ok()
+                {
+                    let repo = repo_clone.clone();
+                    let flag = updating_clone.clone();
+                    let dirty_flag = dirty_clone.clone();
+                    let engine = Arc::clone(&engine);
+                    std::thread::spawn(move || {
+                        run_incremental_update(
+                            &engine,
+                            &repo,
+                            &runtime,
+                            &flag,
+                            &dirty_flag,
+                            progress_logs,
+                        );
+                    });
                 }
                 return;
             }

--- a/crates/vera-mcp/src/watcher.rs
+++ b/crates/vera-mcp/src/watcher.rs
@@ -207,7 +207,9 @@ fn start_watching_with_runtime(
     let index_dir = idx_dir.clone();
 
     let updating = Arc::new(AtomicBool::new(false));
+    let dirty = Arc::new(AtomicBool::new(false));
     let updating_clone = updating.clone();
+    let dirty_clone = dirty.clone();
     let repo_clone = repo_path.clone();
     let engine = Arc::new(SharedEngine {
         build,
@@ -256,11 +258,16 @@ fn start_watching_with_runtime(
                 return;
             }
 
-            // Skip if already updating.
+            // Skip if already updating, but remember that changes arrived:
+            // the running update's final scan happened before these events, so
+            // dropping the batch here would leave the index stale until some
+            // unrelated future change. The runner re-runs once when it sees
+            // the flag.
             if updating_clone
                 .compare_exchange(false, true, Ordering::SeqCst, Ordering::Relaxed)
                 .is_err()
             {
+                dirty_clone.store(true, Ordering::SeqCst);
                 debug!("Skipping auto-update: previous update still running");
                 if progress_logs {
                     eprintln!(
@@ -276,10 +283,11 @@ fn start_watching_with_runtime(
 
             let repo = repo_clone.clone();
             let flag = updating_clone.clone();
+            let dirty_flag = dirty_clone.clone();
             let engine = Arc::clone(&engine);
 
             std::thread::spawn(move || {
-                run_incremental_update(&engine, &repo, &runtime, &flag, progress_logs);
+                run_incremental_update(&engine, &repo, &runtime, &flag, &dirty_flag, progress_logs);
             });
         },
     )
@@ -375,11 +383,41 @@ fn watch_failure_message(repo_path: &Path, error: &notify::Error) -> String {
 }
 
 /// Run an incremental update, resetting the flag when done.
+///
+/// Event batches that arrived while this update was running set `dirty`; the
+/// runner then takes the update lock once more and runs again, so edits made
+/// mid-update are picked up instead of waiting for an unrelated future change.
 fn run_incremental_update(
     engine: &SharedEngine,
     repo_path: &Path,
     runtime: &WatchRuntime,
     updating: &AtomicBool,
+    dirty: &AtomicBool,
+    progress_logs: bool,
+) {
+    loop {
+        run_incremental_update_once(engine, repo_path, runtime, progress_logs);
+
+        updating.store(false, Ordering::SeqCst);
+        if !dirty.swap(false, Ordering::SeqCst) {
+            return;
+        }
+        // Re-acquire the updating flag so a concurrent batch cannot start a
+        // second runner while we trail; if it won the race, its own cycle will
+        // observe any further events.
+        if updating
+            .compare_exchange(false, true, Ordering::SeqCst, Ordering::Relaxed)
+            .is_err()
+        {
+            return;
+        }
+    }
+}
+
+fn run_incremental_update_once(
+    engine: &SharedEngine,
+    repo_path: &Path,
+    runtime: &WatchRuntime,
     progress_logs: bool,
 ) {
     debug!(path = %repo_path.display(), "Auto-update triggered by file changes");
@@ -418,8 +456,6 @@ fn run_incremental_update(
             }
         }
     }
-
-    updating.store(false, Ordering::SeqCst);
 }
 
 #[cfg(test)]
@@ -537,6 +573,81 @@ mod tests {
             std::thread::sleep(Duration::from_millis(25));
         }
         predicate()
+    }
+
+    /// An engine whose update is slow enough to overlap the next event batch.
+    struct SlowCountingEngine {
+        updates: Arc<AtomicUsize>,
+        update_ms: u64,
+    }
+
+    impl IncrementalUpdate for SlowCountingEngine {
+        fn update(
+            &self,
+            _repo_path: &Path,
+            _config: &VeraConfig,
+        ) -> Result<UpdateSummary, anyhow::Error> {
+            self.updates.fetch_add(1, Ordering::SeqCst);
+            std::thread::sleep(Duration::from_millis(self.update_ms));
+            Ok(UpdateSummary {
+                files_modified: 1,
+                files_added: 0,
+                files_deleted: 0,
+                files_unchanged: 0,
+                files_with_tree_sitter_errors: 0,
+                files_using_tier0_fallback: 0,
+                parse_errors: Vec::new(),
+                files_deferred: 0,
+                total_chunks: 0,
+                elapsed_secs: 0.0,
+            })
+        }
+    }
+
+    /// A change landing while an update is running used to be dropped with no
+    /// trailing cycle: the index stayed stale until an unrelated later edit.
+    /// The runner must pick the skipped batch up when it finishes.
+    #[test]
+    fn changes_landing_mid_update_are_picked_up_by_a_trailing_cycle() {
+        let repo = repo_fixture();
+        let updates = Arc::new(AtomicUsize::new(0));
+        let build: EngineBuilder = {
+            let updates = Arc::clone(&updates);
+            Arc::new(move |_| {
+                Ok(Arc::new(SlowCountingEngine {
+                    updates: Arc::clone(&updates),
+                    update_ms: 500,
+                }) as Engine)
+            })
+        };
+
+        let _handle = start_watching_with(
+            repo.path(),
+            false,
+            TEST_DEBOUNCE,
+            &IndexingConfig::default(),
+            build,
+        )
+        .expect("watcher starts");
+
+        // First change starts a slow (500 ms) update.
+        std::fs::write(repo.path().join("src/first.rs"), "fn first() {}").expect("write");
+        assert!(
+            wait_until(Duration::from_secs(5), || updates.load(Ordering::SeqCst)
+                == 1),
+            "first change should start the slow update"
+        );
+
+        // Second change lands while that update is still running: the debounce
+        // window (300 ms) fires well inside it, so the skip path takes it.
+        std::fs::write(repo.path().join("src/second.rs"), "fn second() {}").expect("write");
+
+        // Without the dirty-flag re-trigger the count stays at 1 forever.
+        assert!(
+            wait_until(Duration::from_secs(10), || updates.load(Ordering::SeqCst)
+                >= 2),
+            "a trailing cycle must pick up the change that landed mid-update"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Closes #157.

## Problem

Event batches arriving while an update was running were skipped and dropped. The skip message promised pickup "next cycle", but no next cycle exists without a further filesystem event: a single edit landing during a long update (large repo, slow embedding backend) left the index stale for that file indefinitely.

## Fix

- The skip path sets a `dirty` flag instead of just returning.
- `run_incremental_update` now loops: after finishing and releasing the updating flag, it re-acquires the lock once more (so a concurrent batch cannot start a second runner in between) and runs again if changes had queued up; edits during the trailing run schedule yet another cycle through the same flag.
- The update body itself is unchanged, extracted as `run_incremental_update_once`.

## Verification

Ran locally on this branch:

- New test `changes_landing_mid_update_are_picked_up_by_a_trailing_cycle`: a 500 ms engine holds the update lock while the second change's debounce window fires into the skip path.
  - **Re-trigger disabled (reinjection):** fails — the update count stays at 1 until timeout.
  - **With the fix:** passes — a trailing cycle runs and the count reaches 2.
- Full watcher module suite: 6 passed. Whole vera-mcp lib: 51 passed, 0 failed.
- `cargo fmt --check`: clean. `cargo clippy -p vera-mcp --all-targets`: no new warnings.

Not run: live `vera watch` against a real model backend (the engine is stubbed; the flag/lock protocol is what changed).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Watcher picks up file changes that arrive during an update by running a trailing cycle; previously those batches were dropped and the index stayed stale until another event. Closes races that could leave `dirty` unobserved or cause a redundant extra cycle.

- On skip, set `dirty` and immediately try to acquire `updating`; if won, clear `dirty` and spawn the trailing cycle, eliminating the lost-update window and avoiding double runs.
- `run_incremental_update` loops and re-acquires the lock to run again while `dirty`, preserving a single runner; the update body moved to `run_incremental_update_once`.
- Adds a test that simulates a slow engine and verifies the trailing cycle in `crates/vera-mcp/src/watcher.rs`.

<sup>Written for commit f187438f89dd4d90a8bb0b578c69b801eb16ec57. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/VeraTools/Vera/pull/158?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved update monitoring so changes detected during an active update are processed automatically afterward.
  - Prevented changes from being missed while an update is in progress.
  - Added a trailing update cycle when additional changes are detected during processing.

- **Tests**
  - Added coverage verifying that changes made during an update trigger a follow-up update cycle.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->