### PR TITLE
perf(retrieval): move deep-search blocking work off tokio workers

### DIFF
--- a/crates/vera-core/src/retrieval/completion_client.rs
+++ b/crates/vera-core/src/retrieval/completion_client.rs
@@ -97,6 +97,9 @@ impl CompletionClientConfig {
 }
 
 /// OpenAI-compatible chat completion client for query expansion.
+///
+/// `Clone` is cheap: the inner `reqwest::blocking::Client` is an `Arc`.
+#[derive(Clone)]
 pub struct CompletionClient {
     client: reqwest::blocking::Client,
     config: CompletionClientConfig,

--- a/crates/vera-core/src/retrieval/rag_fusion.rs
+++ b/crates/vera-core/src/retrieval/rag_fusion.rs
@@ -101,9 +101,20 @@ async fn execute_rag_fusion_with_context(
     let hints_dir = index_dir.to_path_buf();
     let hints_query = query.to_string();
     let context_hints =
-        tokio::task::spawn_blocking(move || bm25_context_hints(&hints_dir, &hints_query))
+        match tokio::task::spawn_blocking(move || bm25_context_hints(&hints_dir, &hints_query))
             .await
-            .unwrap_or_default();
+        {
+            Ok(hints) => hints,
+            // Fail-open is deliberate (the pre-filter is optional context), but a
+            // panicking task must not vanish silently.
+            Err(join_error) => {
+                tracing::warn!(
+                    error = %join_error,
+                    "BM25 pre-filter task failed; continuing without context hints"
+                );
+                Vec::new()
+            }
+        };
     debug!(
         hints = context_hints.len(),
         "BM25 pre-filter produced context hints for query expansion"

--- a/crates/vera-core/src/retrieval/rag_fusion.rs
+++ b/crates/vera-core/src/retrieval/rag_fusion.rs
@@ -126,7 +126,9 @@ async fn execute_rag_fusion_with_context(
         expansion_client.expand_query_with_context(&expansion_query, &context_hints)
     })
     .await
-    .map_err(|e| anyhow!("deep-search query expansion task failed: {e}"))?
+    // Preserve the JoinError as the source (panic location, cancellation
+    // reason) rather than flattening it into a message string.
+    .map_err(|e| anyhow::Error::new(e).context("deep-search query expansion task failed"))?
     .map_err(|e| anyhow!("failed to generate deep-search query candidates: {e}"))?;
 
     let queries = dedupe_queries_with_original(query, expanded);

--- a/crates/vera-core/src/retrieval/rag_fusion.rs
+++ b/crates/vera-core/src/retrieval/rag_fusion.rs
@@ -94,15 +94,29 @@ async fn execute_rag_fusion_with_context(
 
     // BM25 pre-filter: run a cheap keyword search to gather codebase context
     // (symbol names and file paths) that helps the LLM generate better rewrites.
-    let context_hints = bm25_context_hints(index_dir, query);
+    // Both this and query expansion block (SQLite/Tantivy opens; a
+    // reqwest::blocking call with a 120 s timeout), so they run on the blocking
+    // pool: inline execution pinned a tokio worker per deep search, and
+    // concurrent searches stacked blocked workers until the runtime starved.
+    let hints_dir = index_dir.to_path_buf();
+    let hints_query = query.to_string();
+    let context_hints =
+        tokio::task::spawn_blocking(move || bm25_context_hints(&hints_dir, &hints_query))
+            .await
+            .unwrap_or_default();
     debug!(
         hints = context_hints.len(),
         "BM25 pre-filter produced context hints for query expansion"
     );
 
-    let expanded = completion_client
-        .expand_query_with_context(query, &context_hints)
-        .map_err(|e| anyhow!("failed to generate deep-search query candidates: {e}"))?;
+    let expansion_client = completion_client.clone();
+    let expansion_query = query.to_string();
+    let expanded = tokio::task::spawn_blocking(move || {
+        expansion_client.expand_query_with_context(&expansion_query, &context_hints)
+    })
+    .await
+    .map_err(|e| anyhow!("deep-search query expansion task failed: {e}"))?
+    .map_err(|e| anyhow!("failed to generate deep-search query candidates: {e}"))?;
 
     let queries = dedupe_queries_with_original(query, expanded);
     if queries.len() <= 1 {


### PR DESCRIPTION
Closes #163.

## Problem

`execute_rag_fusion_with_context` ran two blocking operations inline on tokio workers: the BM25 pre-filter (SQLite/Tantivy store opens + search) and query expansion (`reqwest::blocking::Client`, 120 s timeout). A hung completion endpoint pinned one worker per deep search; concurrent requests stacked blocked workers until the runtime starved, turning one slow upstream into a whole-server stall. Every other blocking operation in this layer is already wrapped — this path was the exception.

## Fix

Both calls moved onto the blocking pool via `tokio::task::spawn_blocking`. `CompletionClient` gains `#[derive(Clone)]` (cheap: the inner `reqwest::blocking::Client` is an `Arc`) so it can cross into the closure. A `JoinError` from the expansion task now surfaces as a distinct "task failed" error rather than being conflated with upstream failures; the hints pre-filter keeps its fail-open behavior via `unwrap_or_default`.

## Verification

Ran locally on this branch:

- Full vera-core suite: **898 passed**, 0 failed.
- `cargo fmt --check`: clean. `cargo clippy -p vera-core --lib`: no new warnings (only the 5 documented pre-existing).

Honest scope note: no unit test pins the "worker not blocked" property — that needs a controllable hung endpoint and runtime instrumentation. What is verified by inspection and suite: identical results flow, error paths preserved (upstream failure vs join failure are distinguishable in logs), and the pattern now matches the wrapping used by `search_hybrid` and `LocalReranker`. Happy to add a benchmark/instrumentation test if maintainers want one.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves deep-search pre-filter and query expansion off Tokio workers onto the blocking pool to prevent runtime starvation. Old behavior ran both inline and could pin a worker; new behavior uses `tokio::task::spawn_blocking`, warns on BM25 pre-filter task failure, and preserves expansion task `JoinError` as the error source with a clear “task failed” classification.

- In `execute_rag_fusion_with_context`, run `bm25_context_hints` and the blocking expansion call in `spawn_blocking`; on BM25 failure, log the `JoinError` and continue without hints; for expansion, wrap `JoinError` via `anyhow::Error::new(...).context("deep-search query expansion task failed")` to keep the source chain.
- `CompletionClient` now derives `Clone` (cheap: inner `reqwest::blocking::Client` is an `Arc`). Deep-search results are unchanged; only error reporting and scheduler impact differ.

<sup>Written for commit 65120f3a7a904d8f00da9fdb610b5fcbdfce27d7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/VeraTools/Vera/pull/164?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved responsiveness by moving search context generation, database access, and query expansion away from asynchronous processing threads.
  * Enabled efficient reuse of completion client instances.
* **Reliability**
  * Improved reporting for background task failures and query-expansion errors.
  * Reduced the risk of blocking operations affecting other application tasks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->