### PR TITLE
fix(storage): neutralize tantivy boolean operators in sanitized queries

### DIFF
--- a/crates/vera-core/src/storage/bm25.rs
+++ b/crates/vera-core/src/storage/bm25.rs
@@ -342,13 +342,35 @@ fn build_schema() -> Bm25Schema {
 }
 
 fn sanitize_query(query_text: &str) -> String {
-    query_text
+    let cleaned: String = query_text
         .chars()
         .map(|c| match c {
             ':' | '(' | ')' | '[' | ']' | '{' | '}' | '^' | '~' | '!' | '\'' | '"' | '`' => ' ',
             _ => c,
         })
-        .collect()
+        .collect();
+
+    // The char pass above cannot neutralize the word-level operators: tantivy
+    // parses a leading `-term` as MustNot (so "NOT NULL constraint"-style
+    // queries silently excluded "null"), a bare `*` as match-all-documents,
+    // and uppercase AND/OR/NOT as boolean operators. Word-boundary stripping
+    // keeps hyphenated terms like "e-mail" intact; lowercasing the operator
+    // words turns them into ordinary terms, which is what the user typed.
+    cleaned
+        .split_whitespace()
+        .map(|word| {
+            let stripped = word.trim_start_matches(['-', '+']);
+            if stripped == "*" {
+                return String::new();
+            }
+            match stripped {
+                "AND" | "OR" | "NOT" => stripped.to_ascii_lowercase(),
+                _ => stripped.to_string(),
+            }
+        })
+        .filter(|word| !word.is_empty())
+        .collect::<Vec<_>>()
+        .join(" ")
 }
 
 fn looks_path_weighted(query_text: &str) -> bool {
@@ -384,6 +406,13 @@ mod tests {
                 file_path: "src/main.rs",
                 content: "struct Config {\n    name: String,\n    port: u16,\n}",
                 symbol_name: Some("Config"),
+                language: "rust",
+            },
+            Bm25Document {
+                chunk_id: "src/db.rs:0",
+                file_path: "src/db.rs",
+                content: "fn save(row: Row) {\n    if row.id is NULL {\n        bail!(\"missing id\");\n    }\n}",
+                symbol_name: Some("save"),
                 language: "rust",
             },
             Bm25Document {
@@ -435,7 +464,7 @@ mod tests {
     fn insert_and_count() {
         let index = Bm25Index::open_in_memory().unwrap();
         index.insert_batch(&sample_docs()).unwrap();
-        assert_eq!(index.doc_count().unwrap(), 8);
+        assert_eq!(index.doc_count().unwrap(), 9);
     }
 
     #[test]
@@ -567,10 +596,10 @@ mod tests {
     fn delete_by_chunk_id() {
         let index = Bm25Index::open_in_memory().unwrap();
         index.insert_batch(&sample_docs()).unwrap();
-        assert_eq!(index.doc_count().unwrap(), 8);
+        assert_eq!(index.doc_count().unwrap(), 9);
 
         index.delete_by_chunk_id("src/main.rs:0").unwrap();
-        assert_eq!(index.doc_count().unwrap(), 7);
+        assert_eq!(index.doc_count().unwrap(), 8);
     }
 
     #[test]
@@ -654,5 +683,40 @@ mod tests {
             sanitize_query("how pandoc's app module orchestrates"),
             "how pandoc s app module orchestrates"
         );
+    }
+
+    /// "NOT NULL world" used to parse NOT as MustNot and exclude the very
+    /// chunks mentioning NULL; it must match exactly what "NULL world" does.
+    /// The fixture needs a doc containing NULL, or the exclusion is invisible.
+    #[test]
+    fn sanitized_query_does_not_exclude_on_uppercase_not() {
+        let index = Bm25Index::open_in_memory().unwrap();
+        index.insert_batch(&sample_docs()).unwrap();
+
+        let with_not = index.search("NOT NULL missing", 10).unwrap();
+        let without = index.search("NULL missing", 10).unwrap();
+
+        assert!(
+            !without.is_empty(),
+            "fixture does not discriminate: nothing matches 'NULL missing'"
+        );
+        assert_eq!(
+            with_not.len(),
+            without.len(),
+            "'NOT X' must match exactly what 'X' matches"
+        );
+    }
+
+    #[test]
+    fn sanitize_query_neutralizes_word_operators_but_keeps_hyphenated_terms() {
+        // Leading +/- are exclusion/inclusion operators only at word start.
+        assert_eq!(sanitize_query("-term +other"), "term other");
+        // Hyphenated words survive.
+        assert_eq!(sanitize_query("e-mail check"), "e-mail check");
+        // A bare * is match-all; kill it. Attached wildcards stay.
+        assert_eq!(sanitize_query("* auth"), "auth");
+        assert_eq!(sanitize_query("auth*"), "auth*");
+        // Operator words lowercase into ordinary terms.
+        assert_eq!(sanitize_query("NOT NULL AND retry"), "not NULL and retry");
     }
 }


### PR DESCRIPTION
Closes #165.

## Problem

`sanitize_query` stripped punctuation operators but left tantivy's word-level operators live: `-term` parsed as MustNot (so `"NOT NULL constraint"` silently excluded every chunk mentioning "null"), `+term` as Must, a bare `*` as match-all-documents, and uppercase `AND`/`OR`/`NOT` as boolean operators. All of these degraded results invisibly.

## Fix

After the existing char pass, each whitespace-separated token is normalized:

- leading `-`/`+` stripped at word boundaries only — hyphenated terms like `e-mail` survive;
- a bare `*` is dropped; attached wildcards like `auth*` stay;
- uppercase `AND`/`OR`/`NOT` are lowercased into ordinary terms, which is what the user typed.

## Verification

Ran locally on this branch:

- `sanitized_query_does_not_exclude_on_uppercase_not`: searches `"NOT NULL missing"` vs `"NULL missing"` through a real in-memory Tantivy index and asserts identical hit sets.
  - The fixture gained a doc containing NULL — **without it the test passed vacuously against the old code** (nothing to exclude), which reinjection exposed. Existing doc-count assertions updated for the new fixture entry.
  - **Old implementation (reinjected):** both new tests fail.
  - **With fix:** all pass.
- `sanitize_query_neutralizes_word_operators_but_keeps_hyphenated_terms` pins each rule (`-term +other`, `e-mail`, bare vs attached `*`, operator words).
- Full vera-core suite: **900 passed**, 0 failed.
- `cargo fmt --check`: clean. `cargo clippy -p vera-core --lib`: no new warnings.

Not run: end-to-end ranking-quality comparison on a large index (the sanitizer's contract is pinned at the unit/integration level above).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Neutralizes Tantivy boolean operators during query sanitization to prevent invisible filtering and match-all queries. Previously `-term`, `+term`, bare `*`, and uppercase `AND/OR/NOT` were applied as operators; now we strip leading +/- at word start, drop bare `*`, and lowercase operator words so they index as ordinary terms.

- The new token-level normalization runs after the existing char-level pass in `sanitize_query` (`bm25.rs`); hyphenated terms (e.g., e-mail) and attached wildcards (e.g., auth*) are preserved.
- Tests: fixture gains a NULL-containing doc; doc-count assertions updated (8 → 9). New tests verify that "NOT NULL ..." matches the same set as "NULL ..." and pin each sanitization rule.

<sup>Written for commit d8bf4814aaf18c7e36f985291f1ebfe6a2b260fd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/VeraTools/Vera/pull/184?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved search query handling for boolean operators and wildcard characters.
  * Preserved hyphenated search terms during query sanitization.
  * Added support for safely handling documents containing NULL values.
  * Improved recognition of uppercase boolean operators such as `NOT`.

* **Tests**
  * Expanded search coverage for operator neutralization, wildcard handling, hyphenated terms, and NULL-containing documents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->