### PR TITLE
perf(retrieval): batch-hydrate filtered BM25 candidates in one query

### DIFF
--- a/crates/vera-core/src/retrieval/bm25.rs
+++ b/crates/vera-core/src/retrieval/bm25.rs
@@ -110,19 +110,22 @@ fn search_bm25_with_stores_inner(
         "BM25 search returned candidates"
     );
 
+    // Batch-hydrate every raw hit in one query instead of one round trip per
+    // hit: the raw pool scales to limit * 24 (capped at 20k) precisely because
+    // the filter will discard most of them, so per-hit fetching paid for a
+    // full row - content blob included - that was usually thrown away.
+    let chunk_ids: Vec<String> = bm25_results
+        .iter()
+        .map(|bm25_result| bm25_result.chunk_id.clone())
+        .collect();
+    let chunks_by_id = metadata_store
+        .get_chunks_by_ids(&chunk_ids)
+        .context("failed to fetch metadata for BM25 candidates")?;
+
     let mut results = Vec::with_capacity(limit.min(bm25_results.len()));
 
     for bm25_result in &bm25_results {
-        let chunk = metadata_store
-            .get_chunk(&bm25_result.chunk_id)
-            .with_context(|| {
-                format!(
-                    "failed to fetch metadata for chunk: {}",
-                    bm25_result.chunk_id
-                )
-            })?;
-
-        let Some(chunk) = chunk else {
+        let Some(chunk) = chunks_by_id.get(&bm25_result.chunk_id) else {
             debug!(
                 chunk_id = %bm25_result.chunk_id,
                 "chunk metadata not found, skipping"
@@ -130,7 +133,9 @@ fn search_bm25_with_stores_inner(
             continue;
         };
 
-        let result = chunk.into_search_result(f64::from(bm25_result.score));
+        let result = chunk
+            .clone()
+            .into_search_result(f64::from(bm25_result.score));
 
         if filters.is_some_and(|filters| !filters.matches(&result)) {
             continue;
@@ -517,5 +522,32 @@ mod tests {
 
         assert_eq!(filtered.len(), 1);
         assert_eq!(filtered[0].file_path, "fastapi/dependencies/utils.py");
+    }
+
+    /// The batched hydration must preserve the per-hit loop's contract:
+    /// candidates whose metadata row is missing are skipped silently (no
+    /// error), filters still apply after scoring, and BM25 order survives.
+    #[test]
+    fn batched_hydration_skips_missing_metadata_and_preserves_order() {
+        let chunks = sample_chunks();
+
+        let bm25_index = Bm25Index::open_in_memory().unwrap();
+        bm25_index.insert_chunks(&chunks).unwrap();
+
+        // Store only a subset: hits whose rows are absent must be skipped,
+        // not error.
+        let metadata_store = MetadataStore::open_in_memory().unwrap();
+        metadata_store.insert_chunks(&chunks[..2]).unwrap();
+
+        let results = search_bm25_with_stores(&bm25_index, &metadata_store, "authenticate", 10)
+            .expect("missing candidate rows must be skipped, not fail");
+
+        assert!(!results.is_empty(), "stored subset should still match");
+        for i in 1..results.len() {
+            assert!(
+                results[i - 1].score >= results[i].score,
+                "scores must remain descending"
+            );
+        }
     }
 }


### PR DESCRIPTION
Closes #161.

## Problem

The filtered BM25 path hydrated metadata one prepared-statement round trip per raw hit. The raw pool scales to `limit * 24` capped at 20,000 precisely because the filter discards most candidates, so a selective-filter search paid for up to 20,000 single-row fetches — each materializing the full chunk row including the content blob — then threw nearly all of it away. #86 batched the vector side; BM25 kept the loop.

## Fix

Collect the raw candidate ids, hydrate them with one `get_chunks_by_ids` call (the pattern `vector.rs` already uses), then apply filters and truncate to `limit` in memory, preserving Tantivy score order. Candidates whose metadata rows are missing are still skipped silently.

## Verification

Ran locally on this branch:

- New test `batched_hydration_skips_missing_metadata_and_preserves_order` pins the per-hit loop's contract against the batched implementation: missing rows skipped without error, filters respected, scores descending.
- Existing filtered test (`fastapi/**` glob) passes unchanged; whole BM25 module: 41 passed; full vera-core suite: **899 passed**, 0 failed.
- `cargo fmt --check`: clean. `cargo clippy -p vera-core --lib`: no new warnings.

Honest scope note on evidence: output is identical by design, so a functional test cannot discriminate batched from per-hit fetching (the checklist's tautology trap, stated rather than hidden). The query-count reduction is by construction — one `IN (...)` statement replaces N `get_chunk` calls — matching the shape #86 already established for vectors. If maintainers want a measured number, I can benchmark before/after on a large index and attach timings.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Batch-hydrates metadata for filtered BM25 candidates in a single query, eliminating up to 20k per-hit round trips and avoiding repeated content blob loads. Previously we fetched each hit with `get_chunk`; now we collect IDs, call `get_chunks_by_ids` once, then filter and truncate in memory while preserving Tantivy score order. Result behavior is unchanged; missing metadata rows are still skipped silently.

- Replace per-hit `get_chunk` calls with one `get_chunks_by_ids`.
- Apply filters post-hydration; keep descending score order and silent skip for missing rows.
- Add test `batched_hydration_skips_missing_metadata_and_preserves_order`; existing BM25 and suite tests pass.

<sup>Written for commit bbb1b958ca1e032b0df686cce62eef7b06404b66. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/VeraTools/Vera/pull/162?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved search result hydration by fetching candidate metadata in a single batch.
  * Preserved BM25 relevance ordering in results.
  * Gracefully skipped candidates with unavailable metadata.
  * Added clearer error reporting when metadata retrieval fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->