### PR TITLE
fix(parsing): markdown chunker ignores '#' lines inside fenced code blocks

### DIFF
--- a/crates/vera-core/src/parsing/chunker.rs
+++ b/crates/vera-core/src/parsing/chunker.rs
@@ -246,6 +246,10 @@ pub fn markdown_section_chunks(source: &str, file_path: &str) -> Vec<Chunk> {
 
     for (i, line) in lines.iter().enumerate() {
         let trimmed = line.trim_start();
+        // CommonMark: a fence indented four or more columns is an indented
+        // code block, not a fence. "    ```" must not swallow the "# Actual"
+        // heading after it.
+        let indent = line.len() - line.trim_start().len();
         // The run is counted over the FIRST character only: a mixed run like
         // "``~~" is not a fence marker. A closer must be the marker run alone
         // (trailing whitespace allowed); an opener may carry an info string
@@ -254,7 +258,7 @@ pub fn markdown_section_chunks(source: &str, file_path: &str) -> Vec<Chunk> {
         let fence_run = marker
             .filter(|ch| matches!(ch, '`' | '~'))
             .map_or(0, |ch| trimmed.chars().take_while(|c| *c == ch).count());
-        if fence_run >= 3 {
+        if fence_run >= 3 && indent < 4 {
             let rest = &trimmed[fence_run..];
             let is_closer = in_fence
                 && marker == fence_char
@@ -953,5 +957,16 @@ mod tests {
         );
         assert!(fenced.content.contains("```python"), "{:?}", fenced.content);
         assert_eq!(chunks[1].symbol_name.as_deref(), Some("After"));
+    }
+
+    /// A fence indented four or more columns is an indented code block per
+    /// CommonMark, not a fence: it must not suppress the following heading.
+    #[test]
+    fn markdown_indented_fence_is_not_recognized() {
+        let source = "    ```\nlet x = 1;\n\n# Actual\ntext\n";
+        let chunks = markdown_section_chunks(source, "README.md");
+
+        assert_eq!(chunks.len(), 2, "{chunks:?}");
+        assert_eq!(chunks[1].symbol_name.as_deref(), Some("Actual"));
     }
 }

--- a/crates/vera-core/src/parsing/chunker.rs
+++ b/crates/vera-core/src/parsing/chunker.rs
@@ -246,16 +246,23 @@ pub fn markdown_section_chunks(source: &str, file_path: &str) -> Vec<Chunk> {
 
     for (i, line) in lines.iter().enumerate() {
         let trimmed = line.trim_start();
-        let fence_run = trimmed
-            .chars()
-            .take_while(|c| *c == '`' || *c == '~')
-            .count();
+        // The run is counted over the FIRST character only: a mixed run like
+        // "``~~" is not a fence marker. A closer must be the marker run alone
+        // (trailing whitespace allowed); an opener may carry an info string
+        // ("```python").
+        let marker = trimmed.chars().next();
+        let fence_run = marker
+            .filter(|ch| matches!(ch, '`' | '~'))
+            .map_or(0, |ch| trimmed.chars().take_while(|c| *c == ch).count());
         if fence_run >= 3 {
-            let ch = trimmed.chars().next();
-            let is_closer = in_fence && ch == fence_char && fence_run >= fence_len;
+            let rest = &trimmed[fence_run..];
+            let is_closer = in_fence
+                && marker == fence_char
+                && fence_run >= fence_len
+                && rest.trim().is_empty();
             if !in_fence || is_closer {
                 in_fence = !in_fence;
-                fence_char = if in_fence { ch } else { None };
+                fence_char = if in_fence { marker } else { None };
                 fence_len = if in_fence { fence_run } else { 0 };
             }
             continue;
@@ -916,6 +923,35 @@ mod tests {
         let chunks = markdown_section_chunks(source, "README.md");
 
         assert_eq!(chunks.len(), 2, "{chunks:?}");
+        assert_eq!(chunks[1].symbol_name.as_deref(), Some("After"));
+    }
+
+    /// "```python" inside an open backtick fence is CONTENT, not a closer:
+    /// CommonMark forbids an info string on a closing fence. The "# comment"
+    /// lines around it must stay inside the fenced section.
+    #[test]
+    fn markdown_fence_with_info_string_does_not_close() {
+        let source = concat!(
+            "```sh\n",
+            "# shell comment\n",
+            "case:\n",
+            "```python\n",
+            "# python comment\n",
+            "print()\n",
+            "```\n",
+            "\n",
+            "# After\n",
+        );
+        let chunks = markdown_section_chunks(source, "README.md");
+
+        assert_eq!(chunks.len(), 2, "{chunks:?}");
+        let fenced = &chunks[0];
+        assert!(
+            fenced.content.contains("# python comment"),
+            "{:?}",
+            fenced.content
+        );
+        assert!(fenced.content.contains("```python"), "{:?}", fenced.content);
         assert_eq!(chunks[1].symbol_name.as_deref(), Some("After"));
     }
 }

--- a/crates/vera-core/src/parsing/chunker.rs
+++ b/crates/vera-core/src/parsing/chunker.rs
@@ -236,9 +236,33 @@ pub fn markdown_section_chunks(source: &str, file_path: &str) -> Vec<Chunk> {
     // Track current section
     let mut section_start: usize = 0;
     let mut section_name: Option<String> = None;
+    // Fenced-code-block state (CommonMark): a line whose trimmed form opens a
+    // fence of >=3 backticks or tildes toggles it, and only the same character
+    // with at least that length closes it. `#` lines inside a fence are code
+    // comments (shell/python/yaml/make), not headings.
+    let mut in_fence = false;
+    let mut fence_char: Option<char> = None;
+    let mut fence_len: usize = 0;
 
     for (i, line) in lines.iter().enumerate() {
         let trimmed = line.trim_start();
+        let fence_run = trimmed
+            .chars()
+            .take_while(|c| *c == '`' || *c == '~')
+            .count();
+        if fence_run >= 3 {
+            let ch = trimmed.chars().next();
+            let is_closer = in_fence && ch == fence_char && fence_run >= fence_len;
+            if !in_fence || is_closer {
+                in_fence = !in_fence;
+                fence_char = if in_fence { ch } else { None };
+                fence_len = if in_fence { fence_run } else { 0 };
+            }
+            continue;
+        }
+        if in_fence {
+            continue;
+        }
         if trimmed.starts_with('#') {
             // Extract heading text (strip leading #s and whitespace)
             let heading = trimmed.trim_start_matches('#').trim();
@@ -853,5 +877,45 @@ mod tests {
         assert_eq!(chunks[0].symbol_name.as_deref(), Some("Cargo.toml"));
         assert_eq!(chunks[0].line_start, 1);
         assert_eq!(chunks[0].line_end, 2);
+    }
+    /// `#` lines inside fenced code blocks are code comments, not headings:
+    /// the fence must not split, and the comment must not name a section.
+    #[test]
+    fn markdown_headings_inside_code_fences_do_not_split_sections() {
+        let source = "# Real Title\n\n```python\n# this is a comment\nx = 1\n```\nmore prose\n";
+        let chunks = markdown_section_chunks(source, "README.md");
+
+        assert_eq!(
+            chunks.len(),
+            1,
+            "one fence-bounded comment must not create a second section: {chunks:?}"
+        );
+        assert_eq!(chunks[0].symbol_name.as_deref(), Some("Real Title"));
+        assert_eq!(chunks[0].line_start, 1);
+        assert_eq!(chunks[0].line_end, 7);
+        assert!(chunks[0].content.contains("# this is a comment"));
+        assert!(chunks[0].content.contains("more prose"));
+    }
+
+    /// A real heading after a closed fence still starts a new section, and a
+    /// tilde fence is tracked the same way as a backtick one.
+    #[test]
+    fn markdown_heading_after_fence_still_starts_section() {
+        let source = "~~~\n# not a heading\n~~~\n\n## Actual Heading\ntext\n";
+        let chunks = markdown_section_chunks(source, "README.md");
+
+        assert_eq!(chunks.len(), 2, "{chunks:?}");
+        assert_eq!(chunks[0].symbol_name.as_deref(), Some("README.md"));
+        assert_eq!(chunks[1].symbol_name.as_deref(), Some("Actual Heading"));
+    }
+
+    /// A longer closing fence than the opener still closes it (CommonMark).
+    #[test]
+    fn markdown_fence_closes_with_longer_run() {
+        let source = "```python\n# comment\n````\n\n# After\ntext\n";
+        let chunks = markdown_section_chunks(source, "README.md");
+
+        assert_eq!(chunks.len(), 2, "{chunks:?}");
+        assert_eq!(chunks[1].symbol_name.as_deref(), Some("After"));
     }
 }


### PR DESCRIPTION
Closes #159.

## Problem

`markdown_section_chunks` keyed section detection on any line starting with `#`. A shell/Python/YAML/Make comment inside a fenced code block became a section title and split the chunk mid-fence:

```
input : "# Real Title\n\n```python\n# this is a comment\nx = 1\n```\nmore prose\n"
old   : 2 chunks — the second named "this is a comment", content straddling the fence
```

That name then flowed into `Symbol:` metadata, BM25 text, and type-relation owner lookups; docs are a first-class corpus (`SearchScope::Docs`).

## Fix

Fence state tracked per CommonMark while iterating lines: a trimmed run of >=3 backticks or tildes toggles it (a longer run of the same char closes it), and heading detection is skipped inside. Fence lines themselves stay in their section's content.

## Verification

Ran locally on this branch:

- New tests:
  - `markdown_headings_inside_code_fences_do_not_split_sections` — the exact issue input yields one chunk titled "Real Title" containing the comment and trailing prose.
  - `markdown_heading_after_fence_still_starts_section` — a tilde fence plus a real later heading produces two correctly-named sections.
  - `markdown_fence_closes_with_longer_run` — a 4-backtick closer ends a 3-backtick opener.
- **Reinjection:** with fence skipping disabled all three fail; with the fix all pass.
- Full vera-core suite: **901 passed**, 0 failed.
- `cargo fmt --check`: clean. `cargo clippy -p vera-core --lib`: no new warnings.

Not run: re-indexing a real docs-heavy repo to compare retrieval quality end to end.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the Markdown section chunker fence-aware per CommonMark so lines starting with '#' inside fenced code blocks are not parsed as headings. Previously, any '#' line split sections mid-fence and polluted symbol_name, BM25 content, and owner lookups.

- Detects fences only when the line has fewer than four leading spaces and a run of ≥3 backticks or tildes; only the same marker with length ≥ the opener closes it.
- Closing fences must be marker-only; info strings are allowed only on openers; mixed marker runs (e.g., "``~~") are ignored.
- Scope limited to `markdown_section_chunks`; no API or output format changes.

<sup>Written for commit 467b074ac24de63c707ac5bc363516d1489aa790. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/VeraTools/Vera/pull/160?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Markdown section parsing for CommonMark-style fenced code blocks.
  * Headings inside backtick or tilde fences are no longer incorrectly treated as document sections.
  * Fences now close only with the matching character, a valid-length closing run, and no trailing info string.
  * Added support for indented fences, longer closing fences, comments, and fence info strings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->